### PR TITLE
fix(docs): add import syntax

### DIFF
--- a/docs/resources/cks_cluster.md
+++ b/docs/resources/cks_cluster.md
@@ -132,3 +132,11 @@ Optional:
 - `signing_algs` (Set of String) A list of signing algorithms that the OpenID Connect discovery endpoint uses.
 - `username_claim` (String) The claim to use as the username.
 - `username_prefix` (String) The prefix to use for the username.
+
+## Import
+
+Import is supported using the following syntax:
+
+```shell
+terraform import coreweave_cks_cluster.default {{id}}
+```

--- a/docs/resources/networking_vpc.md
+++ b/docs/resources/networking_vpc.md
@@ -105,3 +105,11 @@ Required:
 
 - `name` (String)
 - `value` (String)
+
+## Import
+
+Import is supported using the following syntax:
+
+```shell
+terraform import coreweave_networking_vpc.default {{id}}
+```

--- a/examples/resources/coreweave_cks_cluster/import.sh
+++ b/examples/resources/coreweave_cks_cluster/import.sh
@@ -1,0 +1,1 @@
+terraform import coreweave_cks_cluster.default {{id}}

--- a/examples/resources/coreweave_networking_vpc/import.sh
+++ b/examples/resources/coreweave_networking_vpc/import.sh
@@ -1,0 +1,1 @@
+terraform import coreweave_networking_vpc.default {{id}}


### PR DESCRIPTION
Add import syntax examples for `coreweave_cks_cluster` and `coreweave_networking_vpc`.

Fixes: https://github.com/coreweave/terraform-provider-coreweave/issues/74