### PR TITLE
fix: set http.ProxyFromEnvironment in client transport

### DIFF
--- a/coreweave/client.go
+++ b/coreweave/client.go
@@ -19,6 +19,7 @@ import (
 func NewClient(endpoint string, interceptors ...connect.Interceptor) *Client {
 	c := http.Client{
 		Transport: &http.Transport{
+			Proxy:                 http.ProxyFromEnvironment,
 			ResponseHeaderTimeout: 5 * time.Second,
 			ExpectContinueTimeout: 1 * time.Second,
 		},


### PR DESCRIPTION
Fix to allow the client to respect HTTP_PROXY, HTTPS_PROXY and NO_PROXY environment variables