### PR TITLE
fix: set intermediate state before continuing to poll

### DIFF
--- a/coreweave/cks/resource_cluster.go
+++ b/coreweave/cks/resource_cluster.go
@@ -548,6 +548,14 @@ func (r *ClusterResource) Create(ctx context.Context, req resource.CreateRequest
 		return
 	}
 
+	// set state once cluster is created
+	data.Set(createResp.Msg.Cluster)
+	// if we fail to set state, return early as the resource will be orphaned
+	if diag := resp.State.Set(ctx, &data); diag.HasError() {
+		resp.Diagnostics.Append(diag...)
+		return
+	}
+
 	// wait for the cluster to become ready
 	conf := retry.StateChangeConf{
 		Pending: []string{
@@ -639,6 +647,14 @@ func (r *ClusterResource) Update(ctx context.Context, req resource.UpdateRequest
 	updateResp, err := r.client.UpdateCluster(ctx, connect.NewRequest(data.ToUpdateRequest(ctx)))
 	if err != nil {
 		coreweave.HandleAPIError(ctx, err, &resp.Diagnostics)
+		return
+	}
+
+	// set state once cluster is updated
+	data.Set(updateResp.Msg.Cluster)
+	// if we fail to set state, return early
+	if diag := resp.State.Set(ctx, &data); diag.HasError() {
+		resp.Diagnostics.Append(diag...)
 		return
 	}
 

--- a/coreweave/networking/resource_vpc.go
+++ b/coreweave/networking/resource_vpc.go
@@ -384,6 +384,14 @@ func (r *VpcResource) Create(ctx context.Context, req resource.CreateRequest, re
 		return
 	}
 
+	// set state once vpc is created
+	data.Set(createResp.Msg.Vpc)
+	// if we fail to set state, return early as the resource will be orphaned
+	if diag := resp.State.Set(ctx, &data); diag.HasError() {
+		resp.Diagnostics.Append(diag...)
+		return
+	}
+
 	// wait for the vpc to become ready
 	conf := retry.StateChangeConf{
 		Pending: []string{
@@ -464,6 +472,14 @@ func (r *VpcResource) Update(ctx context.Context, req resource.UpdateRequest, re
 	updateResp, err := r.client.UpdateVPC(ctx, connect.NewRequest(data.ToUpdateRequest(ctx)))
 	if err != nil {
 		coreweave.HandleAPIError(ctx, err, &resp.Diagnostics)
+		return
+	}
+
+	// set state once vpc is updated
+	data.Set(updateResp.Msg.Vpc)
+	// if we fail to set state, return early
+	if diag := resp.State.Set(ctx, &data); diag.HasError() {
+		resp.Diagnostics.Append(diag...)
 		return
 	}
 


### PR DESCRIPTION
Fixes an edge case where, if there's a failure during polling, the resource is orphaned after creation because we don't update the state file after the first API call