### PR TITLE
fix: retry deadline exceeded errors

### DIFF
--- a/coreweave/client.go
+++ b/coreweave/client.go
@@ -107,6 +107,10 @@ func RetryPolicy(ctx context.Context, resp *http.Response, err error) (bool, err
 		return true, ctx.Err()
 	}
 
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true, err
+	}
+
 	return baseRetryPolicy(resp, err)
 }
 


### PR DESCRIPTION
There's still an edge case where the error itself can be deadline exceeded, but `ctx.Err()` is nil. This PR updates the retry policy to retry deadline exceeded errors explicitly.