### PR TITLE
fix: increase maximum retry timeout from 5s to 60s

### DIFF
--- a/coreweave/client.go
+++ b/coreweave/client.go
@@ -22,7 +22,7 @@ func NewClient(endpoint string, s3Endpoint string, timeout time.Duration, interc
 	rc.HTTPClient.Timeout = timeout
 	rc.RetryMax = 10
 	rc.RetryWaitMin = 200 * time.Millisecond
-	rc.RetryWaitMax = 5 * time.Second
+	rc.RetryWaitMax = 60 * time.Second
 	// Jittered exponential back-off (min*2^n) with capping.
 	rc.Backoff = retryablehttp.DefaultBackoff
 	// Treat only idempotent verbs + 502/503/504 + transport errors as retryable.


### PR DESCRIPTION
The low retry regularly causes failures in acceptance tests, and doesn't adequately respect the 429 issues. The retryablehttp module should already respect retry-after headers however.