### PR TITLE
ci: run release build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,6 +77,8 @@ jobs:
           go-version-file: 'go.mod'
           cache: true
       - run: go mod download
+      - name: Check go mod tidy
+        run: go mod tidy -diff
       - run: go test -v -cover ./...
         timeout-minutes: 10
 


### PR DESCRIPTION
Add a test step that builds the release locally. This catches build errors that may not have been previously exercised. Also adds go mod tidy to the checks.

Failures expected; will take red-to-green.