### PR TITLE
ci: remove release build caching

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
-          cache: true
+          cache: false
       - name: Update GitHub CLI
         run: sudo apt-get install gh -y
       - name: Import GPG key


### PR DESCRIPTION
While rare, caching can occasionally cause some issues with Go builds, especially long-running ones with lots of objects. This balances against the potential of issues with downloading go modules. Removing the cache should make final release artifacts more deterministic in terms of the final binary, and eliminate the possibility of release build failures due to cache issues.