### PR TITLE
fix(storage): ignore unset noncurrent lifecycle rules

### DIFF
--- a/coreweave/object_storage/resource_bucket_lifecycle_configuration.go
+++ b/coreweave/object_storage/resource_bucket_lifecycle_configuration.go
@@ -280,9 +280,12 @@ func expandRules(ctx context.Context, in []LifecycleRuleModel) []s3types.Lifecyc
 			rule.Expiration = &exp
 		}
 		if r.NoncurrentVersionExpiration != nil {
-			nc := s3types.NoncurrentVersionExpiration{
-				NoncurrentDays:          aws.Int32(r.NoncurrentVersionExpiration.NoncurrentDays.ValueInt32()),
-				NewerNoncurrentVersions: aws.Int32(r.NoncurrentVersionExpiration.NewerNoncurrentVersions.ValueInt32()),
+			nc := s3types.NoncurrentVersionExpiration{}
+			if !r.NoncurrentVersionExpiration.NoncurrentDays.IsNull() {
+				nc.NoncurrentDays = aws.Int32(r.NoncurrentVersionExpiration.NoncurrentDays.ValueInt32())
+			}
+			if !r.NoncurrentVersionExpiration.NewerNoncurrentVersions.IsNull() {
+				nc.NewerNoncurrentVersions = aws.Int32(r.NoncurrentVersionExpiration.NewerNoncurrentVersions.ValueInt32())
 			}
 			rule.NoncurrentVersionExpiration = &nc
 		}


### PR DESCRIPTION
Previously, noncurrent lifecycle transition rules would infer a default value of zero if not set. In some circumstances, this would cause the rule to fail. In others, it may cause an unintended rule. This fixes both cases. For example, this subblock of the lifecycle provider:

```hcl
    noncurrent_version_expiration {
      noncurrent_days = 7
    }
```

would fail to create, due to `newer_noncurrent_versions` being set to `0`, which is invalid (1-100). Similarly, with `newer_noncurrent_versions` set, it would fail because `noncurrent_days` is not a positive integer.

This change makes it so that either of these can be specified independently, without overriding the other.

Tests were added before code changes, and brought red-to-green.