### PR TITLE
fix: debug request/response data for every request

### DIFF
--- a/coreweave/client.go
+++ b/coreweave/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"reflect"
 	"time"
 
 	"buf.build/gen/go/coreweave/cks/connectrpc/go/coreweave/cks/v1beta1/cksv1beta1connect"
@@ -15,7 +16,75 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"google.golang.org/genproto/googleapis/rpc/errdetails"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
 )
+
+func tfLogBaseFields(req connect.AnyRequest) map[string]any {
+	return map[string]any{
+		"procedure":  req.Spec().Procedure,
+		"streamType": req.Spec().StreamType.String(),
+		"peer":       req.Peer().Protocol + "://" + req.Peer().Addr,
+	}
+}
+
+func tfLogRequest(ctx context.Context, req connect.AnyRequest) {
+	reqFields := tfLogBaseFields(req)
+
+	// This is tricky, because AnyRequest does not expose the underlying proto message directly, but always has it (for unary requests).
+	if reqMsg, ok := reflect.ValueOf(req).Elem().FieldByName("Msg").Interface().(proto.Message); ok {
+		reqMsgJSON, err := protojson.Marshal(reqMsg)
+		if err != nil {
+			tflog.Error(ctx, fmt.Sprintf("failed to marshal request message to JSON: %v", err))
+		}
+		reqFields["payload"] = string(reqMsgJSON)
+	} else {
+		tflog.Error(ctx, fmt.Sprintf("failed to get request message for logging; %T.Msg is not a proto.Message", req))
+	}
+
+	tflog.Debug(ctx, "sending API request", reqFields)
+}
+
+func tfLogResponse(ctx context.Context, req connect.AnyRequest, resp connect.AnyResponse, err error) {
+	respFields := tfLogBaseFields(req)
+
+	if err != nil {
+		respFields["error"] = err.Error()
+	}
+
+	// Similarly to request, not knowing the type of AnyResponse means that we have to use reflection to get to the underlying proto message.
+	respValue := reflect.ValueOf(resp)
+	if !respValue.IsValid() || respValue.IsNil() {
+		tflog.Debug(ctx, "got nil or invalid API response", respFields)
+		// Special case, we can't get much more info out of it.
+		return
+	} else if respMsgAttr, ok := respValue.Elem().FieldByName("Msg").Interface().(proto.Message); ok {
+		respMsgJSON, marshalErr := protojson.Marshal(respMsgAttr)
+		if marshalErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("failed to marshal response message to JSON: %+v", marshalErr))
+		}
+		respFields["payload"] = string(respMsgJSON)
+	} else {
+		tflog.Error(ctx, fmt.Sprintf("failed to get response message for logging; %T.Msg is not a proto.Message", resp))
+	}
+
+	tflog.Debug(ctx, "received API response", respFields)
+}
+
+func TFLogInterceptor() connect.Interceptor {
+	return connect.UnaryInterceptorFunc(func(uf connect.UnaryFunc) connect.UnaryFunc {
+		return func(
+			ctx context.Context,
+			req connect.AnyRequest,
+		) (connect.AnyResponse, error) {
+			tfLogRequest(ctx, req)
+			resp, err := uf(ctx, req)
+			tfLogResponse(ctx, req, resp, err)
+
+			return resp, err
+		}
+	})
+}
 
 func NewClient(endpoint string, s3Endpoint string, timeout time.Duration, interceptors ...connect.Interceptor) *Client {
 	rc := retryablehttp.NewClient()

--- a/coreweave/client_test.go
+++ b/coreweave/client_test.go
@@ -1,14 +1,121 @@
 package coreweave_test
 
 import (
+	"bytes"
+	"context"
 	"errors"
 	"testing"
 
+	"buf.build/gen/go/coreweave/cks/connectrpc/go/coreweave/cks/v1beta1/cksv1beta1connect"
+	cksv1beta1 "buf.build/gen/go/coreweave/cks/protocolbuffers/go/coreweave/cks/v1beta1"
 	"connectrpc.com/connect"
-	"github.com/alecthomas/assert/v2"
 	"github.com/coreweave/terraform-provider-coreweave/coreweave"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-log/tflogtest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func TestTFLogInterceptor(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		endpoint   string
+		req        *connect.Request[cksv1beta1.CreateClusterRequest]
+		returnResp *connect.Response[cksv1beta1.CreateClusterResponse]
+		returnErr  error
+		assertion  func(t *testing.T, logEntries []map[string]any)
+	}{
+		{
+			name:       "Basic successful response",
+			endpoint:   "https://api.coreweave.com",
+			req:        connect.NewRequest(&cksv1beta1.CreateClusterRequest{}),
+			returnResp: connect.NewResponse(&cksv1beta1.CreateClusterResponse{}),
+			assertion: func(t *testing.T, logEntries []map[string]any) {
+				t.Helper()
+				assert.Len(t, logEntries, 2)
+				respEntry := logEntries[1]
+				t.Run("request matches", func(t *testing.T) {
+					t.Parallel()
+					reqEntry := logEntries[0]
+					assert.Contains(t, reqEntry["@message"], "sending API request")
+					assert.Equal(t, "connect://api.coreweave.com", reqEntry["peer"])
+					assert.Equal(t, "unary", reqEntry["streamType"])
+					assert.Equal(t, "/coreweave.cks.v1beta1.ClusterService/CreateCluster", reqEntry["procedure"])
+					assert.NotEmpty(t, reqEntry["payload"])
+					assert.NotContains(t, reqEntry, "error")
+				})
+				t.Run("response matches", func(t *testing.T) {
+					t.Parallel()
+					assert.Contains(t, respEntry["@message"], "received API response")
+					assert.Equal(t, "connect://api.coreweave.com", respEntry["peer"])
+					assert.Equal(t, "unary", respEntry["streamType"])
+					assert.Equal(t, "/coreweave.cks.v1beta1.ClusterService/CreateCluster", respEntry["procedure"])
+					assert.NotEmpty(t, respEntry["payload"])
+					assert.NotContains(t, respEntry, "error")
+				})
+			},
+		},
+		{
+			name:       "Basic error response",
+			endpoint:   "https://api.coreweave.com",
+			req:        connect.NewRequest(&cksv1beta1.CreateClusterRequest{}),
+			returnResp: nil,
+			returnErr:  connect.NewError(connect.CodeInternal, errors.New("Internal server error")),
+			assertion: func(t *testing.T, logEntries []map[string]any) {
+				t.Helper()
+				t.Run("request matches", func(t *testing.T) {
+					t.Parallel()
+					reqEntry := logEntries[0]
+					assert.Contains(t, reqEntry["@message"], "sending API request")
+					assert.Equal(t, "connect://api.coreweave.com", reqEntry["peer"])
+					assert.Equal(t, "unary", reqEntry["streamType"])
+					assert.Equal(t, "/coreweave.cks.v1beta1.ClusterService/CreateCluster", reqEntry["procedure"])
+					assert.NotEmpty(t, reqEntry["payload"])
+					assert.NotContains(t, reqEntry, "error")
+				})
+				t.Run("resp shows error", func(t *testing.T) {
+					t.Parallel()
+					respEntry := logEntries[1]
+					assert.Contains(t, respEntry["@message"], "got nil or invalid API response")
+					assert.Equal(t, "connect://api.coreweave.com", respEntry["peer"])
+					assert.Equal(t, "unary", respEntry["streamType"])
+					assert.Equal(t, "/coreweave.cks.v1beta1.ClusterService/CreateCluster", respEntry["procedure"])
+					assert.NotContains(t, respEntry, "payload")
+					assert.Contains(t, respEntry, "error")
+					assert.Contains(t, respEntry["error"], "Internal server error")
+				})
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var logbuf bytes.Buffer
+			ctx := tflogtest.RootLogger(t.Context(), &logbuf)
+
+			interceptor := coreweave.TFLogInterceptor()
+			c := cksv1beta1connect.NewClusterServiceClient(nil, tt.endpoint, connect.WithInterceptors(interceptor, connect.UnaryInterceptorFunc(func(next connect.UnaryFunc) connect.UnaryFunc {
+				return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
+					// This short-circuits the client to return the desired response and error for testing without calling the next func.
+					return tt.returnResp, tt.returnErr
+				}
+			})))
+			resp, err := c.CreateCluster(ctx, tt.req)
+			assert.Equal(t, tt.returnErr, err)
+			assert.Equal(t, tt.returnResp, resp)
+
+			logEntries, err := tflogtest.MultilineJSONDecode(&logbuf)
+			require.NoError(t, err)
+
+			if tt.assertion != nil {
+				tt.assertion(t, logEntries)
+			}
+		})
+	}
+}
 
 func TestHandleAPIError(t *testing.T) {
 	t.Parallel()

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	buf.build/gen/go/coreweave/networking/connectrpc/go v1.18.1-20250310211902-b930cb89bad3.1
 	buf.build/gen/go/coreweave/networking/protocolbuffers/go v1.36.2-20250310211902-b930cb89bad3.1
 	connectrpc.com/connect v1.19.1
-	github.com/alecthomas/assert/v2 v2.11.0
 	github.com/aws/aws-sdk-go-v2 v1.37.0
 	github.com/aws/aws-sdk-go-v2/config v1.30.1
 	github.com/aws/aws-sdk-go-v2/credentials v1.18.1
@@ -26,6 +25,7 @@ require (
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.35.0
 	github.com/hashicorp/terraform-plugin-testing v1.11.0
+	github.com/stretchr/testify v1.11.1
 	github.com/zclconf/go-cty v1.15.0
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250218202821-56aae31c358a
 	google.golang.org/protobuf v1.36.10
@@ -36,7 +36,6 @@ require (
 	buf.build/gen/go/grpc-ecosystem/grpc-gateway/protocolbuffers/go v1.36.2-20241220201140-4c5ba75caaf8.1 // indirect
 	github.com/ProtonMail/go-crypto v1.1.0-alpha.2 // indirect
 	github.com/agext/levenshtein v1.2.2 // indirect
-	github.com/alecthomas/repr v0.4.0 // indirect
 	github.com/apparentlymart/go-textseg/v15 v15.0.0 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.0 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.0 // indirect
@@ -52,6 +51,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.31.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.35.0 // indirect
 	github.com/cloudflare/circl v1.3.7 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fatih/color v1.16.0 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
@@ -69,7 +69,6 @@ require (
 	github.com/hashicorp/terraform-registry-address v0.2.5 // indirect
 	github.com/hashicorp/terraform-svchost v0.1.1 // indirect
 	github.com/hashicorp/yamux v0.1.1 // indirect
-	github.com/hexops/gotextdiff v1.0.3 // indirect
 	github.com/kr/pretty v0.3.0 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
@@ -79,8 +78,8 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/oklog/run v1.0.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rogpeppe/go-internal v1.12.0 // indirect
-	github.com/stretchr/testify v1.11.1 // indirect
 	github.com/vmihailenco/msgpack v4.0.4+incompatible // indirect
 	github.com/vmihailenco/msgpack/v5 v5.4.1 // indirect
 	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
@@ -94,4 +93,5 @@ require (
 	google.golang.org/appengine v1.6.8 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20250218202821-56aae31c358a // indirect
 	google.golang.org/grpc v1.72.1 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -24,10 +24,6 @@ github.com/ProtonMail/go-crypto v1.1.0-alpha.2 h1:bkyFVUP+ROOARdgCiJzNQo2V2kiB97
 github.com/ProtonMail/go-crypto v1.1.0-alpha.2/go.mod h1:rA3QumHc/FZ8pAHreoekgiAbzpNsfQAosU5td4SnOrE=
 github.com/agext/levenshtein v1.2.2 h1:0S/Yg6LYmFJ5stwQeRp6EeOcCbj7xiqQSdNelsXvaqE=
 github.com/agext/levenshtein v1.2.2/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
-github.com/alecthomas/assert/v2 v2.11.0 h1:2Q9r3ki8+JYXvGsDyBXwH3LcJ+WK5D0gc5E8vS6K3D0=
-github.com/alecthomas/assert/v2 v2.11.0/go.mod h1:Bze95FyfUr7x34QZrjL+XP+0qgp/zg8yS+TtBj1WA3k=
-github.com/alecthomas/repr v0.4.0 h1:GhI2A8MACjfegCPVq9f1FLvIBS+DrQ2KQBFZP1iFzXc=
-github.com/alecthomas/repr v0.4.0/go.mod h1:Fr0507jx4eOXV7AlPV6AVZLYrLIuIeSOWtW57eE/O/4=
 github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJEynmyUenKwP++x/+DdGV/Ec=
 github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew1u1fNQOlOtuGxQY=
 github.com/apparentlymart/go-textseg/v15 v15.0.0/go.mod h1:K8XmNZdhEBkdlyDdvbmmsvpAG721bKi0joRfFdHIWJ4=
@@ -158,8 +154,6 @@ github.com/hashicorp/terraform-svchost v0.1.1 h1:EZZimZ1GxdqFRinZ1tpJwVxxt49xc/S
 github.com/hashicorp/terraform-svchost v0.1.1/go.mod h1:mNsjQfZyf/Jhz35v6/0LWcv26+X7JPS+buii2c9/ctc=
 github.com/hashicorp/yamux v0.1.1 h1:yrQxtgseBDrq9Y652vSRDvsKCJKOUD+GzTS4Y0Y8pvE=
 github.com/hashicorp/yamux v0.1.1/go.mod h1:CtWFDAQgb7dxtzFs4tWbplKIe2jSi3+5vKbgIO0SLnQ=
-github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
-github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jhump/protoreflect v1.15.1 h1:HUMERORf3I3ZdX05WaQ6MIpd/NJ434hTp5YiKgfCL6c=

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -198,7 +198,7 @@ func BuildClient(ctx context.Context, model CoreweaveProviderModel, tfVersion, p
 		},
 	)
 
-	return coreweave.NewClient(endpoint, s3Endpoint, timeout, headerInterceptor), nil
+	return coreweave.NewClient(endpoint, s3Endpoint, timeout, headerInterceptor, coreweave.TFLogInterceptor()), nil
 }
 
 func (p *CoreweaveProvider) Resources(ctx context.Context) []func() resource.Resource {


### PR DESCRIPTION
This change adds a connect interceptor implementation that logs the request/response of each request. This makes it much easier to see exactly what data is being transmitted/received at the API layer across all providers.