### PR TITLE
test: reduce collision probability for CKS terraform resource names

### DIFF
--- a/coreweave/cks/resource_cluster_test.go
+++ b/coreweave/cks/resource_cluster_test.go
@@ -197,7 +197,7 @@ func generateResourceNames(clusterNamePrefix string) resourceNames {
 	randomInt := rand.IntN(100)
 
 	clusterName := fmt.Sprintf("%s%s-%x", AcceptanceTestPrefix, clusterNamePrefix, randomInt)
-	resourceName := fmt.Sprintf("test_acc_cks_cluster_%x", randomInt)
+	resourceName := fmt.Sprintf("test_acc_cks_cluster_%s_%x", clusterNamePrefix, randomInt)
 	fullResourceName := fmt.Sprintf("coreweave_cks_cluster.%s", resourceName)
 	fullDataSourceName := fmt.Sprintf("data.coreweave_cks_cluster.%s", resourceName)
 
@@ -796,10 +796,9 @@ func TestEmptyAuditPolicy(t *testing.T) {
 func TestSharedStorage(t *testing.T) {
 	zone := testutil.AcceptanceTestZone
 	kubeVersion := testutil.AcceptanceTestKubeVersion
-	ctx := context.Background()
-
 	// Test 1: create a shared-storage cluster
 	t.Run("create cluster with shared storage", func(t *testing.T) {
+		ctx := t.Context()
 		// Create base (original/source) cluster that is sharing it's storage
 		baseConfig1 := generateResourceNames("shared")
 		baseVpc1 := defaultVpc(baseConfig1.ClusterName, zone)
@@ -830,7 +829,7 @@ func TestSharedStorage(t *testing.T) {
 			SharedStorageClusterId: types.StringValue(fmt.Sprintf("coreweave_cks_cluster.%s.id", baseConfig1.ResourceName)),
 		}
 
-		resource.Test(t, resource.TestCase{
+		resource.ParallelTest(t, resource.TestCase{
 			ProtoV6ProviderFactories: provider.TestProtoV6ProviderFactories,
 			PreCheck: func() {
 				testutil.SetEnvDefaults()


### PR DESCRIPTION
This PR reduces the probability of resource name collisions in CKS terraform tests by incorporating the cluster name prefix into the terraform resource name generation.

While the resource `name` itself, as passed to the API was guaranteed to be unique (and indeed, this is more important because tests may be run concurrently), there remained an intra-test collision problem, where multiple resources had the possibility of sharing the same name Terraform/HCL name, which is illegal Terraform. This change adds the unique string used for the resource name to the terraform identifier as well, which eliminates the possibility of a random collision for this field.