### PR TITLE
docs: Escape special characters

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -23,7 +23,7 @@ provider "coreweave" {
 
 ### Optional
 
-- `endpoint` (String) CoreWeave API Endpoint. This can also be set via the COREWEAVE_API_ENDPOINT environment variable, which takes precedence. Defaults to https://api.coreweave.com/
+- `endpoint` (String) CoreWeave API Endpoint. This can also be set via the COREWEAVE_API_ENDPOINT environment variable, which takes precedence. Defaults to `https://api.coreweave.com/`
 - `http_timeout` (String) Timeout duration for the HTTP client to use. This can also be set via the COREWEAVE_HTTP_TIMEOUT environment variable, which takes precedence. If unset, defaults to 10 seconds
-- `s3_endpoint` (String) CoreWeave S3 Endpoint, used for CoreWeave Object Storage. This can also be set via the COREWEAVE_S3_ENDPOINT environment variable, which takes precedence. Defaults to https://cwobject.com
+- `s3_endpoint` (String) CoreWeave S3 Endpoint, used for CoreWeave Object Storage. This can also be set via the COREWEAVE_S3_ENDPOINT environment variable, which takes precedence. Defaults to `https://cwobject.com`
 - `token` (String, Sensitive) CoreWeave API Token in the form `CW-SECRET-<secret>`. This can also be set via the COREWEAVE_API_TOKEN environment variable, which takes precedence.

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -79,14 +79,14 @@ func (p *CoreweaveProvider) Schema(ctx context.Context, req provider.SchemaReque
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"endpoint": schema.StringAttribute{
-				MarkdownDescription: fmt.Sprintf("CoreWeave API Endpoint. This can also be set via the %s environment variable, which takes precedence. Defaults to %s", CoreweaveApiEndpointEnvVar, CoreweaveApiEndpointDefault),
+				MarkdownDescription: fmt.Sprintf("CoreWeave API Endpoint. This can also be set via the %s environment variable, which takes precedence. Defaults to `%s`", CoreweaveApiEndpointEnvVar, CoreweaveApiEndpointDefault),
 				Optional:            true,
 				Validators: []validator.String{
 					uriValidator{},
 				},
 			},
 			"s3_endpoint": schema.StringAttribute{
-				MarkdownDescription: fmt.Sprintf("CoreWeave S3 Endpoint, used for CoreWeave Object Storage. This can also be set via the %s environment variable, which takes precedence. Defaults to %s", CoreWeaveS3EndpointEnvVar, CoreWeaveS3EndpointDefault),
+				MarkdownDescription: fmt.Sprintf("CoreWeave S3 Endpoint, used for CoreWeave Object Storage. This can also be set via the %s environment variable, which takes precedence. Defaults to `%s`", CoreWeaveS3EndpointEnvVar, CoreWeaveS3EndpointDefault),
 				Optional:            true,
 				Validators: []validator.String{
 					uriValidator{},


### PR DESCRIPTION
- Escapes the <> characters that cause rendering issues in the documentation.
- See: https://registry.terraform.io/providers/coreweave/coreweave/latest/docs#optional
- Rephrases the description for better clarity and grammar.
- Escapes bare URLs to resolve Markdownlint errors