### PR TITLE
fix: Set the user-agent header

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -192,7 +192,7 @@ func BuildClient(ctx context.Context, model CoreweaveProviderModel, tfVersion, p
 		func(next connect.UnaryFunc) connect.UnaryFunc {
 			return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
 				req.Header().Add("Authorization", fmt.Sprintf("Bearer %s", token))
-				req.Header().Add("User-Agent", fmt.Sprintf("Terraform/%s terraform-provider-coreweave/%s (+https://github.com/coreweave/terraform-provider-coreweave)", tfVersion, providerVersion))
+				req.Header().Set("User-Agent", fmt.Sprintf("Terraform/%s terraform-provider-coreweave/%s (+https://github.com/coreweave/terraform-provider-coreweave)", tfVersion, providerVersion))
 				return next(ctx, req)
 			}
 		},


### PR DESCRIPTION
Small change to address [CLDAPI-478](https://coreweave.atlassian.net/browse/CLDAPI-478)

Previously, requests included the default ConnectRPC User-Agent: `connect-go/XXX` 

```
➜  terraform-dev nc -l 3000
POST /coreweave.cwobject.v1.CWObject/CreateAccessKeyFromJWT HTTP/1.1
Host: localhost:3000
User-Agent: connect-go/1.19.1 (go1.25.2)
Content-Length: 5
Accept-Encoding: gzip
Authorization: Bearer CW-SECRET-<REDACTED>
Connect-Protocol-Version: 1
Content-Type: application/proto
```

This change ensures the User-Agent is overridded:

```
➜  terraform-dev nc -l 3000
POST /coreweave.cwobject.v1.CWObject/CreateAccessKeyFromJWT HTTP/1.1
Host: localhost:3000
User-Agent: Terraform/1.14.3 terraform-provider-coreweave/dev (+https://github.com/coreweave/terraform-provider-coreweave)
Content-Length: 5
Accept-Encoding: gzip
Authorization: Bearer CW-SECRET-<REDACTED>
Connect-Protocol-Version: 1
Content-Type: application/proto
```

I didn't see any relevant tests. I'm happy to add one if anyone thinks we should cover this.

[CLDAPI-478]: https://coreweave.atlassian.net/browse/CLDAPI-478?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ