### PR TITLE
feat: add plan-only acceptance tests

### DIFF
--- a/coreweave/cks/resource_cluster_test.go
+++ b/coreweave/cks/resource_cluster_test.go
@@ -544,7 +544,7 @@ func TestClusterResource(t *testing.T) {
 		createClusterTestStep(ctx, t, testStepConfig{
 			TestName: "requires replace on internal_lb_cidr_names removal and audit policy removal",
 			ConfigPlanChecks: resource.ConfigPlanChecks{
-				PostApplyPreRefresh: []plancheck.PlanCheck{
+				PreApply: []plancheck.PlanCheck{
 					plancheck.ExpectResourceAction(config.FullResourceName, plancheck.ResourceActionDestroyBeforeCreate),
 				},
 			},


### PR DESCRIPTION
Needed to modify the createClusterTestStep heavily to add "PlanOnly" test steps to the clusterCreate acceptance tests. I was forced into the heavy "if" logic because of how much the createClusterTestStep function helps add (lots of checks on the cluster object). Also exposed `ExpectNonEmptyPlan` in testStepConfig. 