### PR TITLE
ci: remove unnecessary terraform CLI installation from acceptance tests

### DIFF
--- a/.github/workflows/acceptance-test.yaml
+++ b/.github/workflows/acceptance-test.yaml
@@ -8,10 +8,6 @@ name: Run Acceptance Test
         description: 'Test suite to run (e.g., cks, networking, object-storage)'
         required: true
         type: string
-      terraform_version:
-        description: 'Terraform version to test with'
-        required: true
-        type: string
 
 concurrency:
   group: acceptance-test-${{ inputs.suite }}
@@ -31,9 +27,6 @@ jobs:
         with:
           go-version-file: 'go.mod'
           cache: false
-      - uses: hashicorp/setup-terraform@v3.1.2
-        with:
-          terraform_wrapper: false
 
       - name: Sweep ${{ inputs.suite }} resources
         run: make testacc-sweep SUITES='${{ inputs.suite }}'
@@ -54,10 +47,6 @@ jobs:
         with:
           go-version-file: 'go.mod'
           cache: false
-      - uses: hashicorp/setup-terraform@v3.1.2
-        with:
-          terraform_version: ${{ inputs.terraform_version }}
-          terraform_wrapper: false
       - run: go mod download
 
       - name: Validate ${{ inputs.suite }} acceptance tests

--- a/.github/workflows/acceptance-tests.yaml
+++ b/.github/workflows/acceptance-tests.yaml
@@ -91,9 +91,7 @@ jobs:
       fail-fast: true
       matrix:
         suite: ${{ fromJson(needs.detect-changes.outputs.suites) }}
-        terraform: ['1.12.*', '1.13.*']
     uses: ./.github/workflows/acceptance-test.yaml
     with:
       suite: ${{ matrix.suite }}
-      terraform_version: ${{ matrix.terraform }}
     secrets: inherit


### PR DESCRIPTION
The acceptance tests use the terraform framework, which uses an in-code terraform provider server. This compatibility check is low-value and high-cost, doubling the time that tests take and doubling the total number of tests. This wastes time and resources.

The strongest proof of this is that the tests still work without installing a terraform CLI. The provider is compiled to its own plugin binary and is invoked as a plugin, so it has strong compatibility with Terraform CLI.