### PR TITLE
test(cks): run shared-storage tests in parallel

### DIFF
--- a/coreweave/cks/resource_cluster_test.go
+++ b/coreweave/cks/resource_cluster_test.go
@@ -155,7 +155,7 @@ func TestClusterSchema(t *testing.T) {
 	}
 }
 
-func defaultVpc(name, zone string) *networking.VpcResourceModel {
+func defaultVpc(name, zone string) *networking.VpcResourceModel { //nolint:unparam
 	if len(name) > 30 {
 		// Bail on the tests as early as possible; this is a test definition failure.
 		panic("Vpc name must be 30 characters or less")


### PR DESCRIPTION
This removes the t.Run from the given test. Because resource.ParallelTest accepts a `*testing.T`, its parallelism is scoped to that function. Because it was inside the run, its parallelism was scoped to the `t.Run()`, not to the top-level function. As a result, the top-level function blocks execution of all other tests until it is done.

Two ways to fix this:

1. `t.Parallel()` at the top level
2. Remove the `t.Run()`.

Implemented the second because the t.Run is not providing useful disambiguation, and I'd prefer to remove lines. Recommend looking at the diff with `?w=1`.