### PR TITLE
ci(renovate): replace inherited coreweave/renovate-config with explicit config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -2,6 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended",
+    ":semanticCommits",
     ":disableRateLimiting",
     "helpers:pinGitHubActionDigests"
   ],

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,22 +1,39 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "github>coreweave/renovate-config"
+    "config:recommended",
+    ":disableRateLimiting",
+    "helpers:pinGitHubActionDigests"
   ],
   "semanticCommitType": "deps",
+  "commitMessageTopic": "{{depName}}",
+  "commitMessageExtra": "( {{currentVersion}} → {{newVersion}} )",
+  "commitMessageSuffix": "",
+  "postUpdateOptions": ["gomodTidy"],
+  "rebaseWhen": "conflicted",
+  "commitBodyTable": true,
   "packageRules": [
+    { "matchUpdateTypes": ["major"], "labels": ["type/major"] },
+    { "matchUpdateTypes": ["minor"], "labels": ["type/minor"] },
+    { "matchUpdateTypes": ["patch"], "labels": ["type/patch"] },
+    { "matchUpdateTypes": ["digest"], "labels": ["type/digest"] },
     {
-      // The parent preset (coreweave/renovate-config:semantic-commits) hardcodes
-      // commitMessagePrefix with "!" for all major updates. Override that globally:
-      // no external dependency bump should be treated as a provider breaking change.
-      // Intentional provider breaking changes come from developer-authored feat!/fix! commits.
-      "matchUpdateTypes": ["major"],
-      "commitMessagePrefix": "{{semanticCommitType}}{{#if semanticCommitScope}}({{semanticCommitScope}}){{/if}}:"
+      "matchUpdateTypes": ["digest"],
+      "commitMessageExtra": "( {{currentDigestShort}} → {{newDigestShort}} )"
+    },
+    {
+      // Default: all gomod deps use "deps" commit type regardless of update type.
+      // Placed before more specific rules; later rules take precedence per Renovate's
+      // last-rule-wins ordering.
+      "matchManagers": ["gomod"],
+      "semanticCommitType": "deps",
+      "semanticCommitScope": null
     },
     {
       "matchManagers": ["github-actions"],
       "semanticCommitType": "ci",
-      "semanticCommitScope": "github-action"
+      "semanticCommitScope": "github-action",
+      "addLabels": ["renovate/github-action"]
     },
     {
       "matchManagers": ["mise"],
@@ -24,7 +41,12 @@
       "semanticCommitScope": "mise"
     },
     {
-      // consolidate go.mod updates to use golang-version/go
+      // Ensure Go version range in go.mod is bumped rather than pinned.
+      "matchDatasources": ["golang-version"],
+      "rangeStrategy": "bump"
+    },
+    {
+      // Consolidate go.mod updates to use golang-version/go datasource.
       "matchDatasources": ["github-tags"],
       "matchPackageNames": ["golang/go"],
       "overrideDatasource": "golang-version",


### PR DESCRIPTION
## Summary

Stops extending the monolithic `github>coreweave/renovate-config` preset entirely. All needed behavior is now explicit in `.github/renovate.json5`.

**Problem**: The inherited `semantic-commits` sub-preset mapped patch→`fix` and minor/major→`feat` for unmatched packages, producing misleading commits like `fix(deps): update module connectrpc.com/connect`.

**Fix**: A broad `matchManagers: ["gomod"]` default rule sets `deps` commit type with null scope for all Go modules. More specific rules (buf.build scopes, `hashicorp-tools` → `ci/tools`, etc.) follow it and take precedence via Renovate's last-rule-wins ordering.

## What's kept
- `config:recommended`, `:disableRateLimiting`, `helpers:pinGitHubActionDigests`
- Commit message format: `( old → new )`
- PR labels: `type/{major,minor,patch,digest}`, `renovate/github-action`
- `postUpdateOptions: ["gomodTidy"]`, `rebaseWhen: "conflicted"`, `commitBodyTable`
- `golang-version` `rangeStrategy: "bump"`

## What's dropped (not relevant to this repo)
`docker:enableMajor`, `:enablePreCommit`, `custom-managers.json5`, `bsr.json5`, `nix`, `exposeAllEnv`, `allowedCommands`, `suppressNotifications`, `platformCommit`, `configMigration`, `coreweave/actions` versioning rule, `commitMessagePrefix` `!` override (no longer needed)