### PR TITLE
docs(object-storage): Scope bucket policy examples by org condition

### DIFF
--- a/docs/data-sources/object_storage_bucket_policy_document.md
+++ b/docs/data-sources/object_storage_bucket_policy_document.md
@@ -13,15 +13,33 @@ description: |-
 ## Example Usage
 
 ```terraform
+variable "bucket_name" {
+  type        = string
+  description = "Name of the bucket to allow access to."
+}
+
+variable "org_id" {
+  type        = string
+  description = "CoreWeave organization ID to match in the bucket policy condition."
+}
+
 data "coreweave_object_storage_bucket_policy_document" "default" {
   version = "2012-10-17"
   statement {
-    sid      = "allow-all"
-    effect   = "Allow"
-    action   = ["s3:*"]
-    resource = ["arn:aws:s3:::*"]
+    sid    = "AllowAllInOrg"
+    effect = "Allow"
+    action = ["s3:*"]
+    resource = [
+      "arn:aws:s3:::${var.bucket_name}",
+      "arn:aws:s3:::${var.bucket_name}/*",
+    ]
     principal = {
       "CW" : ["*"]
+    }
+    condition = {
+      "StringEquals" : {
+        "cw:PrincipalOrgID" : var.org_id
+      }
     }
   }
 }

--- a/docs/data-sources/object_storage_bucket_policy_document.md
+++ b/docs/data-sources/object_storage_bucket_policy_document.md
@@ -13,6 +13,14 @@ description: |-
 ## Example Usage
 
 ```terraform
+terraform {
+  required_providers {
+    coreweave = {
+      source = "coreweave/coreweave"
+    }
+  }
+}
+
 variable "bucket_name" {
   type        = string
   description = "Name of the bucket to allow access to."

--- a/docs/data-sources/object_storage_bucket_policy_document.md
+++ b/docs/data-sources/object_storage_bucket_policy_document.md
@@ -34,7 +34,7 @@ variable "org_id" {
 data "coreweave_object_storage_bucket_policy_document" "default" {
   version = "2012-10-17"
   statement {
-    sid    = "AllowAllInOrg"
+    sid    = "AllowUserAndGroup"
     effect = "Allow"
     action = ["s3:*"]
     resource = [
@@ -42,7 +42,8 @@ data "coreweave_object_storage_bucket_policy_document" "default" {
       "arn:aws:s3:::${var.bucket_name}/*",
     ]
     principal = {
-      "CW" : ["*"]
+      "CW"  = ["arn:aws:iam::[ORG-ID]:coreweave/[USER-ID]"]
+      "AWS" = ["arn:aws:iam::[ORG-ID]:saml/[SAML-GROUP-ID]"]
     }
     condition = {
       "StringEquals" : {

--- a/docs/resources/object_storage_bucket_policy.md
+++ b/docs/resources/object_storage_bucket_policy.md
@@ -15,18 +15,31 @@ description: |-
 ```terraform
 ## Example using jsonencode to pass a raw JSON string to the policy attribute
 
+variable "org_id" {
+  type        = string
+  description = "CoreWeave organization ID to match in the bucket policy condition."
+}
+
 locals {
   bucket_policy = {
     Version = "2012-10-17"
     Statement = [
       {
-        Sid    = "allow-all"
+        Sid    = "AllowAllInOrg"
         Effect = "Allow"
         Principal = {
-          "CW" : "*"
+          "CW" : ["*"]
         }
-        Action   = ["s3:*"]
-        Resource = ["arn:aws:s3:::${coreweave_object_storage_bucket.raw.name}"]
+        Action = ["s3:*"]
+        Resource = [
+          "arn:aws:s3:::${coreweave_object_storage_bucket.raw.name}",
+          "arn:aws:s3:::${coreweave_object_storage_bucket.raw.name}/*",
+        ]
+        Condition = {
+          "StringEquals" = {
+            "cw:PrincipalOrgID" = [var.org_id]
+          }
+        }
       },
     ]
   }
@@ -52,17 +65,25 @@ resource "coreweave_object_storage_bucket" "doc" {
 data "coreweave_object_storage_bucket_policy_document" "doc" {
   version = "2012-10-17"
   statement {
-    sid      = "allow-all"
-    effect   = "Allow"
-    action   = ["s3:*"]
-    resource = ["arn:aws:s3:::${coreweave_object_storage_bucket.doc.name}"]
+    sid    = "AllowAllInOrg"
+    effect = "Allow"
+    action = ["s3:*"]
+    resource = [
+      "arn:aws:s3:::${coreweave_object_storage_bucket.doc.name}",
+      "arn:aws:s3:::${coreweave_object_storage_bucket.doc.name}/*",
+    ]
     principal = {
       "CW" : ["*"]
+    }
+    condition = {
+      "StringEquals" : {
+        "cw:PrincipalOrgID" : var.org_id
+      }
     }
   }
 
   statement {
-    sid      = "DenyIfPrefixEquals"
+    sid      = "DenyIfPrefixNotEquals"
     effect   = "Deny"
     action   = ["s3:ListBucket"]
     resource = ["arn:aws:s3:::${coreweave_object_storage_bucket.doc.name}"]
@@ -72,6 +93,9 @@ data "coreweave_object_storage_bucket_policy_document" "doc" {
     condition = {
       "StringNotEquals" : {
         "s3:prefix" : "projects"
+      }
+      "StringEquals" : {
+        "cw:PrincipalOrgID" : var.org_id
       }
     }
   }

--- a/docs/resources/object_storage_bucket_policy.md
+++ b/docs/resources/object_storage_bucket_policy.md
@@ -15,6 +15,14 @@ description: |-
 ```terraform
 ## Example using jsonencode to pass a raw JSON string to the policy attribute
 
+terraform {
+  required_providers {
+    coreweave = {
+      source = "coreweave/coreweave"
+    }
+  }
+}
+
 variable "org_id" {
   type        = string
   description = "CoreWeave organization ID to match in the bucket policy condition."

--- a/docs/resources/object_storage_bucket_policy.md
+++ b/docs/resources/object_storage_bucket_policy.md
@@ -33,10 +33,11 @@ locals {
     Version = "2012-10-17"
     Statement = [
       {
-        Sid    = "AllowAllInOrg"
+        Sid    = "AllowUserAndGroup"
         Effect = "Allow"
         Principal = {
-          "CW" : ["*"]
+          "CW"  = ["arn:aws:iam::[ORG-ID]:coreweave/[USER-ID]"]
+          "AWS" = ["arn:aws:iam::[ORG-ID]:saml/[SAML-GROUP-ID]"]
         }
         Action = ["s3:*"]
         Resource = [
@@ -73,7 +74,7 @@ resource "coreweave_object_storage_bucket" "doc" {
 data "coreweave_object_storage_bucket_policy_document" "doc" {
   version = "2012-10-17"
   statement {
-    sid    = "AllowAllInOrg"
+    sid    = "AllowUserAndGroup"
     effect = "Allow"
     action = ["s3:*"]
     resource = [
@@ -81,7 +82,8 @@ data "coreweave_object_storage_bucket_policy_document" "doc" {
       "arn:aws:s3:::${coreweave_object_storage_bucket.doc.name}/*",
     ]
     principal = {
-      "CW" : ["*"]
+      "CW"  = ["arn:aws:iam::[ORG-ID]:coreweave/[USER-ID]"]
+      "AWS" = ["arn:aws:iam::[ORG-ID]:saml/[SAML-GROUP-ID]"]
     }
     condition = {
       "StringEquals" : {
@@ -96,7 +98,8 @@ data "coreweave_object_storage_bucket_policy_document" "doc" {
     action   = ["s3:ListBucket"]
     resource = ["arn:aws:s3:::${coreweave_object_storage_bucket.doc.name}"]
     principal = {
-      "CW" : ["*"]
+      "CW"  = ["arn:aws:iam::[ORG-ID]:coreweave/[USER-ID]"]
+      "AWS" = ["arn:aws:iam::[ORG-ID]:saml/[SAML-GROUP-ID]"]
     }
     condition = {
       "StringNotEquals" : {

--- a/examples/data-sources/coreweave_object_storage_bucket_policy_document/data-source.tf
+++ b/examples/data-sources/coreweave_object_storage_bucket_policy_document/data-source.tf
@@ -1,12 +1,30 @@
+variable "bucket_name" {
+  type        = string
+  description = "Name of the bucket to allow access to."
+}
+
+variable "org_id" {
+  type        = string
+  description = "CoreWeave organization ID to match in the bucket policy condition."
+}
+
 data "coreweave_object_storage_bucket_policy_document" "default" {
   version = "2012-10-17"
   statement {
-    sid      = "allow-all"
-    effect   = "Allow"
-    action   = ["s3:*"]
-    resource = ["arn:aws:s3:::*"]
+    sid    = "AllowAllInOrg"
+    effect = "Allow"
+    action = ["s3:*"]
+    resource = [
+      "arn:aws:s3:::${var.bucket_name}",
+      "arn:aws:s3:::${var.bucket_name}/*",
+    ]
     principal = {
       "CW" : ["*"]
+    }
+    condition = {
+      "StringEquals" : {
+        "cw:PrincipalOrgID" : var.org_id
+      }
     }
   }
 }

--- a/examples/data-sources/coreweave_object_storage_bucket_policy_document/data-source.tf
+++ b/examples/data-sources/coreweave_object_storage_bucket_policy_document/data-source.tf
@@ -1,3 +1,11 @@
+terraform {
+  required_providers {
+    coreweave = {
+      source = "coreweave/coreweave"
+    }
+  }
+}
+
 variable "bucket_name" {
   type        = string
   description = "Name of the bucket to allow access to."

--- a/examples/data-sources/coreweave_object_storage_bucket_policy_document/data-source.tf
+++ b/examples/data-sources/coreweave_object_storage_bucket_policy_document/data-source.tf
@@ -19,7 +19,7 @@ variable "org_id" {
 data "coreweave_object_storage_bucket_policy_document" "default" {
   version = "2012-10-17"
   statement {
-    sid    = "AllowAllInOrg"
+    sid    = "AllowUserAndGroup"
     effect = "Allow"
     action = ["s3:*"]
     resource = [
@@ -27,7 +27,8 @@ data "coreweave_object_storage_bucket_policy_document" "default" {
       "arn:aws:s3:::${var.bucket_name}/*",
     ]
     principal = {
-      "CW" : ["*"]
+      "CW"  = ["arn:aws:iam::[ORG-ID]:coreweave/[USER-ID]"]
+      "AWS" = ["arn:aws:iam::[ORG-ID]:saml/[SAML-GROUP-ID]"]
     }
     condition = {
       "StringEquals" : {

--- a/examples/resources/coreweave_object_storage_bucket_policy/resource.tf
+++ b/examples/resources/coreweave_object_storage_bucket_policy/resource.tf
@@ -1,17 +1,30 @@
 ## Example using jsonencode to pass a raw JSON string to the policy attribute
 
+variable "org_id" {
+  type        = string
+  description = "CoreWeave organization ID to match in the bucket policy condition."
+}
+
 locals {
   bucket_policy = {
     Version = "2012-10-17"
     Statement = [
       {
-        Sid    = "allow-all"
+        Sid    = "AllowAllInOrg"
         Effect = "Allow"
         Principal = {
-          "CW" : "*"
+          "CW" : ["*"]
         }
-        Action   = ["s3:*"]
-        Resource = ["arn:aws:s3:::${coreweave_object_storage_bucket.raw.name}"]
+        Action = ["s3:*"]
+        Resource = [
+          "arn:aws:s3:::${coreweave_object_storage_bucket.raw.name}",
+          "arn:aws:s3:::${coreweave_object_storage_bucket.raw.name}/*",
+        ]
+        Condition = {
+          "StringEquals" = {
+            "cw:PrincipalOrgID" = [var.org_id]
+          }
+        }
       },
     ]
   }
@@ -37,17 +50,25 @@ resource "coreweave_object_storage_bucket" "doc" {
 data "coreweave_object_storage_bucket_policy_document" "doc" {
   version = "2012-10-17"
   statement {
-    sid      = "allow-all"
-    effect   = "Allow"
-    action   = ["s3:*"]
-    resource = ["arn:aws:s3:::${coreweave_object_storage_bucket.doc.name}"]
+    sid    = "AllowAllInOrg"
+    effect = "Allow"
+    action = ["s3:*"]
+    resource = [
+      "arn:aws:s3:::${coreweave_object_storage_bucket.doc.name}",
+      "arn:aws:s3:::${coreweave_object_storage_bucket.doc.name}/*",
+    ]
     principal = {
       "CW" : ["*"]
+    }
+    condition = {
+      "StringEquals" : {
+        "cw:PrincipalOrgID" : var.org_id
+      }
     }
   }
 
   statement {
-    sid      = "DenyIfPrefixEquals"
+    sid      = "DenyIfPrefixNotEquals"
     effect   = "Deny"
     action   = ["s3:ListBucket"]
     resource = ["arn:aws:s3:::${coreweave_object_storage_bucket.doc.name}"]
@@ -57,6 +78,9 @@ data "coreweave_object_storage_bucket_policy_document" "doc" {
     condition = {
       "StringNotEquals" : {
         "s3:prefix" : "projects"
+      }
+      "StringEquals" : {
+        "cw:PrincipalOrgID" : var.org_id
       }
     }
   }

--- a/examples/resources/coreweave_object_storage_bucket_policy/resource.tf
+++ b/examples/resources/coreweave_object_storage_bucket_policy/resource.tf
@@ -1,5 +1,13 @@
 ## Example using jsonencode to pass a raw JSON string to the policy attribute
 
+terraform {
+  required_providers {
+    coreweave = {
+      source = "coreweave/coreweave"
+    }
+  }
+}
+
 variable "org_id" {
   type        = string
   description = "CoreWeave organization ID to match in the bucket policy condition."

--- a/examples/resources/coreweave_object_storage_bucket_policy/resource.tf
+++ b/examples/resources/coreweave_object_storage_bucket_policy/resource.tf
@@ -18,10 +18,11 @@ locals {
     Version = "2012-10-17"
     Statement = [
       {
-        Sid    = "AllowAllInOrg"
+        Sid    = "AllowUserAndGroup"
         Effect = "Allow"
         Principal = {
-          "CW" : ["*"]
+          "CW"  = ["arn:aws:iam::[ORG-ID]:coreweave/[USER-ID]"]
+          "AWS" = ["arn:aws:iam::[ORG-ID]:saml/[SAML-GROUP-ID]"]
         }
         Action = ["s3:*"]
         Resource = [
@@ -58,7 +59,7 @@ resource "coreweave_object_storage_bucket" "doc" {
 data "coreweave_object_storage_bucket_policy_document" "doc" {
   version = "2012-10-17"
   statement {
-    sid    = "AllowAllInOrg"
+    sid    = "AllowUserAndGroup"
     effect = "Allow"
     action = ["s3:*"]
     resource = [
@@ -66,7 +67,8 @@ data "coreweave_object_storage_bucket_policy_document" "doc" {
       "arn:aws:s3:::${coreweave_object_storage_bucket.doc.name}/*",
     ]
     principal = {
-      "CW" : ["*"]
+      "CW"  = ["arn:aws:iam::[ORG-ID]:coreweave/[USER-ID]"]
+      "AWS" = ["arn:aws:iam::[ORG-ID]:saml/[SAML-GROUP-ID]"]
     }
     condition = {
       "StringEquals" : {
@@ -81,7 +83,8 @@ data "coreweave_object_storage_bucket_policy_document" "doc" {
     action   = ["s3:ListBucket"]
     resource = ["arn:aws:s3:::${coreweave_object_storage_bucket.doc.name}"]
     principal = {
-      "CW" : ["*"]
+      "CW"  = ["arn:aws:iam::[ORG-ID]:coreweave/[USER-ID]"]
+      "AWS" = ["arn:aws:iam::[ORG-ID]:saml/[SAML-GROUP-ID]"]
     }
     condition = {
       "StringNotEquals" : {


### PR DESCRIPTION
## Summary
- Updates Object Storage bucket policy Terraform examples to use one console user (`CW`) and one SAML group (`AWS`) as named principals, aligned with the merged docs PR [coreweave/docs#3044](https://github.com/coreweave/docs/pull/3044).
- Keeps `cw:PrincipalOrgID` in each example as an extra safety measure.
- Replaces the broad `arn:aws:s3:::*` data source example with bucket-specific bucket and object ARNs.
- Declares `coreweave/coreweave` as the provider source in each independently copyable example and regenerates the provider reference docs.

## Rationale
The earlier draft used `"CW": ["*"]`. In HCL, the square brackets are list syntax for the principal map, but `*` as the identifier is not the correct org-scoped wildcard form. The docs now use named principal ARNs for generic examples and reserve bare `"Principal": "*"` for explicit org-wide patterns with `cw:PrincipalOrgID`.

Each example is a standalone root module when copied from the generated reference documentation, so declaring `coreweave/coreweave` once per example makes it directly initializable without duplicating the declaration for every resource.

## Test plan
- [x] Run `terraform fmt` on the updated example files
- [x] Run `make -f GNUmakefile generate`
- [x] Run `go test ./coreweave/object_storage`
- [x] Run `git diff --check`
- [x] Run `terraform init -backend=false` and `terraform validate` for both updated examples.
- [x] Confirm `terraform plan -refresh=false` reaches provider configuration for both examples. It stops as expected without a CoreWeave API token; no remote resources are created.

## Additional validation with documentation example harness

To increase confidence before merge, the changes in this PR were also validated with a credential-free documentation example harness developed on branch `cg/DOCS-3002-terraform-example-harness` ([DOCS-3002](https://coreweave.atlassian.net/browse/DOCS-3002)). That branch is based on this PR and is not part of this merge scope.

The harness copies each registered example into a temporary directory so no `.terraform/` or lockfiles are written under `examples/`, then runs:

1. `terraform fmt -check`
2. `terraform init -backend=false -input=false`
3. `terraform validate`

Both modules in this PR passed:

- `examples/resources/coreweave_object_storage_bucket_policy`
- `examples/data-sources/coreweave_object_storage_bucket_policy_document`

The harness does not run `plan` or `apply`, so it does not require CoreWeave API credentials. It confirms that each example resolves `coreweave/coreweave`, initializes cleanly, and passes schema validation as an independently copyable root module.

Closes [DOCS-2126](https://coreweave.atlassian.net/browse/DOCS-2126)

Made with [Cursor](https://cursor.com)

[DOCS-2126]: https://coreweave.atlassian.net/browse/DOCS-2126?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[DOCS-3002]: https://coreweave.atlassian.net/browse/DOCS-3002?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ