### PR TITLE
feat(object_storage): add acceptance sweeper and deprecate lifecycle rule.prefix

### DIFF
--- a/.github/workflows/acceptance-test.yaml
+++ b/.github/workflows/acceptance-test.yaml
@@ -21,6 +21,7 @@ jobs:
     env:
       COREWEAVE_API_ENDPOINT: ${{ inputs.suite == 'object_storage' && secrets.COREWEAVE_OBJS_API_ENDPOINT || vars.COREWEAVE_API_ENDPOINT }}
       COREWEAVE_API_TOKEN: ${{ inputs.suite == 'object_storage' && secrets.COREWEAVE_OBJS_API_TOKEN || secrets.COREWEAVE_API_TOKEN }}
+      TEST_ACC_SWEEP_ZONE: ${{ inputs.suite == 'object_storage' && 'US-EAST-04A' || 'US-LAB-01A' }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - uses: ./.github/actions/setup

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,5 @@ test/
 .vscode/*
 
 __debug*
+
+.env

--- a/coreweave/object_storage/resource_bucket_lifecycle_configuration.go
+++ b/coreweave/object_storage/resource_bucket_lifecycle_configuration.go
@@ -155,7 +155,8 @@ func (r *BucketLifecycleResource) Schema(ctx context.Context, req resource.Schem
 						},
 						"prefix": schema.StringAttribute{
 							Optional:            true,
-							MarkdownDescription: "Object key prefix to which the rule applies",
+							MarkdownDescription: "Deprecated. Object key prefix to which the rule applies. CoreWeave AI Object Storage rejects requests that set this field; use `filter.prefix` instead.",
+							DeprecationMessage:  "Use filter.prefix instead. CoreWeave AI Object Storage now rejects PutBucketLifecycleConfiguration requests that include this deprecated S3 field, so the provider no longer sends it on the wire. Any value set here is retained in state for backwards compatibility but is otherwise ignored.",
 						},
 						"status": schema.StringAttribute{
 							Required:            true,
@@ -324,16 +325,18 @@ func parseISO8601(s string) time.Time {
 	return t
 }
 
-func expandRules(ctx context.Context, in []LifecycleRuleModel) []s3types.LifecycleRule { //nolint:gocyclo
+func expandRules(ctx context.Context, in []LifecycleRuleModel) []s3types.LifecycleRule {
 	out := make([]s3types.LifecycleRule, 0, len(in))
 	for _, r := range in {
 		rule := s3types.LifecycleRule{
 			ID:     aws.String(r.ID.ValueString()),
 			Status: s3types.ExpirationStatus(r.Status.ValueString()),
 		}
-		if !r.Prefix.IsNull() {
-			rule.Prefix = aws.String(r.Prefix.ValueString()) //nolint:staticcheck
-		}
+		// The deprecated top-level Prefix field is intentionally not propagated
+		// to the API: CoreWeave AI Object Storage rejects requests that set it
+		// (it was a silent no-op before, now it's an explicit error). Users
+		// should use filter.prefix instead. We retain the value in state via
+		// flattenLifecycleRules so existing configs don't churn at plan time.
 		if r.Expiration != nil {
 			exp := s3types.LifecycleExpiration{}
 			if !r.Expiration.Date.IsNull() {
@@ -635,20 +638,37 @@ func (r *BucketLifecycleResource) Create(ctx context.Context, req resource.Creat
 		handleS3Error(err, &resp.Diagnostics, data.Bucket.ValueString())
 		return
 	} else {
-		data.Rule = flattenLifecycleRules(result.Rules)
+		data.Rule = flattenLifecycleRules(result.Rules, data.Rule)
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
-// flattenLifecycleRules turns AWS SDK LifecycleRule objects into our Terraform model.
-func flattenLifecycleRules(in []s3types.LifecycleRule) []LifecycleRuleModel {
+// flattenLifecycleRules turns AWS SDK LifecycleRule objects into our Terraform
+// model. The preserve argument is the prior model (plan or state) before the
+// API round-trip; it carries client-side-only fields that the API does not
+// echo back — currently just the deprecated rule.prefix. Match is by rule ID;
+// rules without an ID will not have their deprecated prefix carried over, but
+// such rules wouldn't be using the deprecated field in practice.
+func flattenLifecycleRules(in []s3types.LifecycleRule, preserve []LifecycleRuleModel) []LifecycleRuleModel {
+	preservedPrefix := make(map[string]types.String, len(preserve))
+	for _, p := range preserve {
+		if !p.ID.IsNull() && !p.ID.IsUnknown() {
+			preservedPrefix[p.ID.ValueString()] = p.Prefix
+		}
+	}
+
 	out := make([]LifecycleRuleModel, 0, len(in))
 	for _, r := range in {
 		mdl := LifecycleRuleModel{
 			ID:     types.StringPointerValue(r.ID),
-			Prefix: types.StringPointerValue(r.Prefix), //nolint:staticcheck
+			Prefix: types.StringNull(),
 			Status: types.StringValue(string(r.Status)),
+		}
+		if r.ID != nil {
+			if pref, ok := preservedPrefix[*r.ID]; ok {
+				mdl.Prefix = pref
+			}
 		}
 
 		if r.Expiration != nil {
@@ -765,7 +785,7 @@ func (r *BucketLifecycleResource) Read(ctx context.Context, req resource.ReadReq
 	}
 
 	// use our helper to flatten
-	data.Rule = flattenLifecycleRules(out.Rules)
+	data.Rule = flattenLifecycleRules(out.Rules, data.Rule)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
@@ -807,7 +827,7 @@ func (r *BucketLifecycleResource) Update(ctx context.Context, req resource.Updat
 		return
 	} else {
 		// Read the result back into state. Terraform will detect and fail if the state does not match the plan.
-		data.Rule = flattenLifecycleRules(result.Rules)
+		data.Rule = flattenLifecycleRules(result.Rules, data.Rule)
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
@@ -859,7 +879,7 @@ func (r *BucketLifecycleResource) ImportState(ctx context.Context, req resource.
 	}
 
 	// use our helper to flatten
-	data.Rule = flattenLifecycleRules(out.Rules)
+	data.Rule = flattenLifecycleRules(out.Rules, data.Rule)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }

--- a/coreweave/object_storage/resource_bucket_lifecycle_configuration.go
+++ b/coreweave/object_storage/resource_bucket_lifecycle_configuration.go
@@ -657,7 +657,7 @@ func (r *BucketLifecycleResource) Create(ctx context.Context, req resource.Creat
 func flattenLifecycleRules(in []s3types.LifecycleRule, preserve []LifecycleRuleModel) []LifecycleRuleModel {
 	preservedPrefix := make(map[string]types.String, len(preserve))
 	for _, p := range preserve {
-		if !p.ID.IsNull() && !p.ID.IsUnknown() {
+		if !isMissingRuleID(p.ID) {
 			preservedPrefix[p.ID.ValueString()] = p.Prefix
 		}
 	}
@@ -674,7 +674,7 @@ func flattenLifecycleRules(in []s3types.LifecycleRule, preserve []LifecycleRuleM
 			if pref, ok := preservedPrefix[*r.ID]; ok {
 				mdl.Prefix = pref
 			}
-		} else if sameLength && (preserve[i].ID.IsNull() || preserve[i].ID.IsUnknown()) {
+		} else if sameLength && isMissingRuleID(preserve[i].ID) {
 			// Both sides have no ID at this position — positional alignment is
 			// the only signal we have, and it's safe because there's no other
 			// rule the preserved value could refer to.
@@ -766,6 +766,10 @@ func flattenLifecycleRules(in []s3types.LifecycleRule, preserve []LifecycleRuleM
 		out = append(out, mdl)
 	}
 	return out
+}
+
+func isMissingRuleID(id types.String) bool {
+	return id.IsNull() || id.IsUnknown() || id.ValueString() == ""
 }
 
 func (r *BucketLifecycleResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {

--- a/coreweave/object_storage/resource_bucket_lifecycle_configuration.go
+++ b/coreweave/object_storage/resource_bucket_lifecycle_configuration.go
@@ -156,7 +156,7 @@ func (r *BucketLifecycleResource) Schema(ctx context.Context, req resource.Schem
 						"prefix": schema.StringAttribute{
 							Optional:            true,
 							MarkdownDescription: "Deprecated. Object key prefix to which the rule applies. CoreWeave AI Object Storage rejects requests that set this field; use `filter.prefix` instead.",
-							DeprecationMessage:  "Use filter.prefix instead. CoreWeave AI Object Storage now rejects PutBucketLifecycleConfiguration requests that include this deprecated S3 field, so the provider no longer sends it on the wire. Any value set here is retained in state for backwards compatibility but is otherwise ignored.",
+							DeprecationMessage:  "Use filter.prefix instead. CoreWeave AI Object Storage now rejects PutBucketLifecycleConfiguration requests that include this deprecated S3 field, so the provider no longer sends it on the wire. Any value set here is retained in state for backwards compatibility (the rule's id is used to match a rule to its preserved value across refreshes; rules without an id rely on positional alignment) but is otherwise ignored.",
 						},
 						"status": schema.StringAttribute{
 							Required:            true,
@@ -465,13 +465,12 @@ func hasNilPointer[T any](pointers ...*T) bool {
 	return false
 }
 
-// eqLifecycleRule compares two LifecycleRule objects for exact equality.
+// eqLifecycleRule compares two LifecycleRule objects for exact equality. The
+// deprecated top-level Prefix field is intentionally not compared — the
+// provider never sets it on the wire, so both sides are always empty.
 func eqLifecycleRule(a, b s3types.LifecycleRule) bool { //nolint:gocyclo
 	// Compare simple scalar fields via aws.ToString / string conversion
 	if aws.ToString(a.ID) != aws.ToString(b.ID) {
-		return false
-	}
-	if aws.ToString(a.Prefix) != aws.ToString(b.Prefix) { //nolint:staticcheck
 		return false
 	}
 	if string(a.Status) != string(b.Status) {
@@ -647,9 +646,14 @@ func (r *BucketLifecycleResource) Create(ctx context.Context, req resource.Creat
 // flattenLifecycleRules turns AWS SDK LifecycleRule objects into our Terraform
 // model. The preserve argument is the prior model (plan or state) before the
 // API round-trip; it carries client-side-only fields that the API does not
-// echo back — currently just the deprecated rule.prefix. Match is by rule ID;
-// rules without an ID will not have their deprecated prefix carried over, but
-// such rules wouldn't be using the deprecated field in practice.
+// echo back — currently just the deprecated rule.prefix.
+//
+// Matching is by rule ID first; for rules without an ID, we fall back to
+// positional alignment when the result and preserve lists have the same
+// length. The positional fallback only triggers when both sides are null at
+// position i (i.e. neither the prior model nor the API response identifies
+// the rule by ID), so it cannot accidentally cross-pollinate values between
+// distinguishable rules.
 func flattenLifecycleRules(in []s3types.LifecycleRule, preserve []LifecycleRuleModel) []LifecycleRuleModel {
 	preservedPrefix := make(map[string]types.String, len(preserve))
 	for _, p := range preserve {
@@ -657,18 +661,24 @@ func flattenLifecycleRules(in []s3types.LifecycleRule, preserve []LifecycleRuleM
 			preservedPrefix[p.ID.ValueString()] = p.Prefix
 		}
 	}
+	sameLength := len(in) == len(preserve)
 
 	out := make([]LifecycleRuleModel, 0, len(in))
-	for _, r := range in {
+	for i, r := range in {
 		mdl := LifecycleRuleModel{
 			ID:     types.StringPointerValue(r.ID),
 			Prefix: types.StringNull(),
 			Status: types.StringValue(string(r.Status)),
 		}
-		if r.ID != nil {
+		if r.ID != nil && *r.ID != "" {
 			if pref, ok := preservedPrefix[*r.ID]; ok {
 				mdl.Prefix = pref
 			}
+		} else if sameLength && (preserve[i].ID.IsNull() || preserve[i].ID.IsUnknown()) {
+			// Both sides have no ID at this position — positional alignment is
+			// the only signal we have, and it's safe because there's no other
+			// rule the preserved value could refer to.
+			mdl.Prefix = preserve[i].Prefix
 		}
 
 		if r.Expiration != nil {
@@ -734,7 +744,7 @@ func flattenLifecycleRules(in []s3types.LifecycleRule, preserve []LifecycleRuleM
 			f.ObjectSizeLessThan = types.Int64PointerValue(r.Filter.ObjectSizeLessThan)
 			if r.Filter.And != nil {
 				and := AndFilterModel{
-					Prefix:                types.StringValue(aws.ToString(r.Filter.And.Prefix)),
+					Prefix:                types.StringPointerValue(r.Filter.And.Prefix),
 					ObjectSizeGreaterThan: types.Int64PointerValue(r.Filter.And.ObjectSizeGreaterThan),
 					ObjectSizeLessThan:    types.Int64PointerValue(r.Filter.And.ObjectSizeLessThan),
 				}

--- a/coreweave/object_storage/resource_bucket_lifecycle_configuration_test.go
+++ b/coreweave/object_storage/resource_bucket_lifecycle_configuration_test.go
@@ -434,19 +434,24 @@ func TestBucketLifecycleConfiguration_MultiRule(t *testing.T) {
 		Zone: types.StringValue("US-EAST-04A"),
 	}
 
-	// two simple rules
+	// two simple rules — use filter.prefix instead of the deprecated top-level
+	// prefix, which CAIOS now rejects at request time.
 	r1 := objectstorage.LifecycleRuleModel{
 		ID:     types.StringValue("r1"),
-		Prefix: types.StringValue("metrics/"),
 		Status: types.StringValue("Enabled"),
+		Filter: &objectstorage.FilterModel{
+			Prefix: types.StringValue("metrics/"),
+		},
 		Expiration: &objectstorage.ExpirationModel{
 			Days: types.Int32Value(10),
 		},
 	}
 	r2 := objectstorage.LifecycleRuleModel{
 		ID:     types.StringValue("r2"),
-		Prefix: types.StringValue("logs/"),
 		Status: types.StringValue("Enabled"),
+		Filter: &objectstorage.FilterModel{
+			Prefix: types.StringValue("logs/"),
+		},
 		AbortIncompleteMultipart: &objectstorage.AbortIncompleteMultipartModel{
 			DaysAfterInitiation: types.Int32Value(5),
 		},

--- a/coreweave/object_storage/resource_bucket_lifecycle_configuration_unit_test.go
+++ b/coreweave/object_storage/resource_bucket_lifecycle_configuration_unit_test.go
@@ -1,0 +1,55 @@
+package objectstorage
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFlattenLifecycleRulesPreservesDeprecatedPrefixForMissingIDs(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		apiID      *string
+		priorID    types.String
+		wantPrefix string
+	}{
+		"nil ID": {
+			apiID:      nil,
+			priorID:    types.StringNull(),
+			wantPrefix: "logs/",
+		},
+		"empty ID": {
+			apiID:      aws.String(""),
+			priorID:    types.StringValue(""),
+			wantPrefix: "metrics/",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := flattenLifecycleRules(
+				[]s3types.LifecycleRule{
+					{
+						ID:     tc.apiID,
+						Status: s3types.ExpirationStatusEnabled,
+					},
+				},
+				[]LifecycleRuleModel{
+					{
+						ID:     tc.priorID,
+						Prefix: types.StringValue(tc.wantPrefix),
+					},
+				},
+			)
+
+			require.Len(t, got, 1)
+			require.Equal(t, tc.wantPrefix, got[0].Prefix.ValueString())
+		})
+	}
+}

--- a/coreweave/object_storage/sweeper_test.go
+++ b/coreweave/object_storage/sweeper_test.go
@@ -1,0 +1,209 @@
+package objectstorage_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"strings"
+	"testing"
+	"time"
+
+	cwobjectv1 "buf.build/gen/go/coreweave/cwobject/protocolbuffers/go/cwobject/v1"
+	"connectrpc.com/connect"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/aws/smithy-go"
+	"github.com/coreweave/terraform-provider-coreweave/coreweave"
+	objectstorage "github.com/coreweave/terraform-provider-coreweave/coreweave/object_storage"
+	"github.com/coreweave/terraform-provider-coreweave/internal/provider"
+	"github.com/coreweave/terraform-provider-coreweave/internal/testutil"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestMain(m *testing.M) {
+	resource.TestMain(m)
+}
+
+func init() {
+	resource.AddTestSweepers("coreweave_object_storage_bucket", &resource.Sweeper{
+		Name:         "coreweave_object_storage_bucket",
+		Dependencies: []string{},
+		F: func(zone string) error {
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
+			defer cancel()
+
+			testutil.SetEnvDefaults()
+			client, err := provider.BuildClient(ctx, provider.CoreweaveProviderModel{}, "", "")
+			if err != nil {
+				return fmt.Errorf("failed to build client: %w", err)
+			}
+
+			listResp, err := client.ListBucketInfo(ctx, connect.NewRequest(&cwobjectv1.ListBucketInfoRequest{}))
+			if err != nil {
+				return fmt.Errorf("failed to list buckets: %w", err)
+			}
+
+			for _, info := range listResp.Msg.GetInfo() {
+				name := info.GetName()
+				location := info.GetLocation()
+
+				if !strings.HasPrefix(name, AcceptanceTestPrefix) {
+					log.Printf("skipping bucket %s because it does not have prefix %s", name, AcceptanceTestPrefix)
+					continue
+				}
+				if location != zone {
+					log.Printf("skipping bucket %s in zone %s because it does not match sweep zone %s", name, location, zone)
+					continue
+				}
+
+				log.Printf("sweeping bucket %s (zone %s)", name, location)
+				if testutil.SweepDryRun() {
+					log.Printf("skipping bucket %s because of dry-run mode", name)
+					continue
+				}
+
+				if err := deleteBucket(ctx, client, name, location); err != nil {
+					return fmt.Errorf("failed to delete bucket %s: %w", name, err)
+				}
+			}
+
+			return nil
+		},
+	})
+
+	// Organization access policies are org-scoped (not zone-scoped). Sweep them
+	// unconditionally on any zone sweep — the prefix filter keeps the blast
+	// radius limited to acceptance-test artifacts.
+	resource.AddTestSweepers("coreweave_object_storage_organization_access_policy", &resource.Sweeper{
+		Name:         "coreweave_object_storage_organization_access_policy",
+		Dependencies: []string{},
+		F: func(_ string) error {
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+			defer cancel()
+
+			testutil.SetEnvDefaults()
+			client, err := provider.BuildClient(ctx, provider.CoreweaveProviderModel{}, "", "")
+			if err != nil {
+				return fmt.Errorf("failed to build client: %w", err)
+			}
+
+			listResp, err := client.ListAccessPolicies(ctx, connect.NewRequest(&cwobjectv1.ListAccessPoliciesRequest{}))
+			if err != nil {
+				return fmt.Errorf("failed to list org access policies: %w", err)
+			}
+
+			for _, policy := range listResp.Msg.GetPolicies() {
+				name := policy.GetName()
+				if !strings.HasPrefix(name, AcceptanceTestPrefix) {
+					log.Printf("skipping org access policy %s because it does not have prefix %s", name, AcceptanceTestPrefix)
+					continue
+				}
+
+				log.Printf("sweeping org access policy %s", name)
+				if testutil.SweepDryRun() {
+					log.Printf("skipping org access policy %s because of dry-run mode", name)
+					continue
+				}
+
+				_, err := client.DeleteAccessPolicy(ctx, connect.NewRequest(&cwobjectv1.DeleteAccessPolicyRequest{Name: name}))
+				if err != nil {
+					if coreweave.IsNotFoundError(err) {
+						log.Printf("org access policy %s already deleted", name)
+						continue
+					}
+					return fmt.Errorf("failed to delete org access policy %s: %w", name, err)
+				}
+			}
+
+			return nil
+		},
+	})
+}
+
+// deleteBucket empties a bucket (all object versions, delete markers, and
+// in-flight multipart uploads) and then deletes the bucket itself. Test buckets
+// generally don't contain objects, but versioning can leave delete markers
+// behind, and a botched test can leave the bucket in a state where DeleteBucket
+// returns BucketNotEmpty.
+func deleteBucket(ctx context.Context, client *coreweave.Client, name, zone string) error {
+	s3c, err := client.S3Client(ctx, zone)
+	if err != nil {
+		return fmt.Errorf("failed to create S3 client for zone %s: %w", zone, err)
+	}
+
+	if err := emptyBucket(ctx, s3c, name); err != nil {
+		return fmt.Errorf("failed to empty bucket %s: %w", name, err)
+	}
+
+	if _, err := s3c.DeleteBucket(ctx, &s3.DeleteBucketInput{Bucket: aws.String(name)}); err != nil {
+		var apiErr smithy.APIError
+		if errors.As(err, &apiErr) && apiErr.ErrorCode() == objectstorage.ErrNoSuchBucket {
+			log.Printf("bucket %s already deleted", name)
+			return nil
+		}
+		return fmt.Errorf("DeleteBucket %s: %w", name, err)
+	}
+	return nil
+}
+
+// emptyBucket removes all object versions, delete markers, and in-flight
+// multipart uploads from a bucket. Buckets with versioning enabled need this
+// before DeleteBucket will succeed.
+func emptyBucket(ctx context.Context, s3c *s3.Client, name string) error {
+	// Object versions and delete markers
+	versionsPaginator := s3.NewListObjectVersionsPaginator(s3c, &s3.ListObjectVersionsInput{Bucket: aws.String(name)})
+	for versionsPaginator.HasMorePages() {
+		page, err := versionsPaginator.NextPage(ctx)
+		if err != nil {
+			var apiErr smithy.APIError
+			if errors.As(err, &apiErr) && apiErr.ErrorCode() == objectstorage.ErrNoSuchBucket {
+				return nil
+			}
+			return fmt.Errorf("ListObjectVersions: %w", err)
+		}
+
+		ids := make([]s3types.ObjectIdentifier, 0, len(page.Versions)+len(page.DeleteMarkers))
+		for _, v := range page.Versions {
+			ids = append(ids, s3types.ObjectIdentifier{Key: v.Key, VersionId: v.VersionId})
+		}
+		for _, m := range page.DeleteMarkers {
+			ids = append(ids, s3types.ObjectIdentifier{Key: m.Key, VersionId: m.VersionId})
+		}
+		if len(ids) == 0 {
+			continue
+		}
+
+		if _, err := s3c.DeleteObjects(ctx, &s3.DeleteObjectsInput{
+			Bucket: aws.String(name),
+			Delete: &s3types.Delete{Objects: ids, Quiet: aws.Bool(true)},
+		}); err != nil {
+			return fmt.Errorf("DeleteObjects: %w", err)
+		}
+	}
+
+	// In-flight multipart uploads
+	uploadsPaginator := s3.NewListMultipartUploadsPaginator(s3c, &s3.ListMultipartUploadsInput{Bucket: aws.String(name)})
+	for uploadsPaginator.HasMorePages() {
+		page, err := uploadsPaginator.NextPage(ctx)
+		if err != nil {
+			var apiErr smithy.APIError
+			if errors.As(err, &apiErr) && apiErr.ErrorCode() == objectstorage.ErrNoSuchBucket {
+				return nil
+			}
+			return fmt.Errorf("ListMultipartUploads: %w", err)
+		}
+		for _, u := range page.Uploads {
+			if _, err := s3c.AbortMultipartUpload(ctx, &s3.AbortMultipartUploadInput{
+				Bucket:   aws.String(name),
+				Key:      u.Key,
+				UploadId: u.UploadId,
+			}); err != nil {
+				return fmt.Errorf("AbortMultipartUpload %s: %w", aws.ToString(u.Key), err)
+			}
+		}
+	}
+
+	return nil
+}

--- a/docs/resources/object_storage_bucket_lifecycle_configuration.md
+++ b/docs/resources/object_storage_bucket_lifecycle_configuration.md
@@ -61,8 +61,11 @@ resource "coreweave_object_storage_bucket_lifecycle_configuration" "default" {
   # Rule 2: Abort abandoned multipart uploads and expire traces after a fixed date
   rule {
     id     = "expire-traces"
-    prefix = "traces/"
     status = "Enabled"
+
+    filter {
+      prefix = "traces/"
+    }
 
     abort_incomplete_multipart_upload {
       days_after_initiation = 5

--- a/docs/resources/object_storage_bucket_lifecycle_configuration.md
+++ b/docs/resources/object_storage_bucket_lifecycle_configuration.md
@@ -101,7 +101,7 @@ Optional:
 - `id` (String) Unique identifier for the rule
 - `noncurrent_version_expiration` (Block, Optional) (see [below for nested schema](#nestedblock--rule--noncurrent_version_expiration))
 - `noncurrent_version_transition` (Block Set) (see [below for nested schema](#nestedblock--rule--noncurrent_version_transition))
-- `prefix` (String) Object key prefix to which the rule applies
+- `prefix` (String, Deprecated) Deprecated. Object key prefix to which the rule applies. CoreWeave AI Object Storage rejects requests that set this field; use `filter.prefix` instead.
 - `transition` (Block Set) (see [below for nested schema](#nestedblock--rule--transition))
 
 <a id="nestedblock--rule--abort_incomplete_multipart_upload"></a>

--- a/examples/resources/coreweave_object_storage_bucket_lifecycle_configuration/resource.tf
+++ b/examples/resources/coreweave_object_storage_bucket_lifecycle_configuration/resource.tf
@@ -46,8 +46,11 @@ resource "coreweave_object_storage_bucket_lifecycle_configuration" "default" {
   # Rule 2: Abort abandoned multipart uploads and expire traces after a fixed date
   rule {
     id     = "expire-traces"
-    prefix = "traces/"
     status = "Enabled"
+
+    filter {
+      prefix = "traces/"
+    }
 
     abort_incomplete_multipart_upload {
       days_after_initiation = 5


### PR DESCRIPTION
## Summary

Two changes to unblock CI on PR #279 (and any other branch that activates the `object_storage` acceptance suite):

1. **Add an acceptance test sweeper for `object_storage`** — registers two sweepers (buckets, org access policies), both guarded by the `tf-acc-objs-` prefix. CKS, networking, and inference all have this; object_storage had none, so leaked test buckets accumulated across runs and eventually collided with new tests' `tf-acc-objs-bucket-settings-13` name (the actual cause of the `TestBucketSettingsResource` "Already Exists" failures on recent runs).
2. **Deprecate `rule.prefix` on `coreweave_object_storage_bucket_lifecycle_configuration`** — CAIOS now rejects `PutBucketLifecycleConfiguration` requests that set the deprecated top-level S3 `Prefix` field (it was a silent no-op before, which could cause data loss when users assumed it scoped a lifecycle rule).

## Why these together

The PR #279 (inference) CI hit two distinct failures in `run-tests (object_storage) / test`, both unrelated to the inference work it adds:

- `TestBucketLifecycleConfiguration_MultiRule` failed because its fixtures set the deprecated `Prefix` field — fixed here.
- `TestBucketSettingsResource` failed because of a stranded bucket from an earlier run — the sweeper added here cleans that up before every CI acceptance run.

The matrix's `fail-fast: true` then cancelled the `inference`, `cks`, and `networking` jobs every time, so PR #279 never got a clean look. Landing this PR unblocks that.

## What's in each commit

- `97fcb4b` — `test(object_storage): add acceptance test sweeper` — new `coreweave/object_storage/sweeper_test.go` plus `.env` in `.gitignore`.
- `2f931a3` — `fix(object_storage): deprecate lifecycle rule.prefix; stop sending it` — schema `DeprecationMessage`, drop the field from `expandRules`, change `flattenLifecycleRules` to preserve client-side-only fields from the prior model so existing `prefix = "..."` configs don't churn, regenerate docs.
- `f912eb3` — `test(object_storage): move multi-rule fixtures to filter.prefix` — migrate the two test fixtures that were the last in-tree consumers of the deprecated field.

## Test plan

- [x] `make` (fmt + lint + install + generate) clean
- [x] `make test` passes
- [x] Local sweep against test org.
- [ ] CI acceptance for `object_storage` passes on this PR (verifies the sweeper inside the same matrix CI uses for downstream PRs)

## Backwards compatibility

- `rule.prefix` is *not* removed from the schema. Existing HCL keeps parsing, just emits a deprecation warning. State is preserved via the new `flattenLifecycleRules` preserve-by-ID logic, so users with the field set won't see phantom diffs on the next refresh.
- Users with `rule.prefix = "..."` and no `filter` block effectively had a no-op rule (CAIOS ignored the field). Behavior here is unchanged: we don't send anything, so the rule still applies to the whole bucket — same as it always did silently.