### PR TITLE
feat(inference): accept full semver versions for deployment runtime

### DIFF
--- a/coreweave/inference/export_test.go
+++ b/coreweave/inference/export_test.go
@@ -2,10 +2,13 @@ package inference
 
 // exported for testing
 
-var (
-	// Validation
-	SemverPattern = semverPattern
+// SemverMatches reports whether v satisfies the deployment runtime version
+// validator. Exposed as a function (rather than the mutable *regexp.Regexp) so
+// external-package tests can exercise the pattern without being able to
+// reassign it.
+func SemverMatches(v string) bool { return semverPattern.MatchString(v) }
 
+var (
 	// Deployment
 	SetFromDeployment = setFromDeployment
 	ToCreateRequest   = toCreateRequest

--- a/coreweave/inference/export_test.go
+++ b/coreweave/inference/export_test.go
@@ -3,6 +3,9 @@ package inference
 // exported for testing
 
 var (
+	// Validation
+	SemverPattern = semverPattern
+
 	// Deployment
 	SetFromDeployment = setFromDeployment
 	ToCreateRequest   = toCreateRequest

--- a/coreweave/inference/resource_inference_deployment.go
+++ b/coreweave/inference/resource_inference_deployment.go
@@ -30,12 +30,34 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 )
 
+const (
+	semverNumericIdentifier = `(0|[1-9][0-9]*)`
+
+	// A pre-release identifier is either:
+	//   - a numeric identifier with no leading zeroes, or
+	//   - an alphanumeric/hyphen identifier containing at least one non-digit
+	semverPrereleaseIdentifier = `(0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*)`
+
+	// Build metadata identifiers may be numeric and may have leading zeroes.
+	semverBuildIdentifier = `[0-9a-zA-Z-]+`
+)
+
 var (
 	_ resource.Resource                = &InferenceDeploymentResource{}
 	_ resource.ResourceWithImportState = &InferenceDeploymentResource{}
 
 	hostnamePattern = regexp.MustCompile(`^[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?$`)
-	semverPattern   = regexp.MustCompile(`^[0-9]+\.[0-9]+\.[0-9]+$`)
+	semverPattern   = regexp.MustCompile(
+		`^` +
+			semverNumericIdentifier + `\.` +
+			semverNumericIdentifier + `\.` +
+			semverNumericIdentifier +
+			`(?:-` + semverPrereleaseIdentifier +
+			`(?:\.` + semverPrereleaseIdentifier + `)*)?` +
+			`(?:\+` + semverBuildIdentifier +
+			`(?:\.` + semverBuildIdentifier + `)*)?` +
+			`$`,
+	)
 
 	conditionAttrTypes = map[string]attr.Type{
 		"type":             types.StringType,

--- a/coreweave/inference/resource_inference_deployment.go
+++ b/coreweave/inference/resource_inference_deployment.go
@@ -31,12 +31,14 @@ import (
 )
 
 const (
-	semverNumericIdentifier = `(0|[1-9][0-9]*)`
+	// Non-capturing groups throughout: the pattern is only used with
+	// MatchString, so captures would be needless bookkeeping.
+	semverNumericIdentifier = `(?:0|[1-9][0-9]*)`
 
 	// A pre-release identifier is either:
 	//   - a numeric identifier with no leading zeroes, or
 	//   - an alphanumeric/hyphen identifier containing at least one non-digit
-	semverPrereleaseIdentifier = `(0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*)`
+	semverPrereleaseIdentifier = `(?:0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*)`
 
 	// Build metadata identifiers may be numeric and may have leading zeroes.
 	semverBuildIdentifier = `[0-9a-zA-Z-]+`

--- a/coreweave/inference/resource_inference_deployment_test.go
+++ b/coreweave/inference/resource_inference_deployment_test.go
@@ -60,6 +60,47 @@ func TestInferenceDeployment_Schema(t *testing.T) {
 	}
 }
 
+func TestInferenceDeployment_SemverPattern(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		version string
+		want    bool
+	}{
+		// Plain core versions.
+		{"1.2.3", true},
+		{"0.0.0", true},
+		{"10.20.30", true},
+		// Pre-release identifiers.
+		{"1.0.0-rc.1", true},
+		{"1.0.0-alpha", true},
+		{"1.0.0-0.3.7", true},
+		// Build metadata, including CoreWeave-flavored builds.
+		{"0.22.0+crwv.2", true},
+		{"1.2.3+build.123", true},
+		{"1.0.0-rc.1+crwv.2", true},
+		// Invalid: missing components, leading zeroes, empty identifiers.
+		{"", false},
+		{"1.2", false},
+		{"1", false},
+		{"v1.2.3", false},
+		{"01.2.3", false},
+		{"1.2.3-", false},
+		{"1.2.3+", false},
+		{"1.2.3 ", false},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.version, func(t *testing.T) {
+			t.Parallel()
+			if got := inference.SemverPattern.MatchString(tc.version); got != tc.want {
+				t.Errorf("SemverPattern.MatchString(%q) = %v, want %v", tc.version, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestInferenceDeployment_SetFromDeployment_NullPreservation(t *testing.T) {
 	t.Parallel()
 

--- a/coreweave/inference/resource_inference_deployment_test.go
+++ b/coreweave/inference/resource_inference_deployment_test.go
@@ -91,11 +91,10 @@ func TestInferenceDeployment_SemverPattern(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
-		t.Run(tc.version, func(t *testing.T) {
+		t.Run(fmt.Sprintf("%q", tc.version), func(t *testing.T) {
 			t.Parallel()
-			if got := inference.SemverPattern.MatchString(tc.version); got != tc.want {
-				t.Errorf("SemverPattern.MatchString(%q) = %v, want %v", tc.version, got, tc.want)
+			if got := inference.SemverMatches(tc.version); got != tc.want {
+				t.Errorf("SemverMatches(%q) = %v, want %v", tc.version, got, tc.want)
 			}
 		})
 	}


### PR DESCRIPTION
Expand the deployment runtime version validator beyond plain major.minor.patch to the full semver grammar, including optional pre-release and build metadata identifiers. This permits CoreWeave engine builds such as 0.22.0+crwv.2 and 1.0.0-rc.1+crwv.2, which is how we handle incremental internal rebuilds against the same upstream base patch version.

Export semverPattern for testing and add a table-driven unit test covering valid full-semver strings (including build metadata) and rejecting malformed inputs (missing components, leading zeroes, empty identifiers).