### PR TITLE
docs(cks_cluster): use host_prefixes in example to drop deprecation warning

### DIFF
--- a/docs/resources/cks_cluster.md
+++ b/docs/resources/cks_cluster.md
@@ -14,9 +14,17 @@ Create and manage clusters on [CoreWeave Kubernetes Service (CKS)](https://docs.
 
 ```terraform
 resource "coreweave_networking_vpc" "default" {
-  name        = "default"
-  zone        = "US-EAST-04A"
-  host_prefix = "10.16.192.0/18"
+  name = "default"
+  zone = "US-EAST-04A"
+
+  host_prefixes = [
+    {
+      name     = "primary"
+      type     = "PRIMARY"
+      prefixes = ["10.16.192.0/18"]
+    },
+  ]
+
   vpc_prefixes = [
     {
       name  = "pod cidr"

--- a/examples/resources/coreweave_cks_cluster/resource.tf
+++ b/examples/resources/coreweave_cks_cluster/resource.tf
@@ -1,7 +1,15 @@
 resource "coreweave_networking_vpc" "default" {
-  name        = "default"
-  zone        = "US-EAST-04A"
-  host_prefix = "10.16.192.0/18"
+  name = "default"
+  zone = "US-EAST-04A"
+
+  host_prefixes = [
+    {
+      name     = "primary"
+      type     = "PRIMARY"
+      prefixes = ["10.16.192.0/18"]
+    },
+  ]
+
   vpc_prefixes = [
     {
       name  = "pod cidr"


### PR DESCRIPTION
## Summary

- Replaces the deprecated single-value `host_prefix` attribute in the `coreweave_networking_vpc "default"` block of the `coreweave_cks_cluster` example with the current `host_prefixes` list form, matching the canonical `coreweave_networking_vpc` example.
- Regenerates the provider docs (`make generate`) so `docs/resources/cks_cluster.md` reflects the updated example.

## Why

The generated Terraform reference doc `cks_cluster.mdx` triggers a deprecation warning under `terraform validate`:

> Attribute Deprecated: `host_prefix` is deprecated. Use `host_prefixes` instead. The field will be removed in a future version.

The doc is generated by terraform-plugin-docs from this provider repo, so the fix must be made upstream in the example source rather than in the docs repo (where it would be overwritten by the weekly sync).

## Changes

- `examples/resources/coreweave_cks_cluster/resource.tf` — `host_prefix` → `host_prefixes` list.
- `docs/resources/cks_cluster.md` — regenerated output.

## Test plan

- [x] `make generate` runs clean and only updates the regenerated `cks_cluster.md`.
- [x] `terraform validate` against the cks_cluster example reports a valid configuration with no `host_prefix` deprecation warning.
- [ ] After merge + weekly sync (or manual `workflow_dispatch` of `terraform-public-docs-cron.yaml`), confirm `public-docs/platform/terraform/resources/cks_cluster.mdx` no longer contains `host_prefix`.

Fixes [DOCS-2749](https://coreweave.atlassian.net/browse/DOCS-2749)

Made with [Cursor](https://cursor.com)

[DOCS-2749]: https://coreweave.atlassian.net/browse/DOCS-2749?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ