### PR TITLE
ci(inference): add Renovate scope and auto-trigger acceptance tests

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -79,6 +79,13 @@
       "semanticCommitScope": "object_storage"
     },
     {
+      "matchPackageNames": ["buf.build/gen/go/coreweave/inference/**"],
+      "groupName": "buf.build/coreweave/inference",
+      "semanticCommitType": "deps",
+      "semanticCommitScope": "inference",
+      "addLabels": ["acceptance-test:inference"]
+    },
+    {
       "matchPackageNames": [
         "github.com/hashicorp/terraform-plugin-framework",
         "github.com/hashicorp/terraform-plugin-framework-validators",

--- a/.github/workflows/acceptance-test.yaml
+++ b/.github/workflows/acceptance-test.yaml
@@ -21,7 +21,7 @@ jobs:
     env:
       COREWEAVE_API_ENDPOINT: ${{ inputs.suite == 'object_storage' && secrets.COREWEAVE_OBJS_API_ENDPOINT || vars.COREWEAVE_API_ENDPOINT }}
       COREWEAVE_API_TOKEN: ${{ inputs.suite == 'object_storage' && secrets.COREWEAVE_OBJS_API_TOKEN || secrets.COREWEAVE_API_TOKEN }}
-      TEST_ACC_SWEEP_ZONE: ${{ inputs.suite == 'object_storage' && 'US-EAST-04A' || 'US-LAB-01A' }}
+      TEST_ACC_SWEEP_ZONE: ${{ inputs.suite == 'object_storage' && 'US-EAST-04A' || inputs.suite == 'inference' && 'RNO2A' || 'US-LAB-01A' }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - uses: ./.github/actions/setup


### PR DESCRIPTION
Renovate bumps to inference proto packages (`buf.build/gen/go/coreweave/inference/**`) were missing two things that CKS, networking, and object_storage already have:

1. **Renovate scope** — no `packageRules` entry existed, so commits came out as bare `deps:` instead of `deps(inference):` and packages weren't grouped.
2. **Acceptance test auto-trigger** — Renovate PRs only touch `go.mod`/`go.sum`, so file-path detection in `acceptance-tests.yaml` never fires. The fix is `addLabels: ["acceptance-test:inference"]` in the Renovate rule; the workflow's label-based opt-in then picks it up automatically.

Also fixes a sweep zone mismatch: the `sweep` job was falling through to `US-LAB-01A` for inference while the `test` job already had the `RNO2A` special case.