### PR TITLE
tests(inference): Fix test configurations

### DIFF
--- a/coreweave/inference/resource_inference_deployment_test.go
+++ b/coreweave/inference/resource_inference_deployment_test.go
@@ -315,6 +315,10 @@ locals {
   preferred_instance  = %q
   available_instances = data.coreweave_inference_deployment_parameters.deploy_params.instance_types
   instance            = local.preferred_instance != "" ? local.preferred_instance : sort(tolist(local.available_instances))[0]
+
+  # Runtime version is required on create; source it from deployment parameters.
+  available_runtime_versions = try(data.coreweave_inference_deployment_parameters.deploy_params.runtime_versions["vllm"].versions, [])
+  runtime_version            = length(local.available_runtime_versions) > 0 ? local.available_runtime_versions[0] : ""
 }
 
 resource "coreweave_inference_gateway" "test" {
@@ -344,7 +348,8 @@ resource "coreweave_inference_deployment" "test" {
   gateway_ids = [coreweave_inference_gateway.test.id]
 
   runtime = {
-    engine = "vllm"
+    engine  = "vllm"
+    version = local.runtime_version
   }
 
   resources = {
@@ -369,6 +374,10 @@ resource "coreweave_inference_deployment" "test" {
     precondition {
       condition     = local.preferred_instance == "" || contains(local.available_instances, local.preferred_instance)
       error_message = "INFR_INSTANCE_ID=\"${local.preferred_instance}\" is not present in inference parameters; available: ${jsonencode(local.available_instances)}"
+    }
+    precondition {
+      condition     = local.runtime_version != ""
+      error_message = "No vllm runtime version available; available: ${jsonencode(local.available_runtime_versions)}"
     }
   }
 }
@@ -400,6 +409,10 @@ locals {
   preferred_instance  = %q
   available_instances = data.coreweave_inference_deployment_parameters.deploy_params.instance_types
   instance            = local.preferred_instance != "" ? local.preferred_instance : sort(tolist(local.available_instances))[0]
+
+  # Runtime version is required on create; source it from deployment parameters.
+  available_runtime_versions = try(data.coreweave_inference_deployment_parameters.deploy_params.runtime_versions["vllm"].versions, [])
+  runtime_version            = length(local.available_runtime_versions) > 0 ? local.available_runtime_versions[0] : ""
 }
 
 resource "coreweave_inference_gateway" "test" {
@@ -430,7 +443,8 @@ resource "coreweave_inference_deployment" "test" {
   disabled    = true
 
   runtime = {
-    engine = "vllm"
+    engine  = "vllm"
+    version = local.runtime_version
   }
 
   resources = {
@@ -457,6 +471,10 @@ resource "coreweave_inference_deployment" "test" {
     precondition {
       condition     = local.preferred_instance == "" || contains(local.available_instances, local.preferred_instance)
       error_message = "INFR_INSTANCE_ID=\"${local.preferred_instance}\" is not present in inference parameters; available: ${jsonencode(local.available_instances)}"
+    }
+    precondition {
+      condition     = local.runtime_version != ""
+      error_message = "No vllm runtime version available; available: ${jsonencode(local.available_runtime_versions)}"
     }
   }
 }

--- a/coreweave/inference/resource_inference_deployment_test.go
+++ b/coreweave/inference/resource_inference_deployment_test.go
@@ -317,8 +317,10 @@ locals {
   instance            = local.preferred_instance != "" ? local.preferred_instance : sort(tolist(local.available_instances))[0]
 
   # Runtime version is required on create; source it from deployment parameters.
+  # Restrict to plain MAJOR.MINOR.PATCH for now — pre-release/build-metadata
+  # versions are excluded pending #319. Revert this commit once #319 lands.
   available_runtime_versions = try(data.coreweave_inference_deployment_parameters.deploy_params.runtime_versions["vllm"].versions, [])
-  runtime_version            = length(local.available_runtime_versions) > 0 ? local.available_runtime_versions[0] : ""
+  runtime_version            = try([for v in local.available_runtime_versions : v if can(regex("^[0-9]+[.][0-9]+[.][0-9]+$", v))][0], "")
 }
 
 resource "coreweave_inference_gateway" "test" {
@@ -377,7 +379,7 @@ resource "coreweave_inference_deployment" "test" {
     }
     precondition {
       condition     = local.runtime_version != ""
-      error_message = "No vllm runtime version available; available: ${jsonencode(local.available_runtime_versions)}"
+      error_message = "No x.y.z vllm runtime version available (pre-release/build-metadata excluded pending #319); available: ${jsonencode(local.available_runtime_versions)}"
     }
   }
 }
@@ -411,8 +413,10 @@ locals {
   instance            = local.preferred_instance != "" ? local.preferred_instance : sort(tolist(local.available_instances))[0]
 
   # Runtime version is required on create; source it from deployment parameters.
+  # Restrict to plain MAJOR.MINOR.PATCH for now — pre-release/build-metadata
+  # versions are excluded pending #319. Revert this commit once #319 lands.
   available_runtime_versions = try(data.coreweave_inference_deployment_parameters.deploy_params.runtime_versions["vllm"].versions, [])
-  runtime_version            = length(local.available_runtime_versions) > 0 ? local.available_runtime_versions[0] : ""
+  runtime_version            = try([for v in local.available_runtime_versions : v if can(regex("^[0-9]+[.][0-9]+[.][0-9]+$", v))][0], "")
 }
 
 resource "coreweave_inference_gateway" "test" {
@@ -474,7 +478,7 @@ resource "coreweave_inference_deployment" "test" {
     }
     precondition {
       condition     = local.runtime_version != ""
-      error_message = "No vllm runtime version available; available: ${jsonencode(local.available_runtime_versions)}"
+      error_message = "No x.y.z vllm runtime version available (pre-release/build-metadata excluded pending #319); available: ${jsonencode(local.available_runtime_versions)}"
     }
   }
 }

--- a/coreweave/inference/resource_inference_integration_test.go
+++ b/coreweave/inference/resource_inference_integration_test.go
@@ -31,8 +31,10 @@ locals {
   instance            = local.preferred_instance != "" ? local.preferred_instance : sort(tolist(local.available_instances))[0]
 
   # Runtime version is required on create; source it from deployment parameters.
+  # Restrict to plain MAJOR.MINOR.PATCH for now — pre-release/build-metadata
+  # versions are excluded pending #319. Revert this commit once #319 lands.
   available_runtime_versions = try(data.coreweave_inference_deployment_parameters.deploy_params.runtime_versions["vllm"].versions, [])
-  runtime_version            = length(local.available_runtime_versions) > 0 ? local.available_runtime_versions[0] : ""
+  runtime_version            = try([for v in local.available_runtime_versions : v if can(regex("^[0-9]+[.][0-9]+[.][0-9]+$", v))][0], "")
 }
 
 resource "coreweave_inference_capacity_claim" "test" {
@@ -106,7 +108,7 @@ resource "coreweave_inference_deployment" "test" {
   lifecycle {
     precondition {
       condition     = local.runtime_version != ""
-      error_message = "No vllm runtime version available; available: ${jsonencode(local.available_runtime_versions)}"
+      error_message = "No x.y.z vllm runtime version available (pre-release/build-metadata excluded pending #319); available: ${jsonencode(local.available_runtime_versions)}"
     }
   }
 

--- a/coreweave/inference/resource_inference_integration_test.go
+++ b/coreweave/inference/resource_inference_integration_test.go
@@ -43,7 +43,7 @@ resource "coreweave_inference_capacity_claim" "test" {
   resources = {
     instance_type  = local.instance
     instance_count = 1
-    capacity_type  = "CAPACITY_TYPE_SERVERLESS"
+    capacity_type  = "CAPACITY_TYPE_CUSTOMER"
     zones          = [local.zone]
   }
 
@@ -148,7 +148,7 @@ func TestInferenceReservedCapacity(t *testing.T) {
 						statecheck.ExpectKnownValue(ccResource, tfjsonpath.New("id"), knownvalue.NotNull()),
 						statecheck.ExpectKnownValue(ccResource, tfjsonpath.New("status"), knownvalue.NotNull()),
 						statecheck.ExpectKnownValue(ccResource, tfjsonpath.New("allocated_instances"), knownvalue.NotNull()),
-						statecheck.ExpectKnownValue(ccResource, tfjsonpath.New("resources").AtMapKey("capacity_type"), knownvalue.StringExact("CAPACITY_TYPE_SERVERLESS")),
+						statecheck.ExpectKnownValue(ccResource, tfjsonpath.New("resources").AtMapKey("capacity_type"), knownvalue.StringExact("CAPACITY_TYPE_CUSTOMER")),
 						statecheck.ExpectKnownValue(gwResource, tfjsonpath.New("id"), knownvalue.NotNull()),
 						statecheck.ExpectKnownValue(depResource, tfjsonpath.New("status"), knownvalue.StringExact("STATUS_READY")),
 						statecheck.ExpectKnownValue(depResource, tfjsonpath.New("autoscaling").AtMapKey("capacity_classes"), knownvalue.ListExact([]knownvalue.Check{knownvalue.StringExact("CAPACITY_CLASS_RESERVED")})),

--- a/coreweave/inference/resource_inference_integration_test.go
+++ b/coreweave/inference/resource_inference_integration_test.go
@@ -29,6 +29,10 @@ locals {
   preferred_instance  = %q
   available_instances = local.zones_map[local.zone].instance_types
   instance            = local.preferred_instance != "" ? local.preferred_instance : sort(tolist(local.available_instances))[0]
+
+  # Runtime version is required on create; source it from deployment parameters.
+  available_runtime_versions = try(data.coreweave_inference_deployment_parameters.deploy_params.runtime_versions["vllm"].versions, [])
+  runtime_version            = length(local.available_runtime_versions) > 0 ? local.available_runtime_versions[0] : ""
 }
 
 resource "coreweave_inference_capacity_claim" "test" {
@@ -68,12 +72,17 @@ resource "coreweave_inference_gateway" "test" {
   }
 }
 
+data "coreweave_inference_deployment_parameters" "deploy_params" {
+  depends_on = [coreweave_inference_gateway.test]
+}
+
 resource "coreweave_inference_deployment" "test" {
   name        = "%s-deploy"
   gateway_ids = [coreweave_inference_gateway.test.id]
 
   runtime = {
-    engine = "vllm"
+    engine  = "vllm"
+    version = local.runtime_version
   }
 
   resources = {
@@ -92,6 +101,13 @@ resource "coreweave_inference_deployment" "test" {
     max              = 1
     priority         = 100
     capacity_classes = ["CAPACITY_CLASS_RESERVED"]
+  }
+
+  lifecycle {
+    precondition {
+      condition     = local.runtime_version != ""
+      error_message = "No vllm runtime version available; available: ${jsonencode(local.available_runtime_versions)}"
+    }
   }
 
   depends_on = [coreweave_inference_capacity_claim.test]


### PR DESCRIPTION
Unblocks #319 and #321

* Add required runtime_version to deployment tests
   * Includes temporary version filter until #319 lands
* Configure reserved-capacity test to use`CAPACITY_TYPE_CUSTOMER`