### PR TITLE
docs(networking_vpc): scope host_prefix /18 requirement to SUNK

### DIFF
--- a/coreweave/networking/resource_vpc.go
+++ b/coreweave/networking/resource_vpc.go
@@ -475,7 +475,7 @@ func (r *VpcResource) Schema(ctx context.Context, req resource.SchemaRequest, re
 			"host_prefix": schema.StringAttribute{
 				Optional:            true,
 				Computed:            true,
-				MarkdownDescription: "An IPv4 CIDR range used to allocate host addresses when booting compute into a VPC.\nThis CIDR must be have a mask size of /18. If left unspecified, a Zone-specific default value will be applied by the server.\nThis field is immutable once set.",
+				MarkdownDescription: "An IPv4 CIDR range used to allocate host addresses when booting compute into a VPC.\nFor SUNK clusters, this CIDR should have a mask size of /18 for optimal rank ordering; exceptions may be granted per customer. For non-SUNK VPCs, any prefix size is accepted. If left unspecified, a Zone-specific default value will be applied by the server.\nThis field is immutable once set.",
 				DeprecationMessage:  "`host_prefix` is deprecated. Use `host_prefixes` instead. The field will be removed in a future version. The equivalent expression for a given resource may be found by refreshing state and running `terraform state show coreweave_networking_vpc.example`.",
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplaceIfConfigured(),
@@ -483,7 +483,7 @@ func (r *VpcResource) Schema(ctx context.Context, req resource.SchemaRequest, re
 				},
 			},
 			"host_prefixes": schema.SetNestedAttribute{
-				MarkdownDescription: "The IPv4 or IPv6 CIDR ranges used to allocate host addresses when booting compute into a VPC.",
+				MarkdownDescription: "The IPv4 or IPv6 CIDR ranges used to allocate host addresses when booting compute into a VPC.\nFor SUNK clusters, an IPv4 prefix with a mask size of /18 is recommended for optimal rank ordering; exceptions may be granted per customer. For non-SUNK VPCs, any prefix size is accepted.",
 				Optional:            true,
 				Computed:            true,
 				Validators: []validator.Set{

--- a/docs/resources/networking_vpc.md
+++ b/docs/resources/networking_vpc.md
@@ -93,9 +93,10 @@ resource "coreweave_networking_vpc" "example" {
 - `dhcp` (Attributes) Settings affecting DHCP behavior within the VPC. (see [below for nested schema](#nestedatt--dhcp))
 - `egress` (Attributes) Settings affecting traffic leaving the VPC. (see [below for nested schema](#nestedatt--egress))
 - `host_prefix` (String, Deprecated) An IPv4 CIDR range used to allocate host addresses when booting compute into a VPC.
-This CIDR must be have a mask size of /18. If left unspecified, a Zone-specific default value will be applied by the server.
+For SUNK clusters, this CIDR should have a mask size of /18 for optimal rank ordering; exceptions may be granted per customer. For non-SUNK VPCs, any prefix size is accepted. If left unspecified, a Zone-specific default value will be applied by the server.
 This field is immutable once set.
-- `host_prefixes` (Attributes Set) The IPv4 or IPv6 CIDR ranges used to allocate host addresses when booting compute into a VPC. (see [below for nested schema](#nestedatt--host_prefixes))
+- `host_prefixes` (Attributes Set) The IPv4 or IPv6 CIDR ranges used to allocate host addresses when booting compute into a VPC.
+For SUNK clusters, an IPv4 prefix with a mask size of /18 is recommended for optimal rank ordering; exceptions may be granted per customer. For non-SUNK VPCs, any prefix size is accepted. (see [below for nested schema](#nestedatt--host_prefixes))
 - `ingress` (Attributes) Settings affecting traffic entering the VPC. (see [below for nested schema](#nestedatt--ingress))
 - `vpc_prefixes` (Attributes Set) A list of additional prefixes associated with the VPC. For example, CKS clusters use these prefixes for Pod and service CIDR ranges. (see [below for nested schema](#nestedatt--vpc_prefixes))
 


### PR DESCRIPTION
## Summary

The `host_prefix` field on the `coreweave_networking_vpc` resource documented the `/18` CIDR mask as an **unconditional** requirement. This is misleading:

- The `/18` is a **SUNK-specific** recommendation (SUNK uses IP-based locality encoding for node rank ordering); non-SUNK VPCs have no such constraint.
- The provider does **not** enforce `/18` at runtime — a customer successfully created a VPC with `/22` host prefixes in `coreweave-us-west-01a`.
- Per-customer exceptions to `/18` already exist for SUNK customers (e.g. a `/21` granted on 2025-10-10).

Enterprise customers without large unused IPv4 blocks were reading the docs and believing they had to consume a `/18` (~16k addresses) per VPC even when a `/22` or smaller would suffice.

## Changes

All edits were made to the Go source (`coreweave/networking/resource_vpc.go`); the `docs/*.md` changes are generated via `make generate`.

- Reworded the deprecated `host_prefix` `MarkdownDescription` to scope the `/18` to SUNK clusters, note that exceptions may be granted per customer, and clarify that non-SUNK VPCs accept any prefix size.
- Added an equivalent SUNK note to the `host_prefixes` `MarkdownDescription`.
- Regenerated `docs/resources/networking_vpc.md`.

No behavioral/schema changes — documentation strings only.

### Note on the example migration

DOCS-2454 also requested migrating `examples/resources/coreweave_cks_cluster/resource.tf` off the deprecated `host_prefix`. That example already uses `host_prefixes` (done in #320), and a repo-wide grep confirms no remaining deprecated `host_prefix` usage in `examples/`, so no change was needed there.

## Test plan

- [x] `go build ./...` passes
- [x] `make generate` produces the regenerated docs included in this PR
- [ ] Confirm rendered Registry / docs.coreweave.com text reads correctly after merge

Resolves [DOCS-2454](https://coreweave.atlassian.net/browse/DOCS-2454)

Made with [Cursor](https://cursor.com)

[DOCS-2454]: https://coreweave.atlassian.net/browse/DOCS-2454?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ