### PR TITLE
ci(release-please): honor config file by removing release-type input

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -20,8 +20,10 @@ jobs:
         uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4.4.1
         id: release
         with:
-          # Release Please creates the release, goreleaser populates it with artifacts
-          release-type: go
+          # DO NOT set `release-type` here.
+          # Setting `release-type` here causes release-please to drop our settings.
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json
     outputs:
       releases: ${{ toJson(steps.release.outputs) }}
       paths_released: ${{ steps.release.outputs.paths_released }}


### PR DESCRIPTION
Remove the `release-type: go` input from the `release-please` workflow and set `config-file` / `manifest-file` explicitly, so the action runs in manifest mode and reads `release-please-config.json`.

## Why

Release-please was not opening release PRs for windows of documentation-only commits. Since v0.15.0, every merged commit has been `docs` or `ci`, and no release PR was created.

From https://github.com/googleapis/release-please-action#advanced-release-configuration:

> Specifying a release-type configuration is the most straight-forward configuration option, but allows for no further customization.