### PR TITLE
fix(inference): Allow W&B server_url without api_key on gateways

### DIFF
--- a/coreweave/inference/resource_inference_gateway.go
+++ b/coreweave/inference/resource_inference_gateway.go
@@ -188,7 +188,10 @@ func (r *InferenceGatewayResource) Schema(_ context.Context, _ resource.SchemaRe
 							"api_key": schema.StringAttribute{
 								Optional:            true,
 								Sensitive:           true,
-								MarkdownDescription: "The organization API key for Weights & Biases. Required if `server_url` is set.",
+								MarkdownDescription: "The organization API key for Weights & Biases. Requires `server_url` to also be set.",
+								Validators: []validator.String{
+									stringvalidator.AlsoRequires(path.MatchRelative().AtParent().AtName("server_url")),
+								},
 							},
 							"server_url": schema.StringAttribute{
 								Optional:            true,
@@ -268,10 +271,6 @@ func (r *InferenceGatewayResource) ConfigValidators(_ context.Context) []resourc
 			path.MatchRoot("routing").AtName("body_based"),
 			path.MatchRoot("routing").AtName("header_based"),
 			path.MatchRoot("routing").AtName("path_based"),
-		),
-		resourcevalidator.RequiredTogether(
-			path.MatchRoot("auth").AtName("weights_and_biases").AtName("api_key"),
-			path.MatchRoot("auth").AtName("weights_and_biases").AtName("server_url"),
 		),
 	}
 }

--- a/coreweave/inference/resource_inference_gateway_test.go
+++ b/coreweave/inference/resource_inference_gateway_test.go
@@ -3,6 +3,7 @@ package inference_test
 import (
 	"fmt"
 	"math/rand/v2"
+	"regexp"
 	"testing"
 
 	inferencev1 "buf.build/gen/go/coreweave/inference/protocolbuffers/go/coreweave/inference/v1alpha1"
@@ -499,6 +500,67 @@ func TestToCreateGatewayRequest_AllRoutingTypes(t *testing.T) {
 		if pbr.PathBasedRouting == nil {
 			t.Error("Routing.PathBased: expected non-nil")
 		}
+	})
+}
+
+// wandbAuthGatewayConfig renders a minimal gateway whose W&B auth block contains
+// only the attributes in wandbAttrs. Zones are hardcoded (no data source) so the
+// plan stays local and never reaches the API.
+func wandbAuthGatewayConfig(wandbAttrs string) string {
+	return fmt.Sprintf(`
+resource "coreweave_inference_gateway" "test" {
+  name  = "unit-test-wandb"
+  zones = ["US-EAST-04A"]
+
+  auth = {
+    weights_and_biases = {
+      %s
+    }
+  }
+
+  routing = {
+    body_based = {
+      api_type = "API_TYPE_OPENAI"
+    }
+  }
+}
+`, wandbAttrs)
+}
+
+// TestInferenceGateway_WandBAuthValidation pins the W&B auth coupling: a
+// server_url may be set without an api_key (W&B custom-instance gateways are
+// read back with a server_url but never an api_key, which is sensitive and not
+// returned by the API), while an api_key still requires a server_url — mirroring
+// the proto's server_url_requires_api_key rule.
+func TestInferenceGateway_WandBAuthValidation(t *testing.T) {
+	// A non-empty token lets the provider configure so a plan-only create can be
+	// computed; no API call is made during plan.
+	t.Setenv("COREWEAVE_API_TOKEN", "CW-SECRET-unit-test")
+
+	t.Run("server_url without api_key is valid", func(t *testing.T) {
+		resource.UnitTest(t, resource.TestCase{
+			ProtoV6ProviderFactories: provider.TestProtoV6ProviderFactories,
+			Steps: []resource.TestStep{
+				{
+					Config:             wandbAuthGatewayConfig(`server_url = "https://wandb.example.com"`),
+					PlanOnly:           true,
+					ExpectNonEmptyPlan: true,
+				},
+			},
+		})
+	})
+
+	t.Run("api_key without server_url is invalid", func(t *testing.T) {
+		resource.UnitTest(t, resource.TestCase{
+			ProtoV6ProviderFactories: provider.TestProtoV6ProviderFactories,
+			Steps: []resource.TestStep{
+				{
+					Config:      wandbAuthGatewayConfig(`api_key = "wandb-key"`),
+					PlanOnly:    true,
+					ExpectError: regexp.MustCompile(`server_url" must be specified when`),
+				},
+			},
+		})
 	})
 }
 

--- a/docs/resources/inference_gateway.md
+++ b/docs/resources/inference_gateway.md
@@ -70,7 +70,7 @@ Optional:
 
 Optional:
 
-- `api_key` (String, Sensitive) The organization API key for Weights & Biases. Required if `server_url` is set.
+- `api_key` (String, Sensitive) The organization API key for Weights & Biases. Requires `server_url` to also be set.
 - `enable_rate_limiting` (Boolean) Whether to enable Weights & Biases controlled rate limiting.
 - `enable_usage_reports` (Boolean) Whether to send usage data to Weights & Biases.
 - `server_url` (String) The Weights & Biases server URL. Defaults to the shared SaaS instance if not set.


### PR DESCRIPTION
The gateway resource required api_key and server_url together, but the API never returns the sensitive api_key, so importing a W&B custom-instance gateway (which has a server_url) failed config validation.
- Replace the bidirectional `RequiredTogether` with a one-directional api_key -> server_url guard via `stringvalidator.AlsoRequires`, matching the proto's server_url_requires_api_key rule: https://github.com/coreweave/infr-api/blob/b7465a37ac53c5b5104ac094e107b9f07ad396d3/internal/proto/coreweave/inference/v1alpha1/gateway.proto#L178-L182

[INF-674](https://coreweave.atlassian.net/browse/INF-674?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ)
[INF-675](https://coreweave.atlassian.net/browse/INF-675?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ)

[INF-674]: https://coreweave.atlassian.net/browse/INF-674?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[INF-675]: https://coreweave.atlassian.net/browse/INF-675?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ