### PR TITLE
fix(inference): Preserve observed status fields across updates

### DIFF
--- a/coreweave/inference/resource_inference_capacity_claim.go
+++ b/coreweave/inference/resource_inference_capacity_claim.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -89,6 +90,7 @@ func (r *InferenceCapacityClaimResource) Schema(_ context.Context, _ resource.Sc
 			"status": schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "The current status of the capacity claim. See the [Inference API overview](https://docs.coreweave.com/products/inference/reference/api-overview#status-values) for status values.",
+				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 			"created_at": schema.StringAttribute{
 				Computed:            true,
@@ -98,10 +100,12 @@ func (r *InferenceCapacityClaimResource) Schema(_ context.Context, _ resource.Sc
 			"updated_at": schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "RFC3339 timestamp of when the capacity claim was last updated.",
+				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 			"conditions": schema.ListNestedAttribute{
 				Computed:            true,
 				MarkdownDescription: "Detailed status conditions for the capacity claim.",
+				PlanModifiers:       []planmodifier.List{listplanmodifier.UseStateForUnknown()},
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
 						"type": schema.StringAttribute{
@@ -228,7 +232,7 @@ func (r *InferenceCapacityClaimResource) Create(ctx context.Context, req resourc
 	}
 
 	// Save initial state before polling so the resource is tracked even if polling fails.
-	resp.Diagnostics.Append(setFromCapacityClaim(&data, createResp.Msg.GetCapacityClaim())...)
+	resp.Diagnostics.Append(setFromCapacityClaim(&data, createResp.Msg.GetCapacityClaim(), false)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -285,7 +289,7 @@ func (r *InferenceCapacityClaimResource) Create(ctx context.Context, req resourc
 		return
 	}
 
-	resp.Diagnostics.Append(setFromCapacityClaim(&data, cc)...)
+	resp.Diagnostics.Append(setFromCapacityClaim(&data, cc, false)...)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
@@ -308,7 +312,7 @@ func (r *InferenceCapacityClaimResource) Read(ctx context.Context, req resource.
 		return
 	}
 
-	resp.Diagnostics.Append(setFromCapacityClaim(&data, getResp.Msg.GetCapacityClaim())...)
+	resp.Diagnostics.Append(setFromCapacityClaim(&data, getResp.Msg.GetCapacityClaim(), false)...)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
@@ -333,7 +337,7 @@ func (r *InferenceCapacityClaimResource) Update(ctx context.Context, req resourc
 
 	// Save intermediate state before polling so an in-flight update is not lost
 	// if polling fails or times out.
-	resp.Diagnostics.Append(setFromCapacityClaim(&data, updateResp.Msg.GetCapacityClaim())...)
+	resp.Diagnostics.Append(setFromCapacityClaim(&data, updateResp.Msg.GetCapacityClaim(), true)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -391,7 +395,7 @@ func (r *InferenceCapacityClaimResource) Update(ctx context.Context, req resourc
 		return
 	}
 
-	resp.Diagnostics.Append(setFromCapacityClaim(&data, cc)...)
+	resp.Diagnostics.Append(setFromCapacityClaim(&data, cc, true)...)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
@@ -517,21 +521,30 @@ func toUpdateCapacityClaimRequest(ctx context.Context, m *InferenceCapacityClaim
 }
 
 // setFromCapacityClaim populates all fields on the model from a proto CapacityClaim response.
-func setFromCapacityClaim(m *InferenceCapacityClaimResourceModel, cc *inferencev1.CapacityClaim) (diagnostics diag.Diagnostics) {
+//
+// When preserveStatusFields is true, the observed status fields (status, allocated_instances,
+// pending_instances, updated_at, conditions) are left untouched on the model. These fields
+// carry UseStateForUnknown plan modifiers, so during Update the plan holds their prior-state
+// values; overwriting them with the fresh API response would violate Terraform's plan/apply
+// consistency check. Read always refreshes them (preserveStatusFields=false).
+func setFromCapacityClaim(m *InferenceCapacityClaimResourceModel, cc *inferencev1.CapacityClaim, preserveStatusFields bool) (diagnostics diag.Diagnostics) {
 	spec := cc.GetSpec()
 	status := cc.GetStatus()
 
 	m.ID = types.StringValue(spec.GetId())
 	m.OrganizationID = types.StringValue(spec.GetOrganizationId())
 	m.Name = types.StringValue(spec.GetName())
-	m.Status = types.StringValue(status.GetStatus().String())
-	m.AllocatedInstances = types.Int64Value(int64(status.GetAllocatedInstances()))
-	m.PendingInstances = types.Int64Value(int64(status.GetPendingInstances()))
+
+	if !preserveStatusFields {
+		m.Status = types.StringValue(status.GetStatus().String())
+		m.AllocatedInstances = types.Int64Value(int64(status.GetAllocatedInstances()))
+		m.PendingInstances = types.Int64Value(int64(status.GetPendingInstances()))
+	}
 
 	if status.GetCreatedAt() != nil {
 		m.CreatedAt = types.StringValue(status.GetCreatedAt().AsTime().Format(time.RFC3339))
 	}
-	if status.GetUpdatedAt() != nil {
+	if !preserveStatusFields && status.GetUpdatedAt() != nil {
 		m.UpdatedAt = types.StringValue(status.GetUpdatedAt().AsTime().Format(time.RFC3339))
 	}
 
@@ -554,25 +567,11 @@ func setFromCapacityClaim(m *InferenceCapacityClaimResourceModel, cc *inferencev
 	}
 
 	// conditions
-	condVals := make([]attr.Value, len(status.GetConditions()))
-	for i, c := range status.GetConditions() {
-		lastUpdate := ""
-		if c.GetLastUpdateTime() != nil {
-			lastUpdate = c.GetLastUpdateTime().AsTime().Format(time.RFC3339)
-		}
-		condObj, diags := types.ObjectValue(conditionAttrTypes, map[string]attr.Value{
-			"type":             types.StringValue(c.GetType()),
-			"status":           types.StringValue(c.GetStatus().String()),
-			"last_update_time": types.StringValue(lastUpdate),
-			"reason":           types.StringValue(c.GetReason()),
-			"message":          types.StringValue(c.GetMessage()),
-		})
+	if !preserveStatusFields {
+		condList, diags := conditionsListFromStatus(status.GetConditions())
 		diagnostics.Append(diags...)
-		condVals[i] = condObj
+		m.Conditions = condList
 	}
-	condList, diags := types.ListValue(types.ObjectType{AttrTypes: conditionAttrTypes}, condVals)
-	diagnostics.Append(diags...)
-	m.Conditions = condList
 
 	return diagnostics
 }

--- a/coreweave/inference/resource_inference_capacity_claim_test.go
+++ b/coreweave/inference/resource_inference_capacity_claim_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -392,6 +393,18 @@ func TestInferenceCapacityClaim(t *testing.T) {
 					Config: capacityClaimConfig(name, 2, preferredZone, preferredInstance),
 					ConfigStateChecks: []statecheck.StateCheck{
 						statecheck.ExpectKnownValue(fullResourceName, tfjsonpath.New("resources").AtMapKey("instance_count"), knownvalue.Int64Exact(2)),
+					},
+				},
+				{
+					// Re-applying the identical config after Update must be a no-op:
+					// the preserved server-observed fields (status, updated_at,
+					// conditions, allocated_instances, pending_instances) must not
+					// produce perpetual plan churn.
+					Config: capacityClaimConfig(name, 2, preferredZone, preferredInstance),
+					ConfigPlanChecks: resource.ConfigPlanChecks{
+						PreApply: []plancheck.PlanCheck{
+							plancheck.ExpectResourceAction(fullResourceName, plancheck.ResourceActionNoop),
+						},
 					},
 				},
 				{

--- a/coreweave/inference/resource_inference_capacity_claim_test.go
+++ b/coreweave/inference/resource_inference_capacity_claim_test.go
@@ -77,7 +77,7 @@ func TestSetFromCapacityClaim_Fields(t *testing.T) {
 	}).Build()
 
 	var m inference.InferenceCapacityClaimResourceModel
-	diags := inference.SetFromCapacityClaim(&m, cc)
+	diags := inference.SetFromCapacityClaim(&m, cc, false)
 	if diags.HasError() {
 		t.Fatalf("SetFromCapacityClaim returned errors: %v", diags)
 	}
@@ -134,6 +134,102 @@ func TestSetFromCapacityClaim_Fields(t *testing.T) {
 	condElems := m.Conditions.Elements()
 	if len(condElems) != 1 {
 		t.Fatalf("Conditions: expected 1 element, got %d", len(condElems))
+	}
+}
+
+// TestSetFromCapacityClaim_PreserveStatusFields verifies that during Update
+// (preserveStatusFields=true) the observed status fields — status,
+// allocated_instances, pending_instances, updated_at, conditions — retain their
+// prior-state values (as carried by the plan via UseStateForUnknown) rather than
+// being overwritten by the fresh API response, while spec fields are still
+// refreshed. Read/Create (preserveStatusFields=false) refresh all fields.
+func TestSetFromCapacityClaim_PreserveStatusFields(t *testing.T) {
+	t.Parallel()
+
+	base := func(status inferencev1.Status, name, condReason string, allocated, pending uint32, updatedAt *timestamppb.Timestamp) *inferencev1.CapacityClaim {
+		return (inferencev1.CapacityClaim_builder{
+			Spec: (inferencev1.CapacityClaimSpec_builder{
+				Id:             "cc-123",
+				Name:           name,
+				OrganizationId: "org-456",
+				Resources: (inferencev1.CapacityClaimResources_builder{
+					InstanceId:    testInstanceType,
+					InstanceCount: 3,
+					CapacityType:  inferencev1.CapacityType_CAPACITY_TYPE_MANAGED,
+					Zones:         []string{"US-WEST-04A"},
+				}).Build(),
+			}).Build(),
+			Status: (inferencev1.CapacityClaimStatus_builder{
+				Status:             status,
+				UpdatedAt:          updatedAt,
+				AllocatedInstances: allocated,
+				PendingInstances:   pending,
+				Conditions: []*inferencev1.Condition{
+					(inferencev1.Condition_builder{
+						Type:   "Ready",
+						Status: inferencev1.Condition_STATUS_TRUE,
+						Reason: condReason,
+					}).Build(),
+				},
+			}).Build(),
+		}).Build()
+	}
+
+	prior := base(inferencev1.Status_STATUS_READY, "my-cc", "AllAllocated", 3, 0, timestamppb.New(time.Unix(1000, 0).UTC()))
+	fresh := base(inferencev1.Status_STATUS_UPDATING, "my-cc-renamed", "Reconciling", 1, 2, timestamppb.New(time.Unix(2000, 0).UTC()))
+
+	// Seed the model with prior-state values (what the plan holds on Update).
+	m := &inference.InferenceCapacityClaimResourceModel{}
+	if diags := inference.SetFromCapacityClaim(m, prior, false); diags.HasError() {
+		t.Fatalf("seed SetFromCapacityClaim returned errors: %v", diags)
+	}
+	priorStatus := m.Status
+	priorUpdatedAt := m.UpdatedAt
+	priorConditions := m.Conditions
+	priorAllocated := m.AllocatedInstances
+	priorPending := m.PendingInstances
+
+	// Update path: status fields must be preserved, spec fields refreshed.
+	if diags := inference.SetFromCapacityClaim(m, fresh, true); diags.HasError() {
+		t.Fatalf("preserve SetFromCapacityClaim returned errors: %v", diags)
+	}
+	if !m.Status.Equal(priorStatus) {
+		t.Errorf("Status: expected preserved %v, got %v", priorStatus, m.Status)
+	}
+	if !m.UpdatedAt.Equal(priorUpdatedAt) {
+		t.Errorf("UpdatedAt: expected preserved %v, got %v", priorUpdatedAt, m.UpdatedAt)
+	}
+	if !m.Conditions.Equal(priorConditions) {
+		t.Errorf("Conditions: expected preserved %v, got %v", priorConditions, m.Conditions)
+	}
+	if !m.AllocatedInstances.Equal(priorAllocated) {
+		t.Errorf("AllocatedInstances: expected preserved %v, got %v", priorAllocated, m.AllocatedInstances)
+	}
+	if !m.PendingInstances.Equal(priorPending) {
+		t.Errorf("PendingInstances: expected preserved %v, got %v", priorPending, m.PendingInstances)
+	}
+	if m.Name.ValueString() != "my-cc-renamed" {
+		t.Errorf("Name: expected spec to refresh to 'my-cc-renamed', got %q", m.Name.ValueString())
+	}
+
+	// Read path: status fields must refresh from the API response.
+	if diags := inference.SetFromCapacityClaim(m, fresh, false); diags.HasError() {
+		t.Fatalf("refresh SetFromCapacityClaim returned errors: %v", diags)
+	}
+	if m.Status.ValueString() != inferencev1.Status_STATUS_UPDATING.String() {
+		t.Errorf("Status: expected refreshed %q, got %q", inferencev1.Status_STATUS_UPDATING.String(), m.Status.ValueString())
+	}
+	if m.AllocatedInstances.ValueInt64() != 1 {
+		t.Errorf("AllocatedInstances: expected refreshed 1, got %d", m.AllocatedInstances.ValueInt64())
+	}
+	if m.PendingInstances.ValueInt64() != 2 {
+		t.Errorf("PendingInstances: expected refreshed 2, got %d", m.PendingInstances.ValueInt64())
+	}
+	if m.UpdatedAt.Equal(priorUpdatedAt) {
+		t.Errorf("UpdatedAt: expected refresh to differ from prior %v, got %v", priorUpdatedAt, m.UpdatedAt)
+	}
+	if m.Conditions.Equal(priorConditions) {
+		t.Errorf("Conditions: expected refresh to differ from prior, got %v", m.Conditions)
 	}
 }
 
@@ -302,6 +398,10 @@ func TestInferenceCapacityClaim(t *testing.T) {
 					ResourceName:      fullResourceName,
 					ImportState:       true,
 					ImportStateVerify: true,
+					// Server-observed fields are intentionally not refreshed into state on
+					// Update (see setFromCapacityClaim preserveStatusFields); a fresh import
+					// Read legitimately observes newer values, so they can't be verified here.
+					ImportStateVerifyIgnore: []string{"status", "updated_at", "conditions", "allocated_instances", "pending_instances"},
 				},
 			},
 		})

--- a/coreweave/inference/resource_inference_deployment.go
+++ b/coreweave/inference/resource_inference_deployment.go
@@ -21,6 +21,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -71,6 +72,31 @@ var (
 
 	errDeploymentFailed = errors.New("inference deployment entered a failed state")
 )
+
+// conditionsListFromStatus converts proto status conditions into the Terraform
+// list value shared by all inference resources.
+func conditionsListFromStatus(conds []*inferencev1.Condition) (types.List, diag.Diagnostics) {
+	var diagnostics diag.Diagnostics
+	condVals := make([]attr.Value, len(conds))
+	for i, c := range conds {
+		lastUpdate := ""
+		if c.GetLastUpdateTime() != nil {
+			lastUpdate = c.GetLastUpdateTime().AsTime().Format(time.RFC3339)
+		}
+		condObj, diags := types.ObjectValue(conditionAttrTypes, map[string]attr.Value{
+			"type":             types.StringValue(c.GetType()),
+			"status":           types.StringValue(c.GetStatus().String()),
+			"last_update_time": types.StringValue(lastUpdate),
+			"reason":           types.StringValue(c.GetReason()),
+			"message":          types.StringValue(c.GetMessage()),
+		})
+		diagnostics.Append(diags...)
+		condVals[i] = condObj
+	}
+	condList, diags := types.ListValue(types.ObjectType{AttrTypes: conditionAttrTypes}, condVals)
+	diagnostics.Append(diags...)
+	return condList, diagnostics
+}
 
 func NewInferenceDeploymentResource() resource.Resource {
 	return &InferenceDeploymentResource{}
@@ -160,6 +186,7 @@ func (r *InferenceDeploymentResource) Schema(_ context.Context, _ resource.Schem
 			"status": schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "The current status of the deployment. See the [Inference API overview](https://docs.coreweave.com/products/inference/reference/api-overview) for status values.",
+				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 			"created_at": schema.StringAttribute{
 				Computed:            true,
@@ -169,10 +196,12 @@ func (r *InferenceDeploymentResource) Schema(_ context.Context, _ resource.Schem
 			"updated_at": schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "RFC3339 timestamp of when the deployment was last updated.",
+				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 			"conditions": schema.ListNestedAttribute{
 				Computed:            true,
 				MarkdownDescription: "Detailed status conditions for the deployment.",
+				PlanModifiers:       []planmodifier.List{listplanmodifier.UseStateForUnknown()},
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
 						"type": schema.StringAttribute{
@@ -395,7 +424,7 @@ func (r *InferenceDeploymentResource) Create(ctx context.Context, req resource.C
 	}
 
 	// Save initial state before polling so the resource is tracked even if polling fails.
-	resp.Diagnostics.Append(setFromDeployment(&data, createResp.Msg.Deployment)...)
+	resp.Diagnostics.Append(setFromDeployment(&data, createResp.Msg.Deployment, false)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -450,7 +479,7 @@ func (r *InferenceDeploymentResource) Create(ctx context.Context, req resource.C
 		return
 	}
 
-	resp.Diagnostics.Append(setFromDeployment(&data, d)...)
+	resp.Diagnostics.Append(setFromDeployment(&data, d, false)...)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
@@ -473,7 +502,7 @@ func (r *InferenceDeploymentResource) Read(ctx context.Context, req resource.Rea
 		return
 	}
 
-	resp.Diagnostics.Append(setFromDeployment(&data, getResp.Msg.Deployment)...)
+	resp.Diagnostics.Append(setFromDeployment(&data, getResp.Msg.Deployment, false)...)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
@@ -498,7 +527,7 @@ func (r *InferenceDeploymentResource) Update(ctx context.Context, req resource.U
 
 	// Save intermediate state before polling so an in-flight update is not lost
 	// if polling fails or times out.
-	resp.Diagnostics.Append(setFromDeployment(&data, updateResp.Msg.Deployment)...)
+	resp.Diagnostics.Append(setFromDeployment(&data, updateResp.Msg.Deployment, true)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -554,7 +583,7 @@ func (r *InferenceDeploymentResource) Update(ctx context.Context, req resource.U
 		return
 	}
 
-	resp.Diagnostics.Append(setFromDeployment(&data, d)...)
+	resp.Diagnostics.Append(setFromDeployment(&data, d, true)...)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
@@ -774,7 +803,13 @@ func ensureDeploymentNested(m *InferenceDeploymentResourceModel) {
 // For Optional (non-Computed) fields, null is preserved when the plan/state was null and
 // the API returns the default (zero/empty) value — matching the CKS pattern for optional
 // fields. Computed fields are always populated from the API response.
-func setFromDeployment(m *InferenceDeploymentResourceModel, d *inferencev1.Deployment) (diagnostics diag.Diagnostics) {
+//
+// When preserveStatusFields is true, the observed status fields (status, updated_at,
+// conditions) are left untouched on the model. These fields carry UseStateForUnknown plan
+// modifiers, so during Update the plan holds their prior-state values; overwriting them with
+// the fresh API response would violate Terraform's plan/apply consistency check. Read always
+// refreshes them (preserveStatusFields=false).
+func setFromDeployment(m *InferenceDeploymentResourceModel, d *inferencev1.Deployment, preserveStatusFields bool) (diagnostics diag.Diagnostics) {
 	spec := d.GetSpec()
 	status := d.GetStatus()
 
@@ -785,13 +820,16 @@ func setFromDeployment(m *InferenceDeploymentResourceModel, d *inferencev1.Deplo
 	m.ID = types.StringValue(spec.GetId())
 	m.OrganizationID = types.StringValue(spec.GetOrganizationId())
 	m.Name = types.StringValue(spec.GetName())
-	m.Status = types.StringValue(status.GetStatus().String())
 	m.Disabled = types.BoolValue(spec.GetDisabled())
+
+	if !preserveStatusFields {
+		m.Status = types.StringValue(status.GetStatus().String())
+	}
 
 	if status.GetCreatedAt() != nil {
 		m.CreatedAt = types.StringValue(status.GetCreatedAt().AsTime().Format(time.RFC3339))
 	}
-	if status.GetUpdatedAt() != nil {
+	if !preserveStatusFields && status.GetUpdatedAt() != nil {
 		m.UpdatedAt = types.StringValue(status.GetUpdatedAt().AsTime().Format(time.RFC3339))
 	}
 
@@ -878,25 +916,11 @@ func setFromDeployment(m *InferenceDeploymentResourceModel, d *inferencev1.Deplo
 	m.Traffic = &TrafficModel{Weight: types.Int64Value(weight)}
 
 	// conditions
-	condVals := make([]attr.Value, len(status.GetConditions()))
-	for i, c := range status.GetConditions() {
-		lastUpdate := ""
-		if c.GetLastUpdateTime() != nil {
-			lastUpdate = c.GetLastUpdateTime().AsTime().Format(time.RFC3339)
-		}
-		condObj, diags := types.ObjectValue(conditionAttrTypes, map[string]attr.Value{
-			"type":             types.StringValue(c.GetType()),
-			"status":           types.StringValue(c.GetStatus().String()),
-			"last_update_time": types.StringValue(lastUpdate),
-			"reason":           types.StringValue(c.GetReason()),
-			"message":          types.StringValue(c.GetMessage()),
-		})
+	if !preserveStatusFields {
+		condList, diags := conditionsListFromStatus(status.GetConditions())
 		diagnostics.Append(diags...)
-		condVals[i] = condObj
+		m.Conditions = condList
 	}
-	condList, diags := types.ListValue(types.ObjectType{AttrTypes: conditionAttrTypes}, condVals)
-	diagnostics.Append(diags...)
-	m.Conditions = condList
 
 	return diagnostics
 }

--- a/coreweave/inference/resource_inference_deployment_test.go
+++ b/coreweave/inference/resource_inference_deployment_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math/rand/v2"
 	"testing"
+	"time"
 
 	inferencev1 "buf.build/gen/go/coreweave/inference/protocolbuffers/go/coreweave/inference/v1alpha1"
 	"github.com/coreweave/terraform-provider-coreweave/coreweave/inference"
@@ -17,6 +18,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 // --- Unit tests for pure helper functions ---
@@ -148,7 +150,7 @@ func TestInferenceDeployment_SetFromDeployment_NullPreservation(t *testing.T) {
 		},
 	}
 
-	inference.SetFromDeployment(m, d)
+	inference.SetFromDeployment(m, d, false)
 
 	// Optional fields with default values should remain null.
 	if !m.Runtime.Version.IsNull() {
@@ -167,7 +169,7 @@ func TestInferenceDeployment_SetFromDeployment_NullPreservation(t *testing.T) {
 		t.Errorf("Autoscaling.CapacityClasses: expected null when API returns empty, got %v", m.Autoscaling.CapacityClasses)
 	}
 	m.Runtime.Version = types.StringUnknown()
-	inference.SetFromDeployment(m, d)
+	inference.SetFromDeployment(m, d, false)
 	if !m.Runtime.Version.IsNull() {
 		t.Errorf("Runtime.Version: expected null when plan is unknown and API returns empty, got %v", m.Runtime.Version)
 	}
@@ -186,6 +188,83 @@ func TestInferenceDeployment_SetFromDeployment_NullPreservation(t *testing.T) {
 	}
 	if m.Autoscaling.Min.ValueInt64() != 1 {
 		t.Errorf("Autoscaling.Min: expected 1, got %d", m.Autoscaling.Min.ValueInt64())
+	}
+}
+
+// TestSetFromDeployment_PreserveStatusFields verifies that during Update
+// (preserveStatusFields=true) the observed status fields — status, updated_at,
+// conditions — retain their prior-state values (as carried by the plan via
+// UseStateForUnknown) rather than being overwritten by the fresh API response,
+// while spec fields are still refreshed. Read/Create (preserveStatusFields=false)
+// refresh all fields.
+func TestSetFromDeployment_PreserveStatusFields(t *testing.T) {
+	t.Parallel()
+
+	base := func(status inferencev1.Status, name, condReason string, updatedAt *timestamppb.Timestamp) *inferencev1.Deployment {
+		return &inferencev1.Deployment{
+			Spec: &inferencev1.DeploymentSpec{
+				Id:        "test-id",
+				Name:      name,
+				Runtime:   &inferencev1.DeploymentRuntime{Engine: "vllm"},
+				Resources: &inferencev1.DeploymentResources{InstanceType: "H100_80GB_SXM5", GpuCount: 1},
+				Model:     &inferencev1.DeploymentModel{Name: "meta-llama/Llama-3.1-8B"},
+				Autoscaling: &inferencev1.DeploymentAutoscaling{
+					Min: 1,
+					Max: 4,
+				},
+				Traffic: &inferencev1.DeploymentTraffic{},
+			},
+			Status: &inferencev1.DeploymentStatus{
+				Status:    status,
+				UpdatedAt: updatedAt,
+				Conditions: []*inferencev1.Condition{
+					{Type: "Ready", Status: inferencev1.Condition_STATUS_TRUE, Reason: condReason},
+				},
+			},
+		}
+	}
+
+	prior := base(inferencev1.Status_STATUS_READY, "my-llm", "AsExpected", timestamppb.New(time.Unix(1000, 0).UTC()))
+	fresh := base(inferencev1.Status_STATUS_UPDATING, "my-llm-renamed", "Reconciling", timestamppb.New(time.Unix(2000, 0).UTC()))
+
+	// Seed the model with prior-state values (what the plan holds on Update).
+	m := &inference.InferenceDeploymentResourceModel{}
+	if diags := inference.SetFromDeployment(m, prior, false); diags.HasError() {
+		t.Fatalf("seed SetFromDeployment returned errors: %v", diags)
+	}
+	priorStatus := m.Status
+	priorUpdatedAt := m.UpdatedAt
+	priorConditions := m.Conditions
+
+	// Update path: status fields must be preserved, spec fields refreshed.
+	if diags := inference.SetFromDeployment(m, fresh, true); diags.HasError() {
+		t.Fatalf("preserve SetFromDeployment returned errors: %v", diags)
+	}
+	if !m.Status.Equal(priorStatus) {
+		t.Errorf("Status: expected preserved %v, got %v", priorStatus, m.Status)
+	}
+	if !m.UpdatedAt.Equal(priorUpdatedAt) {
+		t.Errorf("UpdatedAt: expected preserved %v, got %v", priorUpdatedAt, m.UpdatedAt)
+	}
+	if !m.Conditions.Equal(priorConditions) {
+		t.Errorf("Conditions: expected preserved %v, got %v", priorConditions, m.Conditions)
+	}
+	if m.Name.ValueString() != "my-llm-renamed" {
+		t.Errorf("Name: expected spec to refresh to 'my-llm-renamed', got %q", m.Name.ValueString())
+	}
+
+	// Read path: status fields must refresh from the API response.
+	if diags := inference.SetFromDeployment(m, fresh, false); diags.HasError() {
+		t.Fatalf("refresh SetFromDeployment returned errors: %v", diags)
+	}
+	if m.Status.ValueString() != inferencev1.Status_STATUS_UPDATING.String() {
+		t.Errorf("Status: expected refreshed %q, got %q", inferencev1.Status_STATUS_UPDATING.String(), m.Status.ValueString())
+	}
+	if m.UpdatedAt.Equal(priorUpdatedAt) {
+		t.Errorf("UpdatedAt: expected refresh to differ from prior %v, got %v", priorUpdatedAt, m.UpdatedAt)
+	}
+	if m.Conditions.Equal(priorConditions) {
+		t.Errorf("Conditions: expected refresh to differ from prior, got %v", m.Conditions)
 	}
 }
 
@@ -566,6 +645,10 @@ func TestInferenceDeployment(t *testing.T) {
 					ResourceName:      fullResourceName,
 					ImportState:       true,
 					ImportStateVerify: true,
+					// Server-observed fields are intentionally not refreshed into state on
+					// Update (see setFromDeployment preserveStatusFields); a fresh import Read
+					// legitimately observes newer values, so they can't be verified here.
+					ImportStateVerifyIgnore: []string{"status", "updated_at", "conditions"},
 				},
 			},
 		})

--- a/coreweave/inference/resource_inference_deployment_test.go
+++ b/coreweave/inference/resource_inference_deployment_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -639,6 +640,17 @@ func TestInferenceDeployment(t *testing.T) {
 						statecheck.ExpectKnownValue(fullResourceName, tfjsonpath.New("autoscaling").AtMapKey("max"), knownvalue.Int64Exact(4)),
 						statecheck.ExpectKnownValue(fullResourceName, tfjsonpath.New("disabled"), knownvalue.Bool(true)),
 						statecheck.ExpectKnownValue(fullResourceName, tfjsonpath.New("traffic").AtMapKey("weight"), knownvalue.Int64Exact(50)),
+					},
+				},
+				{
+					// Re-applying the identical config after Update must be a no-op:
+					// the preserved server-observed fields (status, updated_at,
+					// conditions) must not produce perpetual plan churn.
+					Config: inferenceDeploymentUpdatedConfig(name, preferredZone, preferredInstance),
+					ConfigPlanChecks: resource.ConfigPlanChecks{
+						PreApply: []plancheck.PlanCheck{
+							plancheck.ExpectResourceAction(fullResourceName, plancheck.ResourceActionNoop),
+						},
 					},
 				},
 				{

--- a/coreweave/inference/resource_inference_gateway.go
+++ b/coreweave/inference/resource_inference_gateway.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -116,6 +117,7 @@ func (r *InferenceGatewayResource) Schema(_ context.Context, _ resource.SchemaRe
 			"status": schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "The current status of the gateway. See the [Inference API overview](https://docs.coreweave.com/products/inference/reference/api-overview) for status values.",
+				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 			"created_at": schema.StringAttribute{
 				Computed:            true,
@@ -125,10 +127,12 @@ func (r *InferenceGatewayResource) Schema(_ context.Context, _ resource.SchemaRe
 			"updated_at": schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "RFC3339 timestamp of when the gateway was last updated.",
+				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 			"conditions": schema.ListNestedAttribute{
 				Computed:            true,
 				MarkdownDescription: "Detailed status conditions for the gateway.",
+				PlanModifiers:       []planmodifier.List{listplanmodifier.UseStateForUnknown()},
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
 						"type": schema.StringAttribute{
@@ -312,7 +316,7 @@ func (r *InferenceGatewayResource) Create(ctx context.Context, req resource.Crea
 	}
 
 	// Save initial state before polling so the resource is tracked even if polling fails.
-	resp.Diagnostics.Append(setFromGateway(&data, createResp.Msg.Gateway)...)
+	resp.Diagnostics.Append(setFromGateway(&data, createResp.Msg.Gateway, false)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -367,7 +371,7 @@ func (r *InferenceGatewayResource) Create(ctx context.Context, req resource.Crea
 		return
 	}
 
-	resp.Diagnostics.Append(setFromGateway(&data, gw)...)
+	resp.Diagnostics.Append(setFromGateway(&data, gw, false)...)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
@@ -390,7 +394,7 @@ func (r *InferenceGatewayResource) Read(ctx context.Context, req resource.ReadRe
 		return
 	}
 
-	resp.Diagnostics.Append(setFromGateway(&data, getResp.Msg.Gateway)...)
+	resp.Diagnostics.Append(setFromGateway(&data, getResp.Msg.Gateway, false)...)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
@@ -415,7 +419,7 @@ func (r *InferenceGatewayResource) Update(ctx context.Context, req resource.Upda
 
 	// Save intermediate state before polling so an in-flight update is not lost
 	// if polling fails or times out.
-	resp.Diagnostics.Append(setFromGateway(&data, updateResp.Msg.Gateway)...)
+	resp.Diagnostics.Append(setFromGateway(&data, updateResp.Msg.Gateway, true)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -471,7 +475,7 @@ func (r *InferenceGatewayResource) Update(ctx context.Context, req resource.Upda
 		return
 	}
 
-	resp.Diagnostics.Append(setFromGateway(&data, gw)...)
+	resp.Diagnostics.Append(setFromGateway(&data, gw, true)...)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
@@ -708,20 +712,29 @@ func toUpdateGatewayRequest(ctx context.Context, m *InferenceGatewayResourceMode
 // For Optional (non-Computed) fields, null is preserved when the plan/state was null and the
 // API returns the default (zero/empty) value.
 //
+// When preserveStatusFields is true, the observed status fields (status, updated_at,
+// conditions) are left untouched on the model. These fields carry UseStateForUnknown plan
+// modifiers, so during Update the plan holds their prior-state values; overwriting them with
+// the fresh API response would violate Terraform's plan/apply consistency check. Read always
+// refreshes them (preserveStatusFields=false).
+//
 //nolint:gocyclo
-func setFromGateway(m *InferenceGatewayResourceModel, gw *inferencev1.Gateway) (diagnostics diag.Diagnostics) {
+func setFromGateway(m *InferenceGatewayResourceModel, gw *inferencev1.Gateway, preserveStatusFields bool) (diagnostics diag.Diagnostics) {
 	spec := gw.GetSpec()
 	status := gw.GetStatus()
 
 	m.ID = types.StringValue(spec.GetId())
 	m.OrganizationID = types.StringValue(spec.GetOrganizationId())
 	m.Name = types.StringValue(spec.GetName())
-	m.Status = types.StringValue(status.GetStatus().String())
+
+	if !preserveStatusFields {
+		m.Status = types.StringValue(status.GetStatus().String())
+	}
 
 	if status.GetCreatedAt() != nil {
 		m.CreatedAt = types.StringValue(status.GetCreatedAt().AsTime().Format(time.RFC3339))
 	}
-	if status.GetUpdatedAt() != nil {
+	if !preserveStatusFields && status.GetUpdatedAt() != nil {
 		m.UpdatedAt = types.StringValue(status.GetUpdatedAt().AsTime().Format(time.RFC3339))
 	}
 
@@ -844,25 +857,11 @@ func setFromGateway(m *InferenceGatewayResourceModel, gw *inferencev1.Gateway) (
 	m.Endpoints = epSet
 
 	// conditions
-	condVals := make([]attr.Value, len(status.GetConditions()))
-	for i, c := range status.GetConditions() {
-		lastUpdate := ""
-		if c.GetLastUpdateTime() != nil {
-			lastUpdate = c.GetLastUpdateTime().AsTime().Format(time.RFC3339)
-		}
-		condObj, diags := types.ObjectValue(conditionAttrTypes, map[string]attr.Value{
-			"type":             types.StringValue(c.GetType()),
-			"status":           types.StringValue(c.GetStatus().String()),
-			"last_update_time": types.StringValue(lastUpdate),
-			"reason":           types.StringValue(c.GetReason()),
-			"message":          types.StringValue(c.GetMessage()),
-		})
+	if !preserveStatusFields {
+		condList, diags := conditionsListFromStatus(status.GetConditions())
 		diagnostics.Append(diags...)
-		condVals[i] = condObj
+		m.Conditions = condList
 	}
-	condList, diags := types.ListValue(types.ObjectType{AttrTypes: conditionAttrTypes}, condVals)
-	diagnostics.Append(diags...)
-	m.Conditions = condList
 
 	return diagnostics
 }

--- a/coreweave/inference/resource_inference_gateway_test.go
+++ b/coreweave/inference/resource_inference_gateway_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -744,6 +745,17 @@ func TestInferenceGateway(t *testing.T) {
 					Config: gatewayUpdatedConfig(name, preferredZone),
 					ConfigStateChecks: []statecheck.StateCheck{
 						statecheck.ExpectKnownValue(fullResourceName, tfjsonpath.New("routing").AtMapKey("header_based").AtMapKey("header_name"), knownvalue.StringExact("X-Model-Name")),
+					},
+				},
+				{
+					// Re-applying the identical config after Update must be a no-op:
+					// the preserved server-observed fields (status, updated_at,
+					// conditions) must not produce perpetual plan churn.
+					Config: gatewayUpdatedConfig(name, preferredZone),
+					ConfigPlanChecks: resource.ConfigPlanChecks{
+						PreApply: []plancheck.PlanCheck{
+							plancheck.ExpectResourceAction(fullResourceName, plancheck.ResourceActionNoop),
+						},
 					},
 				},
 				{

--- a/coreweave/inference/resource_inference_gateway_test.go
+++ b/coreweave/inference/resource_inference_gateway_test.go
@@ -5,6 +5,7 @@ import (
 	"math/rand/v2"
 	"regexp"
 	"testing"
+	"time"
 
 	inferencev1 "buf.build/gen/go/coreweave/inference/protocolbuffers/go/coreweave/inference/v1alpha1"
 	"github.com/coreweave/terraform-provider-coreweave/coreweave/inference"
@@ -17,6 +18,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 // --- Unit tests ---
@@ -59,7 +61,7 @@ func TestSetFromGateway_CoreWeaveAuth(t *testing.T) {
 	}
 
 	m := &inference.InferenceGatewayResourceModel{}
-	diags := inference.SetFromGateway(m, gw)
+	diags := inference.SetFromGateway(m, gw, false)
 	if diags.HasError() {
 		t.Fatalf("SetFromGateway returned errors: %v", diags)
 	}
@@ -72,6 +74,85 @@ func TestSetFromGateway_CoreWeaveAuth(t *testing.T) {
 	}
 	if m.ID.ValueString() != "gw-123" {
 		t.Errorf("ID: got %q, want %q", m.ID.ValueString(), "gw-123")
+	}
+}
+
+// TestSetFromGateway_PreserveStatusFields verifies that during Update
+// (preserveStatusFields=true) the observed status fields — status, updated_at,
+// conditions — retain their prior-state values (as carried by the plan via
+// UseStateForUnknown) rather than being overwritten by the fresh API response,
+// while spec fields are still refreshed. Read/Create (preserveStatusFields=false)
+// refresh all fields.
+func TestSetFromGateway_PreserveStatusFields(t *testing.T) {
+	t.Parallel()
+
+	base := func(status inferencev1.Status, name, condReason string, updatedAt *timestamppb.Timestamp) *inferencev1.Gateway {
+		return &inferencev1.Gateway{
+			Spec: &inferencev1.GatewaySpec{
+				Id:             "gw-123",
+				Name:           name,
+				OrganizationId: "org-abc",
+				Zones:          []string{"US-EAST-04A"},
+				Auth: &inferencev1.GatewaySpec_CoreWeaveAuth{
+					CoreWeaveAuth: &inferencev1.CoreWeaveAuth{},
+				},
+				Routing: &inferencev1.GatewaySpec_BodyBasedRouting{
+					BodyBasedRouting: &inferencev1.BodyBasedRouting{
+						ApiType: inferencev1.BodyBasedRouting_API_TYPE_OPENAI,
+					},
+				},
+			},
+			Status: &inferencev1.GatewayStatus{
+				Status:    status,
+				UpdatedAt: updatedAt,
+				Conditions: []*inferencev1.Condition{
+					{Type: "Ready", Status: inferencev1.Condition_STATUS_TRUE, Reason: condReason},
+				},
+			},
+		}
+	}
+
+	prior := base(inferencev1.Status_STATUS_READY, "test-gw", "AsExpected", timestamppb.New(time.Unix(1000, 0).UTC()))
+	fresh := base(inferencev1.Status_STATUS_UPDATING, "test-gw-renamed", "Reconciling", timestamppb.New(time.Unix(2000, 0).UTC()))
+
+	// Seed the model with prior-state values (what the plan holds on Update).
+	m := &inference.InferenceGatewayResourceModel{}
+	if diags := inference.SetFromGateway(m, prior, false); diags.HasError() {
+		t.Fatalf("seed SetFromGateway returned errors: %v", diags)
+	}
+	priorStatus := m.Status
+	priorUpdatedAt := m.UpdatedAt
+	priorConditions := m.Conditions
+
+	// Update path: status fields must be preserved, spec fields refreshed.
+	if diags := inference.SetFromGateway(m, fresh, true); diags.HasError() {
+		t.Fatalf("preserve SetFromGateway returned errors: %v", diags)
+	}
+	if !m.Status.Equal(priorStatus) {
+		t.Errorf("Status: expected preserved %v, got %v", priorStatus, m.Status)
+	}
+	if !m.UpdatedAt.Equal(priorUpdatedAt) {
+		t.Errorf("UpdatedAt: expected preserved %v, got %v", priorUpdatedAt, m.UpdatedAt)
+	}
+	if !m.Conditions.Equal(priorConditions) {
+		t.Errorf("Conditions: expected preserved %v, got %v", priorConditions, m.Conditions)
+	}
+	if m.Name.ValueString() != "test-gw-renamed" {
+		t.Errorf("Name: expected spec to refresh to 'test-gw-renamed', got %q", m.Name.ValueString())
+	}
+
+	// Read path: status fields must refresh from the API response.
+	if diags := inference.SetFromGateway(m, fresh, false); diags.HasError() {
+		t.Fatalf("refresh SetFromGateway returned errors: %v", diags)
+	}
+	if m.Status.ValueString() != inferencev1.Status_STATUS_UPDATING.String() {
+		t.Errorf("Status: expected refreshed %q, got %q", inferencev1.Status_STATUS_UPDATING.String(), m.Status.ValueString())
+	}
+	if m.UpdatedAt.Equal(priorUpdatedAt) {
+		t.Errorf("UpdatedAt: expected refresh to differ from prior %v, got %v", priorUpdatedAt, m.UpdatedAt)
+	}
+	if m.Conditions.Equal(priorConditions) {
+		t.Errorf("Conditions: expected refresh to differ from prior, got %v", m.Conditions)
 	}
 }
 
@@ -115,7 +196,7 @@ func TestSetFromGateway_WeightsAndBiasesAuth(t *testing.T) {
 		},
 	}
 
-	diags := inference.SetFromGateway(m, gw)
+	diags := inference.SetFromGateway(m, gw, false)
 	if diags.HasError() {
 		t.Fatalf("SetFromGateway returned errors: %v", diags)
 	}
@@ -183,7 +264,7 @@ func TestSetFromGateway_NullPreservation(t *testing.T) {
 		EndpointConfiguration: nil,
 	}
 
-	diags := inference.SetFromGateway(m, gw)
+	diags := inference.SetFromGateway(m, gw, false)
 	if diags.HasError() {
 		t.Fatalf("SetFromGateway returned errors: %v", diags)
 	}
@@ -231,7 +312,7 @@ func TestSetFromGateway_BodyBasedRouting(t *testing.T) {
 	}
 
 	m := &inference.InferenceGatewayResourceModel{}
-	diags := inference.SetFromGateway(m, gw)
+	diags := inference.SetFromGateway(m, gw, false)
 	if diags.HasError() {
 		t.Fatalf("SetFromGateway returned errors: %v", diags)
 	}
@@ -273,7 +354,7 @@ func TestSetFromGateway_HeaderBasedRouting(t *testing.T) {
 	}
 
 	m := &inference.InferenceGatewayResourceModel{}
-	diags := inference.SetFromGateway(m, gw)
+	diags := inference.SetFromGateway(m, gw, false)
 	if diags.HasError() {
 		t.Fatalf("SetFromGateway returned errors: %v", diags)
 	}
@@ -313,7 +394,7 @@ func TestSetFromGateway_PathBasedRouting(t *testing.T) {
 	}
 
 	m := &inference.InferenceGatewayResourceModel{}
-	diags := inference.SetFromGateway(m, gw)
+	diags := inference.SetFromGateway(m, gw, false)
 	if diags.HasError() {
 		t.Fatalf("SetFromGateway returned errors: %v", diags)
 	}
@@ -669,6 +750,10 @@ func TestInferenceGateway(t *testing.T) {
 					ResourceName:      fullResourceName,
 					ImportState:       true,
 					ImportStateVerify: true,
+					// Server-observed fields are intentionally not refreshed into state on
+					// Update (see setFromGateway preserveStatusFields); a fresh import Read
+					// legitimately observes newer values, so they can't be verified here.
+					ImportStateVerifyIgnore: []string{"status", "updated_at", "conditions"},
 				},
 			},
 		})


### PR DESCRIPTION
The status, updated_at, and conditions attributes (plus allocated_instances and pending_instances on capacity claims) are server-observed and mutate independently of config. On every plan these showed as "known after apply" churn, and a naive UseStateForUnknown would trip Terraform's plan/apply consistency check because the API returns fresh values during Update.

Add UseStateForUnknown plan modifiers to these computed attributes and make the flatten helpers to leave them untouched during Update (preserveStatusFields), so state keeps the planned prior-state values. Read and Create still refresh them from the API response.