### PR TITLE
feat(cks): add kubelet configuration overrides to cks_cluster

### DIFF
--- a/coreweave/cks/data_source_cluster.go
+++ b/coreweave/cks/data_source_cluster.go
@@ -10,6 +10,7 @@ import (
 	"github.com/coreweave/terraform-provider-coreweave/coreweave"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -179,6 +180,11 @@ func (d *ClusterDataSource) Schema(ctx context.Context, req datasource.SchemaReq
 						Computed:            true,
 					},
 				},
+			},
+			"kubelet": schema.StringAttribute{
+				CustomType:          jsontypes.NormalizedType{},
+				MarkdownDescription: "Selective overrides applied to every cluster Node's kubelet configuration, as a JSON object.",
+				Computed:            true,
 			},
 		},
 	}

--- a/coreweave/cks/resource_cluster.go
+++ b/coreweave/cks/resource_cluster.go
@@ -13,6 +13,7 @@ import (
 	"github.com/coreweave/terraform-provider-coreweave/coreweave"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -31,6 +32,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/zclconf/go-cty/cty"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
+	"google.golang.org/protobuf/types/known/structpb"
 )
 
 const (
@@ -164,6 +166,7 @@ type ClusterResourceModel struct {
 	SharedStorageClusterId      types.String              `tfsdk:"shared_storage_cluster_id"` //nolint:staticcheck
 	AdditionalServerSans        types.Set                 `tfsdk:"additional_server_sans"`
 	Tailscale                   *TailscaleResourceModel   `tfsdk:"tailscale"`
+	Kubelet                     jsontypes.Normalized      `tfsdk:"kubelet"`
 }
 
 func nodePortEmpty(np *cksv1beta1.PortRange) bool {
@@ -321,6 +324,7 @@ func (c *ClusterResourceModel) Set(cluster *cksv1beta1.Cluster) {
 	}
 
 	c.setTailscale(cluster)
+	c.setKubelet(cluster)
 
 	// Note: SharedStorageClusterId is not returned by the API, so we preserve it from the plan.
 	// This is intentional since it's marked as RequiresReplace - Terraform will manage this value.
@@ -332,6 +336,42 @@ func (c *ClusterResourceModel) setTailscale(cluster *cksv1beta1.Cluster) {
 	} else {
 		c.Tailscale = nil
 	}
+}
+
+// setKubelet flattens the API's kubelet override struct into normalized JSON
+// state. When the API returns no overrides we preserve a null value so an unset
+// HCL block does not perpetually diff against an empty object. Normalized JSON
+// state compares semantically, so key ordering differences never produce drift.
+func (c *ClusterResourceModel) setKubelet(cluster *cksv1beta1.Cluster) {
+	if cluster.Kubelet == nil || len(cluster.Kubelet.GetFields()) == 0 {
+		c.Kubelet = jsontypes.NewNormalizedNull()
+		return
+	}
+
+	raw, err := cluster.Kubelet.MarshalJSON()
+	if err != nil {
+		// The value came from the API as a well-formed struct; a marshal failure
+		// here is not actionable by the user, so fall back to null rather than panic.
+		c.Kubelet = jsontypes.NewNormalizedNull()
+		return
+	}
+	c.Kubelet = jsontypes.NewNormalizedValue(string(raw))
+}
+
+// kubeletStruct converts the normalized-JSON kubelet attribute into the
+// *structpb.Struct the API expects. It returns nil when the attribute is unset.
+// The value is validated as a JSON object at plan time (see kubeletValidator),
+// so a parse failure here is not expected in practice.
+func (c *ClusterResourceModel) kubeletStruct() (*structpb.Struct, error) {
+	if c.Kubelet.IsNull() || c.Kubelet.IsUnknown() {
+		return nil, nil
+	}
+
+	s := &structpb.Struct{}
+	if err := s.UnmarshalJSON([]byte(c.Kubelet.ValueString())); err != nil {
+		return nil, err
+	}
+	return s, nil
 }
 
 func (c *ClusterResourceModel) oidcSigningAlgs(ctx context.Context) []cksv1beta1.SigningAlgorithm {
@@ -459,6 +499,12 @@ func (c *ClusterResourceModel) ToCreateRequest(ctx context.Context) *cksv1beta1.
 		req.Tailscale = &cksv1beta1.Tailscale{ClientId: c.Tailscale.ClientID.ValueString()}
 	}
 
+	// Errors are ignored here because the value is validated as a JSON object at
+	// plan time; a nil result simply omits the field from the request.
+	if kubelet, _ := c.kubeletStruct(); kubelet != nil {
+		req.Kubelet = kubelet
+	}
+
 	return req
 }
 
@@ -502,6 +548,52 @@ func authWebhookChanged(plan, state *AuthWebhookResourceModel) bool {
 		return false
 	}
 	return !plan.Server.Equal(state.Server) || !plan.CA.Equal(state.CA)
+}
+
+// kubeletChanged reports whether the kubelet configuration differs between plan
+// and state. It compares JSON semantically so that a re-serialized value with
+// reordered keys (as returned by the API) is not mistaken for a change, which
+// would otherwise trigger an unnecessary Node reboot.
+func kubeletChanged(ctx context.Context, plan, state *ClusterResourceModel) bool {
+	if plan.Kubelet.IsNull() != state.Kubelet.IsNull() {
+		return true
+	}
+	if plan.Kubelet.IsNull() {
+		return false
+	}
+	equal, _ := plan.Kubelet.StringSemanticEquals(ctx, state.Kubelet)
+	return !equal
+}
+
+// kubeletValidator ensures the kubelet attribute is a JSON object, matching the
+// google.protobuf.Struct shape the CKS API expects. jsontypes.Normalized already
+// guarantees the value is syntactically valid JSON; this rejects non-object JSON
+// (arrays, scalars) with a clear error at plan time.
+type kubeletValidator struct{}
+
+var _ validator.String = kubeletValidator{}
+
+func (kubeletValidator) Description(_ context.Context) string {
+	return "must be a JSON object of kubelet configuration overrides"
+}
+
+func (v kubeletValidator) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+func (kubeletValidator) ValidateString(_ context.Context, req validator.StringRequest, resp *validator.StringResponse) {
+	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
+		return
+	}
+
+	s := &structpb.Struct{}
+	if err := s.UnmarshalJSON([]byte(req.ConfigValue.ValueString())); err != nil {
+		resp.Diagnostics.AddAttributeError(
+			req.Path,
+			"Invalid kubelet configuration",
+			fmt.Sprintf("The kubelet value must be a JSON object of kubelet configuration overrides: %s", err),
+		)
+	}
 }
 
 // buildUpdateRequest constructs an UpdateClusterRequest containing only the fields
@@ -597,6 +689,15 @@ func buildUpdateRequest(ctx context.Context, plan, state *ClusterResourceModel) 
 			req.Tailscale = &cksv1beta1.Tailscale{}
 		}
 		paths = append(paths, "tailscale.client_id")
+	}
+
+	if kubeletChanged(ctx, plan, state) {
+		// A nil struct clears the overrides; the mask path signals the change
+		// either way. Errors are ignored because the value is validated at plan time.
+		if kubelet, _ := plan.kubeletStruct(); kubelet != nil {
+			req.Kubelet = kubelet
+		}
+		paths = append(paths, "kubelet")
 	}
 
 	req.UpdateMask = &fieldmaskpb.FieldMask{Paths: paths}
@@ -964,6 +1065,14 @@ func (r *ClusterResource) Schema(ctx context.Context, req resource.SchemaRequest
 					},
 				},
 			},
+			"kubelet": schema.StringAttribute{
+				CustomType:          jsontypes.NormalizedType{},
+				Optional:            true,
+				MarkdownDescription: "Selective overrides applied to every cluster Node's kubelet configuration, as a JSON object (e.g. `jsonencode({ maxPods = 256 })`). A Node reboot is required for changes to take effect, and unknown options are stored but ignored by CKS. See the [Kubernetes kubelet configuration reference](https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/) for supported options.",
+				Validators: []validator.String{
+					kubeletValidator{},
+				},
+			},
 		},
 	}
 }
@@ -1291,6 +1400,10 @@ func MustRenderClusterResource(ctx context.Context, resourceName string, cluster
 		resourceBody.SetAttributeValue("tailscale", cty.ObjectVal(map[string]cty.Value{
 			"client_id": cty.StringVal(cluster.Tailscale.ClientID.ValueString()),
 		}))
+	}
+
+	if !cluster.Kubelet.IsNull() && !cluster.Kubelet.IsUnknown() {
+		resourceBody.SetAttributeValue("kubelet", cty.StringVal(cluster.Kubelet.ValueString()))
 	}
 
 	var buf bytes.Buffer

--- a/coreweave/cks/resource_cluster.go
+++ b/coreweave/cks/resource_cluster.go
@@ -565,10 +565,10 @@ func kubeletChanged(ctx context.Context, plan, state *ClusterResourceModel) bool
 	return !equal
 }
 
-// kubeletValidator ensures the kubelet attribute is a JSON object, matching the
-// google.protobuf.Struct shape the CKS API expects. jsontypes.Normalized already
-// guarantees the value is syntactically valid JSON; this rejects non-object JSON
-// (arrays, scalars) with a clear error at plan time.
+// kubeletValidator ensures the kubelet attribute is a non-empty JSON object,
+// matching the google.protobuf.Struct shape the CKS API expects. jsontypes.Normalized
+// already guarantees the value is syntactically valid JSON; this rejects non-object
+// JSON (arrays, scalars) and empty objects with a clear error at plan time.
 type kubeletValidator struct{}
 
 var _ validator.String = kubeletValidator{}
@@ -592,6 +592,15 @@ func (kubeletValidator) ValidateString(_ context.Context, req validator.StringRe
 			req.Path,
 			"Invalid kubelet configuration",
 			fmt.Sprintf("The kubelet value must be a JSON object of kubelet configuration overrides: %s", err),
+		)
+		return
+	}
+
+	if len(s.GetFields()) == 0 {
+		resp.Diagnostics.AddAttributeError(
+			req.Path,
+			"Invalid kubelet configuration",
+			"The kubelet value must be a non-empty JSON object of kubelet configuration overrides; remove the attribute instead of setting it to an empty object.",
 		)
 	}
 }

--- a/coreweave/cks/resource_cluster_test.go
+++ b/coreweave/cks/resource_cluster_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/coreweave/terraform-provider-coreweave/internal/provider"
 	"github.com/coreweave/terraform-provider-coreweave/internal/testutil"
 	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	fwresource "github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -829,6 +830,99 @@ func TestClusterResource_Tailscale(t *testing.T) {
 		{
 			PreConfig: func() {
 				t.Log("Beginning coreweave_cks_cluster import test (tailscale)")
+			},
+			ResourceName:      config.FullResourceName,
+			ImportState:       true,
+			ImportStateVerify: true,
+		},
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: provider.TestProtoV6ProviderFactories,
+		PreCheck: func() {
+			testutil.SetEnvDefaults()
+		},
+		Steps: steps,
+	})
+}
+
+func TestClusterResource_Kubelet(t *testing.T) {
+	config := generateResourceNames("cks-kubelet")
+	zone := testutil.AcceptanceTestZone
+	kubeVersion := testutil.AcceptanceTestKubeVersion
+
+	vpc := defaultVpc(config.ClusterName, zone)
+
+	base := &cks.ClusterResourceModel{
+		VpcId:               types.StringValue(fmt.Sprintf("coreweave_networking_vpc.%s.id", config.ResourceName)),
+		Name:                types.StringValue(config.ClusterName),
+		Zone:                types.StringValue(zone),
+		Version:             types.StringValue(kubeVersion),
+		Public:              types.BoolValue(false),
+		PodCidrName:         types.StringValue("pod-cidr"),
+		ServiceCidrName:     types.StringValue("service-cidr"),
+		InternalLBCidrNames: types.ListValueMust(types.StringType, []attr.Value{types.StringValue("internal-lb-cidr")}),
+	}
+
+	withKubelet := with(*base, func(c *cks.ClusterResourceModel) {
+		c.Kubelet = jsontypes.NewNormalizedValue(`{"maxPods":256}`)
+	})
+
+	ctx := t.Context()
+
+	steps := []resource.TestStep{
+		// Step 1: create without kubelet overrides
+		createClusterTestStep(ctx, t, testStepConfig{
+			TestName: "create without kubelet",
+			ConfigPlanChecks: resource.ConfigPlanChecks{
+				PreApply: []plancheck.PlanCheck{
+					plancheck.ExpectResourceAction(config.FullResourceName, plancheck.ResourceActionCreate),
+				},
+			},
+			Resources: config,
+			cluster:   *base,
+			vpc:       *vpc,
+		}),
+		// Step 2: add kubelet overrides
+		createClusterTestStep(ctx, t, testStepConfig{
+			TestName: "add kubelet maxPods",
+			ConfigPlanChecks: resource.ConfigPlanChecks{
+				PreApply: []plancheck.PlanCheck{
+					plancheck.ExpectResourceAction(config.FullResourceName, plancheck.ResourceActionUpdate),
+				},
+			},
+			Resources: config,
+			cluster:   withKubelet,
+			vpc:       *vpc,
+		}),
+		// Step 3: reapply same config — expect noop (semantic JSON roundtrip)
+		{
+			PreConfig: func() {
+				t.Log("Reapplying kubelet config to verify noop (roundtrip)")
+			},
+			Config: networking.MustRenderVpcResource(ctx, config.ResourceName, vpc) + "\n" + cks.MustRenderClusterResource(ctx, config.ResourceName, &withKubelet),
+			ConfigPlanChecks: resource.ConfigPlanChecks{
+				PreApply: []plancheck.PlanCheck{
+					plancheck.ExpectResourceAction(config.FullResourceName, plancheck.ResourceActionNoop),
+				},
+			},
+		},
+		// Step 4: remove kubelet block
+		createClusterTestStep(ctx, t, testStepConfig{
+			TestName: "remove kubelet block",
+			ConfigPlanChecks: resource.ConfigPlanChecks{
+				PreApply: []plancheck.PlanCheck{
+					plancheck.ExpectResourceAction(config.FullResourceName, plancheck.ResourceActionUpdate),
+				},
+			},
+			Resources: config,
+			cluster:   *base,
+			vpc:       *vpc,
+		}),
+		// Step 5: import verify
+		{
+			PreConfig: func() {
+				t.Log("Beginning coreweave_cks_cluster import test (kubelet)")
 			},
 			ResourceName:      config.FullResourceName,
 			ImportState:       true,

--- a/coreweave/cks/update_mask_test.go
+++ b/coreweave/cks/update_mask_test.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -331,5 +333,14 @@ func TestBuildUpdateRequest(t *testing.T) {
 			t.Error("expected nil kubelet when semantically unchanged")
 		}
 		expectMaskPaths(t, req.UpdateMask.Paths)
+	})
+
+	t.Run("empty object is rejected", func(t *testing.T) {
+		req := validator.StringRequest{Path: path.Root("kubelet"), ConfigValue: types.StringValue(`{}`)}
+		resp := &validator.StringResponse{}
+		kubeletValidator{}.ValidateString(ctx, req, resp)
+		if !resp.Diagnostics.HasError() {
+			t.Error("expected an error for an empty kubelet object, got none")
+		}
 	})
 }

--- a/coreweave/cks/update_mask_test.go
+++ b/coreweave/cks/update_mask_test.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
@@ -31,6 +32,7 @@ func TestBuildUpdateRequest(t *testing.T) {
 			}),
 			AuditPolicy:          types.StringNull(),
 			AdditionalServerSans: types.SetNull(types.StringType),
+			Kubelet:              jsontypes.NewNormalizedNull(),
 		}
 	}
 
@@ -276,5 +278,58 @@ func TestBuildUpdateRequest(t *testing.T) {
 			t.Error("expected nil network when only version/public/audit_policy changed")
 		}
 		expectMaskPaths(t, req.UpdateMask.Paths, "audit_policy", "public", "version")
+	})
+
+	t.Run("kubelet added", func(t *testing.T) {
+		state := baseModel()
+		plan := baseModel()
+		plan.Kubelet = jsontypes.NewNormalizedValue(`{"maxPods":256}`)
+		req := buildUpdateRequest(ctx, &plan, &state)
+		if req.Kubelet == nil {
+			t.Fatal("expected non-nil kubelet")
+		}
+		if got := req.Kubelet.GetFields()["maxPods"].GetNumberValue(); got != 256 {
+			t.Errorf("expected maxPods=256, got %v", got)
+		}
+		if req.Network != nil {
+			t.Error("expected nil network on kubelet-only change")
+		}
+		expectMaskPaths(t, req.UpdateMask.Paths, "kubelet")
+	})
+
+	t.Run("kubelet changed", func(t *testing.T) {
+		state := baseModel()
+		state.Kubelet = jsontypes.NewNormalizedValue(`{"maxPods":110}`)
+		plan := baseModel()
+		plan.Kubelet = jsontypes.NewNormalizedValue(`{"maxPods":256}`)
+		req := buildUpdateRequest(ctx, &plan, &state)
+		if req.Kubelet == nil {
+			t.Fatal("expected non-nil kubelet")
+		}
+		expectMaskPaths(t, req.UpdateMask.Paths, "kubelet")
+	})
+
+	t.Run("kubelet removed clears field but sets mask", func(t *testing.T) {
+		state := baseModel()
+		state.Kubelet = jsontypes.NewNormalizedValue(`{"maxPods":256}`)
+		plan := baseModel()
+		req := buildUpdateRequest(ctx, &plan, &state)
+		if req.Kubelet != nil {
+			t.Error("expected nil kubelet when removing overrides")
+		}
+		expectMaskPaths(t, req.UpdateMask.Paths, "kubelet")
+	})
+
+	t.Run("kubelet semantically equal produces no change", func(t *testing.T) {
+		state := baseModel()
+		state.Kubelet = jsontypes.NewNormalizedValue(`{"maxPods":256}`)
+		plan := baseModel()
+		// Same object, different key order/whitespace as the API might return.
+		plan.Kubelet = jsontypes.NewNormalizedValue(`{ "maxPods": 256 }`)
+		req := buildUpdateRequest(ctx, &plan, &state)
+		if req.Kubelet != nil {
+			t.Error("expected nil kubelet when semantically unchanged")
+		}
+		expectMaskPaths(t, req.UpdateMask.Paths)
 	})
 }

--- a/docs/data-sources/cks_cluster.md
+++ b/docs/data-sources/cks_cluster.md
@@ -34,6 +34,7 @@ data "coreweave_cks_cluster" "default" {
 - `authz_webhook` (Attributes) The authorization webhook configuration of the cluster. (see [below for nested schema](#nestedatt--authz_webhook))
 - `internal_lb_cidr_names` (List of String) The internal load balancer CIDR names of the cluster.
 - `internal_lb_cidr_names_v6` (List of String) The IPv6 internal load balancer CIDR names of the cluster.
+- `kubelet` (String) Selective overrides applied to every cluster Node's kubelet configuration, as a JSON object.
 - `name` (String) The name of the cluster.
 - `node_port_range` (Attributes) The Kubernetes Service NodePort range. (see [below for nested schema](#nestedatt--node_port_range))
 - `oidc` (Attributes) The OIDC configuration of the cluster. (see [below for nested schema](#nestedatt--oidc))

--- a/docs/resources/cks_cluster.md
+++ b/docs/resources/cks_cluster.md
@@ -51,6 +51,7 @@ resource "coreweave_cks_cluster" "default" {
   service_cidr_name      = "service cidr"
   internal_lb_cidr_names = ["internal lb cidr"]
   audit_policy           = filebase64("${path.module}/audit-policy.yaml")
+  kubelet                = jsonencode({ maxPods = 256 })
   oidc = {
     ca              = filebase64("${path.module}/example-ca.crt")
     client_id       = "kbyuFDidLLm280LIwVFiazOqjO3ty8KH"
@@ -94,6 +95,7 @@ The prefixes must exist in the cluster's VPC. This field is append-only.
 - `authn_webhook` (Attributes) Authentication webhook configuration for the cluster. (see [below for nested schema](#nestedatt--authn_webhook))
 - `authz_webhook` (Attributes) Authorization webhook configuration for the cluster. (see [below for nested schema](#nestedatt--authz_webhook))
 - `internal_lb_cidr_names_v6` (List of String) IPv6 Internal Load Balancer CIDR names. If any IPv6 field is set, then ALL IPv6 fields must be set.
+- `kubelet` (String) Selective overrides applied to every cluster Node's kubelet configuration, as a JSON object (e.g. `jsonencode({ maxPods = 256 })`). A Node reboot is required for changes to take effect, and unknown options are stored but ignored by CKS. See the [Kubernetes kubelet configuration reference](https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/) for supported options.
 - `node_port_range` (Attributes) Kubernetes Service NodePort range. NodePort range can be expanded in existing clusters but not shrunk. Updating the NodePort range to a smaller range will require a replacement of the cluster. (see [below for nested schema](#nestedatt--node_port_range))
 - `oidc` (Attributes) OpenID Connect (OIDC) configuration for authentication to the api-server. (see [below for nested schema](#nestedatt--oidc))
 - `pod_cidr_name_v6` (String) IPv6 Pod CIDR name. If any IPv6 field is set, then ALL IPv6 fields must be set.

--- a/examples/resources/coreweave_cks_cluster/resource.tf
+++ b/examples/resources/coreweave_cks_cluster/resource.tf
@@ -36,6 +36,7 @@ resource "coreweave_cks_cluster" "default" {
   service_cidr_name      = "service cidr"
   internal_lb_cidr_names = ["internal lb cidr"]
   audit_policy           = filebase64("${path.module}/audit-policy.yaml")
+  kubelet                = jsonencode({ maxPods = 256 })
   oidc = {
     ca              = filebase64("${path.module}/example-ca.crt")
     client_id       = "kbyuFDidLLm280LIwVFiazOqjO3ty8KH"

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/hashicorp/go-uuid v1.0.3
 	github.com/hashicorp/hcl/v2 v2.24.0
 	github.com/hashicorp/terraform-plugin-framework v1.15.1
+	github.com/hashicorp/terraform-plugin-framework-jsontypes v0.2.0
 	github.com/hashicorp/terraform-plugin-framework-nettypes v0.3.0
 	github.com/hashicorp/terraform-plugin-framework-validators v0.18.0
 	github.com/hashicorp/terraform-plugin-go v0.29.0

--- a/go.sum
+++ b/go.sum
@@ -146,6 +146,8 @@ github.com/hashicorp/terraform-json v0.27.1 h1:zWhEracxJW6lcjt/JvximOYyc12pS/gaK
 github.com/hashicorp/terraform-json v0.27.1/go.mod h1:GzPLJ1PLdUG5xL6xn1OXWIjteQRT2CNT9o/6A9mi9hE=
 github.com/hashicorp/terraform-plugin-framework v1.15.1 h1:2mKDkwb8rlx/tvJTlIcpw0ykcmvdWv+4gY3SIgk8Pq8=
 github.com/hashicorp/terraform-plugin-framework v1.15.1/go.mod h1:hxrNI/GY32KPISpWqlCoTLM9JZsGH3CyYlir09bD/fI=
+github.com/hashicorp/terraform-plugin-framework-jsontypes v0.2.0 h1:SJXL5FfJJm17554Kpt9jFXngdM6fXbnUnZ6iT2IeiYA=
+github.com/hashicorp/terraform-plugin-framework-jsontypes v0.2.0/go.mod h1:p0phD0IYhsu9bR4+6OetVvvH59I6LwjXGnTVEr8ox6E=
 github.com/hashicorp/terraform-plugin-framework-nettypes v0.3.0 h1:cEiRvdFAhFnivRm9JI/8l2g8oruzkioUAwItkEM7bmU=
 github.com/hashicorp/terraform-plugin-framework-nettypes v0.3.0/go.mod h1:SDIm7W2x3Bs9otNC0ysbaSQ7H4H/EPimoACTy+7Z9rU=
 github.com/hashicorp/terraform-plugin-framework-validators v0.18.0 h1:OQnlOt98ua//rCw+QhBbSqfW3QbwtVrcdWeQN5gI3Hw=


### PR DESCRIPTION
## What

Adds a new optional `kubelet` attribute to the `coreweave_cks_cluster` resource (and the corresponding read-only attribute on the data source), exposing the CKS API's cluster-level kubelet override field.

This lets operators set kubelet options such as `maxPods`:

```hcl
resource "coreweave_cks_cluster" "example" {
  # ...
  kubelet = jsonencode({ maxPods = 256 })
}
```

## Why

The CKS API and proto (`Cluster`/`CreateClusterRequest`/`UpdateClusterRequest`) already carry a `kubelet` field (`google.protobuf.Struct`, "selective overrides applied to every cluster Node's kubelet configuration"), but the Terraform provider never surfaced it — so there was no way to set things like `maxPods` from Terraform. This closes that gap.

## Details

- **Type:** the attribute is a normalized-JSON string (`jsontypes.Normalized`). This is the natural fit for the arbitrary-JSON `structpb.Struct` field and, crucially, compares JSON **semantically** — so a value the API re-serializes with reordered keys does not produce a spurious diff (and therefore no unnecessary Node reboot, which the API requires on kubelet changes).
- **Validation:** a plan-time validator rejects non-object JSON (arrays/scalars) with a clear error, since the API expects an object.
- **Wiring:** threaded through create, update (adds the `kubelet` field-mask path, only when the value semantically changed), and read/flatten. Unset ⇄ null is preserved so an omitted block never drifts.
- **Data source:** the resource and data source share one model (`ClusterDataSourceModel = ClusterResourceModel`), so the field is also added (read-only) to the data source schema and its docs — required for the shared model to map cleanly.

## Testing

- `go build ./...`, `go vet ./...`, `gofmt` — all clean.
- `go test ./coreweave/cks/` — passes. Added unit coverage to `TestBuildUpdateRequest` (kubelet added / changed / removed / semantically-equal-noop) and a `TestClusterResource_Kubelet` acceptance test (create → add → reapply-noop → remove → import verify), mirroring the existing Tailscale test.
- Docs regenerated by hand to match `tfplugindocs` output (Terraform isn't available in my environment to run `make generate`); please re-run `make generate` in CI/locally to confirm no drift.

## Notes

- Adds one dependency: `github.com/hashicorp/terraform-plugin-framework-jsontypes` (official HashiCorp helper; the repo already uses the sibling `-nettypes`).
