### PR TITLE
feat(inference): support runtime engine env

### DIFF
--- a/coreweave/inference/data_source_inference_deployment_parameters.go
+++ b/coreweave/inference/data_source_inference_deployment_parameters.go
@@ -28,6 +28,7 @@ type InferenceDeploymentParametersDataSourceModel struct {
 	GatewayIds           types.Set `tfsdk:"gateway_ids"`
 	RuntimeVersions      types.Map `tfsdk:"runtime_versions"`
 	RuntimeConfigOptions types.Map `tfsdk:"runtime_config_options"`
+	EngineEnvOptions     types.Map `tfsdk:"engine_env_options"`
 	InstanceTypes        types.Set `tfsdk:"instance_types"`
 }
 
@@ -38,6 +39,10 @@ var (
 
 	runtimeConfigOptionsAttrTypes = map[string]attr.Type{
 		"allowed_keys": types.ListType{ElemType: types.StringType},
+	}
+
+	engineEnvOptionsAttrTypes = map[string]attr.Type{
+		"allowed_names": types.ListType{ElemType: types.StringType},
 	}
 )
 
@@ -76,6 +81,19 @@ func (d *InferenceDeploymentParametersDataSource) Schema(_ context.Context, _ da
 							Computed:            true,
 							ElementType:         types.StringType,
 							MarkdownDescription: "Configuration keys accepted by the engine's `engine_config` field.",
+						},
+					},
+				},
+			},
+			"engine_env_options": schema.MapNestedAttribute{
+				Computed:            true,
+				MarkdownDescription: "Available engine environment variable options per engine (keyed by engine name).",
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"allowed_names": schema.ListAttribute{
+							Computed:            true,
+							ElementType:         types.StringType,
+							MarkdownDescription: "Environment variable names accepted by the engine's `engine_env` field.",
 						},
 					},
 				},
@@ -163,6 +181,26 @@ func (d *InferenceDeploymentParametersDataSource) Read(ctx context.Context, _ da
 		}
 	}
 	data.RuntimeConfigOptions = types.MapValueMust(types.ObjectType{AttrTypes: runtimeConfigOptionsAttrTypes}, rcoMap)
+
+	// engine_env_options: map[string]object{allowed_names: list[string]}
+	eeoMap := make(map[string]attr.Value)
+	if rp := msg.GetRuntimeParameters(); rp != nil {
+		for engine, eeo := range rp.GetEngineEnvOptions() {
+			nameVals := make([]attr.Value, len(eeo.GetAllowedNames()))
+			for i, name := range eeo.GetAllowedNames() {
+				nameVals[i] = types.StringValue(name)
+			}
+			obj, diags := types.ObjectValue(engineEnvOptionsAttrTypes, map[string]attr.Value{
+				"allowed_names": types.ListValueMust(types.StringType, nameVals),
+			})
+			resp.Diagnostics.Append(diags...)
+			if resp.Diagnostics.HasError() {
+				return
+			}
+			eeoMap[engine] = obj
+		}
+	}
+	data.EngineEnvOptions = types.MapValueMust(types.ObjectType{AttrTypes: engineEnvOptionsAttrTypes}, eeoMap)
 
 	// instance_types
 	var instanceTypeVals []attr.Value

--- a/coreweave/inference/resource_inference_capacity_claim.go
+++ b/coreweave/inference/resource_inference_capacity_claim.go
@@ -9,7 +9,6 @@ import (
 	inferencev1 "buf.build/gen/go/coreweave/inference/protocolbuffers/go/coreweave/inference/v1alpha1"
 	"connectrpc.com/connect"
 	"github.com/coreweave/terraform-provider-coreweave/coreweave"
-	cwvalidators "github.com/coreweave/terraform-provider-coreweave/internal/validators"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -167,17 +166,10 @@ func (r *InferenceCapacityClaimResource) Schema(_ context.Context, _ resource.Sc
 					},
 					"capacity_type": schema.StringAttribute{
 						Required:            true,
-						MarkdownDescription: fmt.Sprintf("The [capacity type](https://docs.coreweave.com/products/inference/scaling#capacity-claims) for the capacity claim. Must be one of: %s. `CAPACITY_TYPE_SERVERLESS` is deprecated and is no longer accepted. Existing claims were automatically migrated to `CAPACITY_TYPE_MANAGED`; update your configuration to use `CAPACITY_TYPE_MANAGED`.", coreweave.EnumMarkdownValuesExcludingDeprecated(inferencev1.CapacityType_CAPACITY_TYPE_MANAGED.Descriptor())),
+						MarkdownDescription: fmt.Sprintf("The [capacity type](https://docs.coreweave.com/products/inference/scaling#capacity-claims) for the capacity claim. Must be one of: %s.", coreweave.EnumMarkdownValuesExcludingDeprecated(inferencev1.CapacityType_CAPACITY_TYPE_MANAGED.Descriptor())),
 						PlanModifiers:       []planmodifier.String{stringplanmodifier.RequiresReplace()},
 						Validators: []validator.String{
 							stringvalidator.OneOf(coreweave.EnumValues(inferencev1.CapacityType_name, true)...),
-							// Reject deprecated values (e.g. CAPACITY_TYPE_SERVERLESS) at plan
-							// time: the API rejects them, and with RequiresReplace a deprecated
-							// value would otherwise produce a destructive, non-convergent plan.
-							cwvalidators.RejectDeprecatedEnumValue(
-								inferencev1.CapacityType_CAPACITY_TYPE_MANAGED.Descriptor(),
-								`Change capacity_type to CAPACITY_TYPE_MANAGED. Existing claims were automatically migrated; no replacement will be triggered.`,
-							),
 						},
 					},
 					"zones": schema.SetAttribute{

--- a/coreweave/inference/resource_inference_deployment.go
+++ b/coreweave/inference/resource_inference_deployment.go
@@ -112,6 +112,7 @@ type RuntimeModel struct {
 	Engine       types.String `tfsdk:"engine"`
 	Version      types.String `tfsdk:"version"`
 	EngineConfig types.Map    `tfsdk:"engine_config"`
+	EngineEnv    types.Map    `tfsdk:"engine_env"`
 }
 
 type ResourcesModel struct {
@@ -274,6 +275,11 @@ func (r *InferenceDeploymentResource) Schema(_ context.Context, _ resource.Schem
 						ElementType:         types.StringType,
 						Optional:            true,
 						MarkdownDescription: "Engine-specific configuration key/value pairs.",
+					},
+					"engine_env": schema.MapAttribute{
+						ElementType:         types.StringType,
+						Optional:            true,
+						MarkdownDescription: "Engine-specific environment variables to inject into the model runtime container. Variable names must come from the selected engine's server-side allow list, exposed by `data.coreweave_inference_deployment_parameters.<name>.engine_env_options[<engine>].allowed_names`; unsupported names are rejected by the API.",
 					},
 				},
 			},
@@ -712,6 +718,14 @@ func buildDeploymentFields(ctx context.Context, m *InferenceDeploymentResourceMo
 		}
 		f.Runtime.EngineConfig = ec
 	}
+	if !m.Runtime.EngineEnv.IsNull() && !m.Runtime.EngineEnv.IsUnknown() {
+		ee := map[string]string{}
+		diagnostics.Append(m.Runtime.EngineEnv.ElementsAs(ctx, &ee, false)...)
+		if diagnostics.HasError() {
+			return deploymentFields{}, diagnostics
+		}
+		f.Runtime.EngineEnv = ee
+	}
 	if !m.Autoscaling.Priority.IsNull() && !m.Autoscaling.Priority.IsUnknown() {
 		f.Autoscaling.Priority = uint32(m.Autoscaling.Priority.ValueInt64()) //nolint:gosec
 	}
@@ -779,7 +793,11 @@ func toUpdateRequest(ctx context.Context, m *InferenceDeploymentResourceModel) (
 // preservation checks in setFromDeployment behave correctly on first import.
 func ensureDeploymentNested(m *InferenceDeploymentResourceModel) {
 	if m.Runtime == nil {
-		m.Runtime = &RuntimeModel{Version: types.StringNull(), EngineConfig: types.MapNull(types.StringType)}
+		m.Runtime = &RuntimeModel{
+			Version:      types.StringNull(),
+			EngineConfig: types.MapNull(types.StringType),
+			EngineEnv:    types.MapNull(types.StringType),
+		}
 	}
 	if m.Resources == nil {
 		m.Resources = &ResourcesModel{}
@@ -797,6 +815,42 @@ func ensureDeploymentNested(m *InferenceDeploymentResourceModel) {
 	if m.Traffic == nil {
 		m.Traffic = &TrafficModel{Weight: types.Int64Null()}
 	}
+}
+
+func stringMapFromProtoPreservingNull(current types.Map, values map[string]string) (types.Map, diag.Diagnostics) {
+	var diagnostics diag.Diagnostics
+
+	if current.IsNull() && len(values) == 0 {
+		return types.MapNull(types.StringType), diagnostics
+	}
+
+	mapVals := make(map[string]attr.Value, len(values))
+	for k, v := range values {
+		mapVals[k] = types.StringValue(v)
+	}
+	result, diags := types.MapValue(types.StringType, mapVals)
+	diagnostics.Append(diags...)
+	return result, diagnostics
+}
+
+func setRuntimeFromDeployment(m *RuntimeModel, rt *inferencev1.DeploymentRuntime) (diagnostics diag.Diagnostics) {
+	m.Engine = types.StringValue(rt.GetEngine())
+
+	if (m.Version.IsNull() || m.Version.IsUnknown()) && rt.GetVersion() == "" {
+		m.Version = types.StringNull()
+	} else {
+		m.Version = types.StringValue(rt.GetVersion())
+	}
+
+	engineConfig, diags := stringMapFromProtoPreservingNull(m.EngineConfig, rt.GetEngineConfig())
+	diagnostics.Append(diags...)
+	m.EngineConfig = engineConfig
+
+	engineEnv, diags := stringMapFromProtoPreservingNull(m.EngineEnv, rt.GetEngineEnv())
+	diagnostics.Append(diags...)
+	m.EngineEnv = engineEnv
+
+	return diagnostics
 }
 
 // setFromDeployment populates all fields on the model from a proto Deployment response.
@@ -844,25 +898,7 @@ func setFromDeployment(m *InferenceDeploymentResourceModel, d *inferencev1.Deplo
 
 	// runtime
 	if rt := spec.GetRuntime(); rt != nil {
-		m.Runtime.Engine = types.StringValue(rt.GetEngine())
-
-		if (m.Runtime.Version.IsNull() || m.Runtime.Version.IsUnknown()) && rt.GetVersion() == "" {
-			m.Runtime.Version = types.StringNull()
-		} else {
-			m.Runtime.Version = types.StringValue(rt.GetVersion())
-		}
-
-		if m.Runtime.EngineConfig.IsNull() && len(rt.GetEngineConfig()) == 0 {
-			m.Runtime.EngineConfig = types.MapNull(types.StringType)
-		} else {
-			ecVals := make(map[string]attr.Value, len(rt.GetEngineConfig()))
-			for k, v := range rt.GetEngineConfig() {
-				ecVals[k] = types.StringValue(v)
-			}
-			ecMap, diags := types.MapValue(types.StringType, ecVals)
-			diagnostics.Append(diags...)
-			m.Runtime.EngineConfig = ecMap
-		}
+		diagnostics.Append(setRuntimeFromDeployment(m.Runtime, rt)...)
 	}
 
 	// resources

--- a/coreweave/inference/resource_inference_deployment_test.go
+++ b/coreweave/inference/resource_inference_deployment_test.go
@@ -22,6 +22,11 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
+const (
+	acceptanceEngineEnvName  = "VLLM_USE_FLASHINFER_MOE_FP4"
+	acceptanceEngineEnvValue = "0"
+)
+
 // --- Unit tests for pure helper functions ---
 
 func TestInferenceDeployment_Schema(t *testing.T) {
@@ -140,6 +145,7 @@ func TestInferenceDeployment_SetFromDeployment_NullPreservation(t *testing.T) {
 		Runtime: &inference.RuntimeModel{
 			Version:      types.StringNull(),
 			EngineConfig: types.MapNull(types.StringType),
+			EngineEnv:    types.MapNull(types.StringType),
 		},
 		Autoscaling: &inference.AutoscalingModel{
 			Priority:        types.Int64Null(),
@@ -159,6 +165,9 @@ func TestInferenceDeployment_SetFromDeployment_NullPreservation(t *testing.T) {
 	}
 	if !m.Runtime.EngineConfig.IsNull() {
 		t.Errorf("Runtime.EngineConfig: expected null when API returns empty map, got %v", m.Runtime.EngineConfig)
+	}
+	if !m.Runtime.EngineEnv.IsNull() {
+		t.Errorf("Runtime.EngineEnv: expected null when API returns empty map, got %v", m.Runtime.EngineEnv)
 	}
 	if !m.Autoscaling.Priority.IsNull() {
 		t.Errorf("Autoscaling.Priority: expected null when API returns 0, got %v", m.Autoscaling.Priority)
@@ -269,6 +278,63 @@ func TestSetFromDeployment_PreserveStatusFields(t *testing.T) {
 	}
 }
 
+func TestInferenceDeployment_SetFromDeployment_RuntimeMaps(t *testing.T) {
+	t.Parallel()
+
+	d := &inferencev1.Deployment{
+		Spec: &inferencev1.DeploymentSpec{
+			Id:   "test-id",
+			Name: "my-llm",
+			Runtime: &inferencev1.DeploymentRuntime{
+				Engine: "vllm",
+				EngineEnv: map[string]string{
+					"VLLM_LOGGING_LEVEL": "INFO",
+				},
+			},
+			Resources: &inferencev1.DeploymentResources{
+				InstanceType: "H100_80GB_SXM5",
+				GpuCount:     1,
+			},
+			Model: &inferencev1.DeploymentModel{
+				Name:   "meta-llama/Llama-3.1-8B",
+				Bucket: "my-bucket",
+				Path:   "models/llama",
+			},
+			Autoscaling: &inferencev1.DeploymentAutoscaling{
+				Min: 1,
+				Max: 4,
+			},
+		},
+		Status: &inferencev1.DeploymentStatus{
+			Status: inferencev1.Status_STATUS_READY,
+		},
+	}
+
+	m := &inference.InferenceDeploymentResourceModel{
+		Runtime: &inference.RuntimeModel{
+			Version:      types.StringNull(),
+			EngineConfig: types.MapNull(types.StringType),
+			EngineEnv:    types.MapNull(types.StringType),
+		},
+		Autoscaling: &inference.AutoscalingModel{
+			Priority:        types.Int64Null(),
+			CapacityClasses: types.ListNull(types.StringType),
+			Concurrency:     types.Int64Null(),
+		},
+	}
+
+	inference.SetFromDeployment(m, d, false)
+
+	var engineEnv map[string]string
+	diags := m.Runtime.EngineEnv.ElementsAs(t.Context(), &engineEnv, false)
+	if diags.HasError() {
+		t.Fatalf("EngineEnv ElementsAs returned errors: %v", diags)
+	}
+	if got := engineEnv["VLLM_LOGGING_LEVEL"]; got != "INFO" {
+		t.Errorf("Runtime.EngineEnv[\"VLLM_LOGGING_LEVEL\"]: got %q, want 'INFO'", got)
+	}
+}
+
 func TestInferenceDeployment_ToCreateRequest_OptionalFields(t *testing.T) {
 	t.Parallel()
 
@@ -283,6 +349,7 @@ func TestInferenceDeployment_ToCreateRequest_OptionalFields(t *testing.T) {
 			Engine:       types.StringValue("vllm"),
 			Version:      types.StringNull(),
 			EngineConfig: types.MapNull(types.StringType),
+			EngineEnv:    types.MapNull(types.StringType),
 		},
 		Resources: &inference.ResourcesModel{
 			InstanceType: types.StringValue("H100_80GB_SXM5"),
@@ -319,6 +386,9 @@ func TestInferenceDeployment_ToCreateRequest_OptionalFields(t *testing.T) {
 	if len(req.Runtime.EngineConfig) != 0 {
 		t.Errorf("Runtime.EngineConfig: expected empty map, got %v", req.Runtime.EngineConfig)
 	}
+	if len(req.Runtime.EngineEnv) != 0 {
+		t.Errorf("Runtime.EngineEnv: expected empty map, got %v", req.Runtime.EngineEnv)
+	}
 	if req.Autoscaling.Priority != 0 {
 		t.Errorf("Autoscaling.Priority: expected 0 when null, got %d", req.Autoscaling.Priority)
 	}
@@ -336,6 +406,9 @@ func TestInferenceDeployment_ToUpdateRequest_Fields(t *testing.T) {
 	ctx := t.Context()
 	gwIds := types.SetValueMust(types.StringType, []attr.Value{types.StringValue("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")})
 	ccList, _ := types.ListValueFrom(ctx, types.StringType, []string{"CAPACITY_CLASS_RESERVED"})
+	engineEnv := types.MapValueMust(types.StringType, map[string]attr.Value{
+		"VLLM_LOGGING_LEVEL": types.StringValue("INFO"),
+	})
 
 	m := &inference.InferenceDeploymentResourceModel{
 		ID:         types.StringValue("deploy-123"),
@@ -346,6 +419,7 @@ func TestInferenceDeployment_ToUpdateRequest_Fields(t *testing.T) {
 			Engine:       types.StringValue("vllm"),
 			Version:      types.StringValue("1.0.0"),
 			EngineConfig: types.MapNull(types.StringType),
+			EngineEnv:    engineEnv,
 		},
 		Resources: &inference.ResourcesModel{
 			InstanceType: types.StringValue("H100_80GB_SXM5"),
@@ -384,6 +458,9 @@ func TestInferenceDeployment_ToUpdateRequest_Fields(t *testing.T) {
 	}
 	if req.Runtime.Version != "1.0.0" {
 		t.Errorf("Runtime.Version: got %q, want '1.0.0'", req.Runtime.Version)
+	}
+	if got := req.Runtime.EngineEnv["VLLM_LOGGING_LEVEL"]; got != "INFO" {
+		t.Errorf("Runtime.EngineEnv[\"VLLM_LOGGING_LEVEL\"]: got %q, want 'INFO'", got)
 	}
 	if req.Resources.GpuCount != 2 {
 		t.Errorf("GpuCount: expected 2, got %d", req.Resources.GpuCount)
@@ -441,6 +518,9 @@ locals {
   # versions are excluded pending #319. Revert this commit once #319 lands.
   available_runtime_versions = try(data.coreweave_inference_deployment_parameters.deploy_params.runtime_versions["vllm"].versions, [])
   runtime_version            = try([for v in local.available_runtime_versions : v if can(regex("^[0-9]+[.][0-9]+[.][0-9]+$", v))][0], "")
+  available_engine_env_names = try(data.coreweave_inference_deployment_parameters.deploy_params.engine_env_options["vllm"].allowed_names, [])
+  engine_env_name            = %q
+  engine_env_value           = %q
 }
 
 resource "coreweave_inference_gateway" "test" {
@@ -472,6 +552,9 @@ resource "coreweave_inference_deployment" "test" {
   runtime = {
     engine  = "vllm"
     version = local.runtime_version
+    engine_env = {
+      (local.engine_env_name) = local.engine_env_value
+    }
   }
 
   resources = {
@@ -501,9 +584,13 @@ resource "coreweave_inference_deployment" "test" {
       condition     = local.runtime_version != ""
       error_message = "No x.y.z vllm runtime version available (pre-release/build-metadata excluded pending #319); available: ${jsonencode(local.available_runtime_versions)}"
     }
+    precondition {
+      condition     = contains(local.available_engine_env_names, local.engine_env_name)
+      error_message = "${local.engine_env_name} is not present in vllm engine env options; available: ${jsonencode(local.available_engine_env_names)}"
+    }
   }
 }
-`, preferredZone, preferredInstance, name, name, modelName, modelBucket, modelPath)
+`, preferredZone, preferredInstance, acceptanceEngineEnvName, acceptanceEngineEnvValue, name, name, modelName, modelBucket, modelPath)
 }
 
 func inferenceDeploymentUpdatedConfig(name, preferredZone, preferredInstance string) string {
@@ -537,6 +624,9 @@ locals {
   # versions are excluded pending #319. Revert this commit once #319 lands.
   available_runtime_versions = try(data.coreweave_inference_deployment_parameters.deploy_params.runtime_versions["vllm"].versions, [])
   runtime_version            = try([for v in local.available_runtime_versions : v if can(regex("^[0-9]+[.][0-9]+[.][0-9]+$", v))][0], "")
+  available_engine_env_names = try(data.coreweave_inference_deployment_parameters.deploy_params.engine_env_options["vllm"].allowed_names, [])
+  engine_env_name            = %q
+  engine_env_value           = %q
 }
 
 resource "coreweave_inference_gateway" "test" {
@@ -569,6 +659,9 @@ resource "coreweave_inference_deployment" "test" {
   runtime = {
     engine  = "vllm"
     version = local.runtime_version
+    engine_env = {
+      (local.engine_env_name) = local.engine_env_value
+    }
   }
 
   resources = {
@@ -600,9 +693,13 @@ resource "coreweave_inference_deployment" "test" {
       condition     = local.runtime_version != ""
       error_message = "No x.y.z vllm runtime version available (pre-release/build-metadata excluded pending #319); available: ${jsonencode(local.available_runtime_versions)}"
     }
+    precondition {
+      condition     = contains(local.available_engine_env_names, local.engine_env_name)
+      error_message = "${local.engine_env_name} is not present in vllm engine env options; available: ${jsonencode(local.available_engine_env_names)}"
+    }
   }
 }
-`, preferredZone, preferredInstance, name, name, modelName, modelBucket, modelPath)
+`, preferredZone, preferredInstance, acceptanceEngineEnvName, acceptanceEngineEnvValue, name, name, modelName, modelBucket, modelPath)
 }
 
 func TestInferenceDeployment(t *testing.T) {
@@ -629,6 +726,7 @@ func TestInferenceDeployment(t *testing.T) {
 						statecheck.ExpectKnownValue(fullResourceName, tfjsonpath.New("id"), knownvalue.NotNull()),
 						statecheck.ExpectKnownValue(fullResourceName, tfjsonpath.New("organization_id"), knownvalue.NotNull()),
 						statecheck.ExpectKnownValue(fullResourceName, tfjsonpath.New("created_at"), knownvalue.NotNull()),
+						statecheck.ExpectKnownValue(fullResourceName, tfjsonpath.New("runtime").AtMapKey("engine_env").AtMapKey(acceptanceEngineEnvName), knownvalue.StringExact(acceptanceEngineEnvValue)),
 						statecheck.ExpectKnownValue(fullResourceName, tfjsonpath.New("autoscaling").AtMapKey("min"), knownvalue.Int64Exact(1)),
 						statecheck.ExpectKnownValue(fullResourceName, tfjsonpath.New("autoscaling").AtMapKey("max"), knownvalue.Int64Exact(2)),
 					},
@@ -639,6 +737,7 @@ func TestInferenceDeployment(t *testing.T) {
 						statecheck.ExpectKnownValue(fullResourceName, tfjsonpath.New("autoscaling").AtMapKey("min"), knownvalue.Int64Exact(2)),
 						statecheck.ExpectKnownValue(fullResourceName, tfjsonpath.New("autoscaling").AtMapKey("max"), knownvalue.Int64Exact(4)),
 						statecheck.ExpectKnownValue(fullResourceName, tfjsonpath.New("disabled"), knownvalue.Bool(true)),
+						statecheck.ExpectKnownValue(fullResourceName, tfjsonpath.New("runtime").AtMapKey("engine_env").AtMapKey(acceptanceEngineEnvName), knownvalue.StringExact(acceptanceEngineEnvValue)),
 						statecheck.ExpectKnownValue(fullResourceName, tfjsonpath.New("traffic").AtMapKey("weight"), knownvalue.Int64Exact(50)),
 					},
 				},
@@ -684,6 +783,11 @@ func TestInferenceDeploymentParameters(t *testing.T) {
 						statecheck.ExpectKnownValue(
 							"data.coreweave_inference_deployment_parameters.test",
 							tfjsonpath.New("instance_types"),
+							knownvalue.NotNull(),
+						),
+						statecheck.ExpectKnownValue(
+							"data.coreweave_inference_deployment_parameters.test",
+							tfjsonpath.New("engine_env_options"),
 							knownvalue.NotNull(),
 						),
 					},

--- a/docs/data-sources/inference_deployment_parameters.md
+++ b/docs/data-sources/inference_deployment_parameters.md
@@ -33,10 +33,19 @@ output "vllm_versions" {
 
 ### Read-Only
 
+- `engine_env_options` (Attributes Map) Available engine environment variable options per engine (keyed by engine name). (see [below for nested schema](#nestedatt--engine_env_options))
 - `gateway_ids` (Set of String) Gateway IDs available for the current organization.
 - `instance_types` (Set of String) Available instance types for deployments.
 - `runtime_config_options` (Attributes Map) Available runtime config options per engine (keyed by engine name). (see [below for nested schema](#nestedatt--runtime_config_options))
 - `runtime_versions` (Attributes Map) Available runtime versions per engine (keyed by engine name). (see [below for nested schema](#nestedatt--runtime_versions))
+
+<a id="nestedatt--engine_env_options"></a>
+### Nested Schema for `engine_env_options`
+
+Read-Only:
+
+- `allowed_names` (List of String) Environment variable names accepted by the engine's `engine_env` field.
+
 
 <a id="nestedatt--runtime_config_options"></a>
 ### Nested Schema for `runtime_config_options`

--- a/docs/resources/inference_capacity_claim.md
+++ b/docs/resources/inference_capacity_claim.md
@@ -49,7 +49,7 @@ resource "coreweave_inference_capacity_claim" "example" {
 
 Required:
 
-- `capacity_type` (String) The [capacity type](https://docs.coreweave.com/products/inference/scaling#capacity-claims) for the capacity claim. Must be one of: `CAPACITY_TYPE_CUSTOMER`, `CAPACITY_TYPE_MANAGED`. `CAPACITY_TYPE_SERVERLESS` is deprecated and is no longer accepted. Existing claims were automatically migrated to `CAPACITY_TYPE_MANAGED`; update your configuration to use `CAPACITY_TYPE_MANAGED`.
+- `capacity_type` (String) The [capacity type](https://docs.coreweave.com/products/inference/scaling#capacity-claims) for the capacity claim. Must be one of: `CAPACITY_TYPE_CUSTOMER`, `CAPACITY_TYPE_MANAGED`.
 - `instance_count` (Number) The number of instances to reserve. Must be at least 1.
 - `instance_type` (String) The instance type to reserve (e.g. `gb200-4x`).
 - `zones` (Set of String) The availability zones where the capacity claim may use resources from (e.g. `US-WEST-04A`). At least one is required.

--- a/docs/resources/inference_deployment.md
+++ b/docs/resources/inference_deployment.md
@@ -26,6 +26,9 @@ resource "coreweave_inference_deployment" "example" {
     engine_config = {
       "max-model-len" = "8192"
     }
+    engine_env = {
+      VLLM_USE_FLASHINFER_MOE_FP4 = "0"
+    }
   }
 
   resources = {
@@ -123,6 +126,7 @@ Required:
 Optional:
 
 - `engine_config` (Map of String) Engine-specific configuration key/value pairs.
+- `engine_env` (Map of String) Engine-specific environment variables to inject into the model runtime container. Variable names must come from the selected engine's server-side allow list, exposed by `data.coreweave_inference_deployment_parameters.<name>.engine_env_options[<engine>].allowed_names`; unsupported names are rejected by the API.
 - `version` (String) The version of the engine. If not set, defaults to the latest available version. Must follow semver format (e.g. `1.2.3`).
 
 

--- a/examples/resources/coreweave_inference_deployment/resource.tf
+++ b/examples/resources/coreweave_inference_deployment/resource.tf
@@ -11,6 +11,9 @@ resource "coreweave_inference_deployment" "example" {
     engine_config = {
       "max-model-len" = "8192"
     }
+    engine_env = {
+      VLLM_USE_FLASHINFER_MOE_FP4 = "0"
+    }
   }
 
   resources = {

--- a/go.mod
+++ b/go.mod
@@ -7,8 +7,8 @@ require (
 	buf.build/gen/go/coreweave/cks/protocolbuffers/go v1.36.11-20260326215135-be22b90e1aa6.1
 	buf.build/gen/go/coreweave/cwobject/connectrpc/go v1.19.1-20250604181649-b97f17b05d5b.2
 	buf.build/gen/go/coreweave/cwobject/protocolbuffers/go v1.36.10-20250604181649-b97f17b05d5b.1
-	buf.build/gen/go/coreweave/inference/connectrpc/go v1.20.0-20260612031318-f73d5826317e.1
-	buf.build/gen/go/coreweave/inference/protocolbuffers/go v1.36.11-20260612031318-f73d5826317e.1
+	buf.build/gen/go/coreweave/inference/connectrpc/go v1.20.0-20260629172746-aab7cbdc0c7d.1
+	buf.build/gen/go/coreweave/inference/protocolbuffers/go v1.36.11-20260629172746-aab7cbdc0c7d.1
 	buf.build/gen/go/coreweave/networking/connectrpc/go v1.19.1-20260121155637-a637e7777165.2
 	buf.build/gen/go/coreweave/networking/protocolbuffers/go v1.36.11-20260121155637-a637e7777165.1
 	connectrpc.com/connect v1.20.0

--- a/go.sum
+++ b/go.sum
@@ -8,10 +8,10 @@ buf.build/gen/go/coreweave/cwobject/connectrpc/go v1.19.1-20250604181649-b97f17b
 buf.build/gen/go/coreweave/cwobject/connectrpc/go v1.19.1-20250604181649-b97f17b05d5b.2/go.mod h1:psL+HRMYCDFcWXSom8U7bD6hienITQq/yHCJNlNXuU4=
 buf.build/gen/go/coreweave/cwobject/protocolbuffers/go v1.36.10-20250604181649-b97f17b05d5b.1 h1:MVGYLA7uYissV+3Q3XzT+y0i7clq/A734X8IDN1Ax9c=
 buf.build/gen/go/coreweave/cwobject/protocolbuffers/go v1.36.10-20250604181649-b97f17b05d5b.1/go.mod h1:GVgzP9nXZj2+Hm3L+N3dRTm9zEURuxAcrkdPLPryg3U=
-buf.build/gen/go/coreweave/inference/connectrpc/go v1.20.0-20260612031318-f73d5826317e.1 h1:f0S14d2ethj38UtJb7feDjZ0BRj3ZAYJkA4KDRGTI7s=
-buf.build/gen/go/coreweave/inference/connectrpc/go v1.20.0-20260612031318-f73d5826317e.1/go.mod h1:GBVUSwqooLa9GLRDuc8h2IMr+a5gNHqIw709tGBKBy8=
-buf.build/gen/go/coreweave/inference/protocolbuffers/go v1.36.11-20260612031318-f73d5826317e.1 h1:kXnxgT8lTsGNJqURxZBj3+VJVoGYMCW7Cie8mE0lyF8=
-buf.build/gen/go/coreweave/inference/protocolbuffers/go v1.36.11-20260612031318-f73d5826317e.1/go.mod h1:hTrh8mWkz7c4WFsceMlVfBHnYUjz8CZ6ROAOHPpsIS4=
+buf.build/gen/go/coreweave/inference/connectrpc/go v1.20.0-20260629172746-aab7cbdc0c7d.1 h1:VMykBNN1Pf9AqaU+isYebTEz+odUEmkK8Y9EJ51o3AY=
+buf.build/gen/go/coreweave/inference/connectrpc/go v1.20.0-20260629172746-aab7cbdc0c7d.1/go.mod h1:AbIMJQsn9NhIlum6zqtYl8VdkYVmlZdtKa+FelQuoyE=
+buf.build/gen/go/coreweave/inference/protocolbuffers/go v1.36.11-20260629172746-aab7cbdc0c7d.1 h1:dcqCkrIoz7WXkcKcP4FWgmsiUAi/GUeGgCU5x+RPiIE=
+buf.build/gen/go/coreweave/inference/protocolbuffers/go v1.36.11-20260629172746-aab7cbdc0c7d.1/go.mod h1:hTrh8mWkz7c4WFsceMlVfBHnYUjz8CZ6ROAOHPpsIS4=
 buf.build/gen/go/coreweave/networking/connectrpc/go v1.19.1-20260121155637-a637e7777165.2 h1:7/T8Tbyq8JVWu5ZXznB84IdZ6zN/oXeDcebMaTc+eyc=
 buf.build/gen/go/coreweave/networking/connectrpc/go v1.19.1-20260121155637-a637e7777165.2/go.mod h1:Ri2fOqnsxnYU4CdWVP0GNqzSYq7L+Zw1AV/ebdbNITs=
 buf.build/gen/go/coreweave/networking/protocolbuffers/go v1.36.11-20260121155637-a637e7777165.1 h1:HgaTPkFCzegYtbVOir7vdty10GHoFxMceoscwcH0x7s=

--- a/internal/validators/deprecated_enum_test.go
+++ b/internal/validators/deprecated_enum_test.go
@@ -11,19 +11,21 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// Wire-contract enum names, pinned as string literals on purpose: these are the
-// strings the provider promises to users, and the generated proto enum is the
-// system under test here — not the source of truth for these assertions. Do NOT
-// replace these with inferencev1.* constants; if a proto change ever drifts a
-// name, these tests should fail rather than silently track the change.
 const (
-	capacityTypeServerless = "CAPACITY_TYPE_SERVERLESS" // deprecated upstream
+	capacityTypeServerless = "CAPACITY_TYPE_SERVERLESS"
 	capacityTypeManaged    = "CAPACITY_TYPE_MANAGED"
 	capacityTypeCustomer   = "CAPACITY_TYPE_CUSTOMER"
 	deprecationGuidance    = "Use CAPACITY_TYPE_MANAGED instead."
 )
 
-func TestDeprecatedEnumValue_Warn(t *testing.T) {
+func TestCapacityTypeServerlessIsNotGenerated(t *testing.T) {
+	t.Parallel()
+
+	_, ok := inferencev1.CapacityType_value[capacityTypeServerless]
+	assert.False(t, ok, "%s should not be present in the current generated CapacityType enum", capacityTypeServerless)
+}
+
+func TestDeprecatedEnumValue_CurrentCapacityTypeDescriptor(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -31,7 +33,7 @@ func TestDeprecatedEnumValue_Warn(t *testing.T) {
 		value       types.String
 		wantWarning bool
 	}{
-		{"deprecated value warns", types.StringValue(capacityTypeServerless), true},
+		{"removed serverless value does not warn", types.StringValue(capacityTypeServerless), false},
 		{"replacement value does not warn", types.StringValue(capacityTypeManaged), false},
 		{"other valid value does not warn", types.StringValue(capacityTypeCustomer), false},
 		{"unrecognized value does not warn", types.StringValue("NOT_A_REAL_VALUE"), false},
@@ -55,7 +57,7 @@ func TestDeprecatedEnumValue_Warn(t *testing.T) {
 	}
 }
 
-func TestRejectDeprecatedEnumValue(t *testing.T) {
+func TestRejectDeprecatedEnumValue_CurrentCapacityTypeDescriptor(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -63,7 +65,7 @@ func TestRejectDeprecatedEnumValue(t *testing.T) {
 		value     types.String
 		wantError bool
 	}{
-		{"deprecated value errors", types.StringValue(capacityTypeServerless), true},
+		{"removed serverless value does not error", types.StringValue(capacityTypeServerless), false},
 		{"replacement value does not error", types.StringValue(capacityTypeManaged), false},
 		{"other valid value does not error", types.StringValue(capacityTypeCustomer), false},
 		{"unrecognized value does not error", types.StringValue("NOT_A_REAL_VALUE"), false},
@@ -82,29 +84,9 @@ func TestRejectDeprecatedEnumValue(t *testing.T) {
 			v.ValidateString(t.Context(), req, resp)
 
 			assert.Equal(t, tt.wantError, resp.Diagnostics.HasError())
-			if tt.wantError {
-				// Message should carry the caller-supplied migration guidance.
-				assert.Contains(t, resp.Diagnostics.Errors()[0].Detail(), deprecationGuidance)
-			}
 			assert.Zero(t, resp.Diagnostics.WarningsCount(), "reject validator emits errors, not warnings")
 		})
 	}
-}
-
-func TestRejectDeprecatedEnumValue_FallbackListsValidValues(t *testing.T) {
-	t.Parallel()
-
-	// With empty guidance, the error falls back to listing the enum's
-	// non-deprecated values.
-	v := validators.RejectDeprecatedEnumValue(inferencev1.CapacityType_CAPACITY_TYPE_MANAGED.Descriptor(), "")
-	req := validator.StringRequest{Path: path.Root("capacity_type"), ConfigValue: types.StringValue(capacityTypeServerless)}
-	resp := &validator.StringResponse{}
-	v.ValidateString(t.Context(), req, resp)
-
-	assert.True(t, resp.Diagnostics.HasError())
-	detail := resp.Diagnostics.Errors()[0].Detail()
-	assert.Contains(t, detail, capacityTypeManaged)
-	assert.Contains(t, detail, capacityTypeCustomer)
 }
 
 func TestDeprecatedEnumValue_NilDescriptor(t *testing.T) {


### PR DESCRIPTION
bump protos and expose a new field!

it permits setting env var names from a server side allow list, structurally similar to engine-config but with different permitted values