### PR TITLE
chore(examples/resources/cks_cluster): drop audience

### DIFF
--- a/examples/resources/coreweave_cks_cluster_tailscale/main.tf
+++ b/examples/resources/coreweave_cks_cluster_tailscale/main.tf
@@ -65,7 +65,6 @@ resource "terraform_data" "cluster_tfvars" {
 resource "tailscale_federated_identity" "default" {
   description = var.cks_cluster.name
   issuer      = var.service_account_oidc_issuer_url
-  audience    = var.service_account_oidc_issuer_url
   subject     = "system:serviceaccount:cw-tailscale:tailscale"
   scopes = [
     "auth_keys",


### PR DESCRIPTION
We no longer require a non-default audience in Tailscale Federated Identity configuration.

We now expect the default value of `api.tailscale.com/[CLIENT-ID]`, which is default populated value. Therefore `audience` should remain unset in the Terraform plan.