### PR TITLE
ci(test): fail generate check on untracked generated files

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,8 +37,9 @@ jobs:
       - run: make generate
       - name: git diff
         run: |
+          git add -N docs/ # make untracked generated docs visible to git diff
           git diff --compact-summary --exit-code || \
-            (echo; echo "Unexpected difference in directories after code generation. Run 'make generate' command and commit."; exit 1)
+            (echo; echo "Unexpected difference in directories after code generation (including new files). Run 'make generate' command and commit."; exit 1)
 
   snapshot-build:
     uses: ./.github/workflows/build.yml


### PR DESCRIPTION
The original changes PR #345 hadn't included the generated docs changes and the `generate` check still succeeded:
https://github.com/coreweave/terraform-provider-coreweave/actions/runs/28622006850/job/84879970255?pr=345

Since `git diff --exit-code` only reports changes to tracked files, the generate job passed even when 'make generate' created brand-new docs pages that were never committed (e.g. PR #345's
docs/resources/object_storage_bucket_inventory.md). 

This registers untracked files under docs/ with git add -N (intent-to-add) first so new generated docs also fail the check, while keeping the compact-summary diff output.