### PR TITLE
ci(renovate): require full semver action annotations

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -4,7 +4,8 @@
     "config:recommended",
     ":semanticCommits",
     ":disableRateLimiting",
-    "helpers:pinGitHubActionDigests"
+    "helpers:pinGitHubActionDigests",
+    "helpers:pinGitHubActionDigestsToSemver"
   ],
   "semanticCommitType": "deps",
   "commitMessageTopic": "{{depName}}",


### PR DESCRIPTION
Configures Renovate's full-SemVer preset for digest-pinned GitHub Actions. SHA pinning stays unchanged, while tracking comments resolve to full release tags such as `v3.0.0` instead of mutable major aliases such as `v3`.

## Why

PRs #288 and #289 show that major-only comments hide the exact tagged release a digest tracks.

## Validation

- `renovate-config-validator`
- `git diff --check`
