### PR TITLE
ci(renovate): manage mise runtime

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -13,6 +13,20 @@
   "postUpdateOptions": ["gomodTidy"],
   "rebaseWhen": "conflicted",
   "commitBodyTable": true,
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/^\\.github/actions/setup/action\\.yml$/"
+      ],
+      "matchStrings": [
+        "uses: jdx/mise-action@[^\\n]+\\n\\s+with:\\n\\s+version: (?<currentValue>v[0-9]+\\.[0-9]+\\.[0-9]+)"
+      ],
+      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "jdx/mise",
+      "versioningTemplate": "semver-coerced"
+    }
+  ],
   "packageRules": [
     { "matchUpdateTypes": ["major"], "labels": ["type/major"] },
     { "matchUpdateTypes": ["minor"], "labels": ["type/minor"] },
@@ -40,6 +54,12 @@
       "matchManagers": ["mise"],
       "semanticCommitType": "ci",
       "semanticCommitScope": "mise"
+    },
+    {
+      "matchDepNames": ["jdx/mise"],
+      "commitMessagePrefix": "ci(mise):",
+      "commitMessageAction": "update",
+      "commitMessageTopic": "mise"
     },
     {
       // Ensure Go version range in go.mod is bumped rather than pinned.

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -23,7 +23,7 @@
         "uses: jdx/mise-action@[^\\n]+\\n\\s+with:\\n\\s+version: (?<currentValue>v[0-9]+\\.[0-9]+\\.[0-9]+)"
       ],
       "datasourceTemplate": "github-releases",
-      "depNameTemplate": "jdx/mise",
+      "packageNameTemplate": "jdx/mise",
       "versioningTemplate": "semver-coerced"
     }
   ],
@@ -56,7 +56,7 @@
       "semanticCommitScope": "mise"
     },
     {
-      "matchDepNames": ["jdx/mise"],
+      "matchPackageNames": ["jdx/mise"],
       "commitMessagePrefix": "ci(mise):",
       "commitMessageAction": "update",
       "commitMessageTopic": "mise"


### PR DESCRIPTION
Teach Renovate to manage the mise runtime pin in the shared setup action while leaving the current mise version unchanged.

## Why

Renovate can open focused mise update PRs titled `ci(mise): update mise`; existing update and automerge policy remains unchanged. This replaces the one-off manual runtime bump in #261 with ongoing dependency management.

## Validation

- Renovate 43.279.0 configuration validation
- Exact regex extraction: one match for `v2026.1.7`
- `git diff --check`

Supersedes #261.
