### PR TITLE
fix(object_storage): use `Current` (not `Latest`) for bucket inventory included_object_versions

### DIFF
--- a/coreweave/object_storage/resource_bucket_inventory.go
+++ b/coreweave/object_storage/resource_bucket_inventory.go
@@ -114,8 +114,8 @@ func (r *BucketInventoryResource) Schema(ctx context.Context, req resource.Schem
 			},
 			"included_object_versions": schema.StringAttribute{
 				Required:            true,
-				MarkdownDescription: "Specifies which object versions are included in the inventory results. Valid values are `All` and `Latest`.",
-				Validators:          []validator.String{stringvalidator.OneOf("All", "Latest")},
+				MarkdownDescription: "Specifies which object versions are included in the inventory results. Valid values are `All` and `Current`.",
+				Validators:          []validator.String{stringvalidator.OneOf("All", "Current")},
 			},
 			"optional_fields": schema.SetAttribute{
 				Optional:            true,

--- a/coreweave/object_storage/resource_bucket_inventory.go
+++ b/coreweave/object_storage/resource_bucket_inventory.go
@@ -45,6 +45,17 @@ const (
 	ErrNoSuchInventoryConfiguration string = "NoSuchInventoryConfiguration"
 )
 
+// enumStrings converts an AWS SDK string-enum's Values() slice into the []string
+// form the OneOf validator expects, so the accepted values track the SDK enum
+// instead of being maintained as separate string literals.
+func enumStrings[T ~string](vals []T) []string {
+	out := make([]string, len(vals))
+	for i, v := range vals {
+		out[i] = string(v)
+	}
+	return out
+}
+
 // NewBucketInventoryResource returns a new resource instance.
 func NewBucketInventoryResource() resource.Resource {
 	return &BucketInventoryResource{}
@@ -115,7 +126,9 @@ func (r *BucketInventoryResource) Schema(ctx context.Context, req resource.Schem
 			"included_object_versions": schema.StringAttribute{
 				Required:            true,
 				MarkdownDescription: "Specifies which object versions are included in the inventory results. Valid values are `All` and `Current`.",
-				Validators:          []validator.String{stringvalidator.OneOf("All", "Current")},
+				// Accepted values are sourced from the AWS SDK enum rather than
+				// hardcoded literals; see s3types.InventoryIncludedObjectVersions.
+				Validators: []validator.String{stringvalidator.OneOf(enumStrings(s3types.InventoryIncludedObjectVersions("").Values())...)},
 			},
 			"optional_fields": schema.SetAttribute{
 				Optional:            true,

--- a/coreweave/object_storage/resource_bucket_inventory_test.go
+++ b/coreweave/object_storage/resource_bucket_inventory_test.go
@@ -224,7 +224,7 @@ func TestBucketInventoryBasic(t *testing.T) {
 // accepted by the API and that switching between them is planned and applied as
 // an in-place update (the attribute is not RequiresReplace).
 func TestBucketInventoryIncludedObjectVersions(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	randomInt := rand.IntN(100000)
 	bucket := objectstorage.BucketResourceModel{
@@ -363,7 +363,7 @@ func TestBucketInventoryIncludedObjectVersionsInvalid(t *testing.T) {
 // the config is deleted out-of-band, the next refresh must notice it is gone
 // (Read -> RemoveResource) and plan to recreate it, producing a non-empty plan.
 func TestBucketInventoryDisappears(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	randomInt := rand.IntN(100000)
 	bucket := objectstorage.BucketResourceModel{

--- a/coreweave/object_storage/resource_bucket_inventory_test.go
+++ b/coreweave/object_storage/resource_bucket_inventory_test.go
@@ -121,7 +121,7 @@ func TestBucketInventoryBasic(t *testing.T) {
 	base := objectstorage.BucketInventoryResourceModel{
 		Name:                   types.StringValue("daily-report"),
 		Enabled:                types.BoolValue(true),
-		IncludedObjectVersions: types.StringValue("All"),
+		IncludedObjectVersions: types.StringValue("Current"),
 		OptionalFields: types.SetValueMust(types.StringType, []attr.Value{
 			types.StringValue("Size"),
 			types.StringValue("LastAccessedDate"),
@@ -209,6 +209,99 @@ func TestBucketInventoryBasic(t *testing.T) {
 				return nil
 			},
 		},
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: provider.TestProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckInventoryDestroy(ctx, t),
+		Steps:                    steps,
+	})
+}
+
+// TestBucketInventoryIncludedObjectVersions exercises both valid
+// included_object_versions values — "Current" and "All" — proving each is
+// accepted by the API and that switching between them is planned and applied as
+// an in-place update (the attribute is not RequiresReplace).
+func TestBucketInventoryIncludedObjectVersions(t *testing.T) {
+	ctx := context.Background()
+
+	randomInt := rand.IntN(100000)
+	bucket := objectstorage.BucketResourceModel{
+		Name: types.StringValue(fmt.Sprintf("%sinv-iov-%x", AcceptanceTestPrefix, randomInt)),
+		Zone: types.StringValue("US-EAST-04A"),
+	}
+
+	resourceName := "test_inv_iov"
+	rs := fmt.Sprintf("coreweave_object_storage_bucket_inventory.%s", resourceName)
+
+	destArn := fmt.Sprintf("arn:aws:s3:::%s", bucket.Name.ValueString())
+
+	// newInventory returns an otherwise-identical config so the only diff between
+	// steps is included_object_versions.
+	newInventory := func(versions string) objectstorage.BucketInventoryResourceModel {
+		return objectstorage.BucketInventoryResourceModel{
+			Name:                   types.StringValue("daily-report"),
+			Enabled:                types.BoolValue(true),
+			IncludedObjectVersions: types.StringValue(versions),
+			Schedule:               &objectstorage.ScheduleModel{Frequency: types.StringValue("Daily")},
+			Destination: &objectstorage.DestinationModel{
+				Bucket: &objectstorage.BucketModel{
+					BucketArn: types.StringValue(destArn),
+					Format:    types.StringValue("CSV"),
+				},
+			},
+		}
+	}
+
+	steps := []resource.TestStep{
+		// 1. create with "Current"
+		createInventoryTestStep(ctx, t, inventoryTestConfig{
+			name:         "create with Current",
+			resourceName: resourceName,
+			bucket:       bucket,
+			inventory:    newInventory("Current"),
+			configPlanChecks: resource.ConfigPlanChecks{
+				PreApply: []plancheck.PlanCheck{
+					plancheck.ExpectResourceAction(rs, plancheck.ResourceActionCreate),
+				},
+			},
+		}),
+		// 2. no-op: identical config must produce an EMPTY plan
+		createInventoryTestStep(ctx, t, inventoryTestConfig{
+			name:         "no-op after create with Current",
+			resourceName: resourceName,
+			bucket:       bucket,
+			inventory:    newInventory("Current"),
+			configPlanChecks: resource.ConfigPlanChecks{
+				PreApply: []plancheck.PlanCheck{
+					plancheck.ExpectEmptyPlan(),
+				},
+			},
+		}),
+		// 3. update "Current" -> "All": must plan and apply an in-place update
+		createInventoryTestStep(ctx, t, inventoryTestConfig{
+			name:         "update to All",
+			resourceName: resourceName,
+			bucket:       bucket,
+			inventory:    newInventory("All"),
+			configPlanChecks: resource.ConfigPlanChecks{
+				PreApply: []plancheck.PlanCheck{
+					plancheck.ExpectResourceAction(rs, plancheck.ResourceActionUpdate),
+				},
+			},
+		}),
+		// 4. no-op after update: still stable, no drift
+		createInventoryTestStep(ctx, t, inventoryTestConfig{
+			name:         "no-op after update to All",
+			resourceName: resourceName,
+			bucket:       bucket,
+			inventory:    newInventory("All"),
+			configPlanChecks: resource.ConfigPlanChecks{
+				PreApply: []plancheck.PlanCheck{
+					plancheck.ExpectEmptyPlan(),
+				},
+			},
+		}),
 	}
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/coreweave/object_storage/resource_bucket_inventory_test.go
+++ b/coreweave/object_storage/resource_bucket_inventory_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"math/rand/v2"
+	"regexp"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -103,7 +104,7 @@ func createInventoryTestStep(ctx context.Context, t *testing.T, opts inventoryTe
 //   - re-apply the changed config and assert an EMPTY plan again
 //   - import round-trip
 func TestBucketInventoryBasic(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	randomInt := rand.IntN(100000)
 	bucket := objectstorage.BucketResourceModel{
@@ -308,6 +309,53 @@ func TestBucketInventoryIncludedObjectVersions(t *testing.T) {
 		ProtoV6ProviderFactories: provider.TestProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckInventoryDestroy(ctx, t),
 		Steps:                    steps,
+	})
+}
+
+// TestBucketInventoryIncludedObjectVersionsInvalid confirms that an unsupported
+// included_object_versions value (e.g. "Latest") is rejected at plan time by the
+// schema validator, before any API call is made. The unit tests exercise the
+// validator directly; this is the acceptance-level guardrail requested in review.
+func TestBucketInventoryIncludedObjectVersionsInvalid(t *testing.T) {
+	ctx := t.Context()
+
+	randomInt := rand.IntN(100000)
+	bucket := objectstorage.BucketResourceModel{
+		Name: types.StringValue(fmt.Sprintf("%sinv-invalid-%x", AcceptanceTestPrefix, randomInt)),
+		Zone: types.StringValue("US-EAST-04A"),
+	}
+
+	destArn := fmt.Sprintf("arn:aws:s3:::%s", bucket.Name.ValueString())
+
+	inv := objectstorage.BucketInventoryResourceModel{
+		Bucket:                 types.StringValue(fmt.Sprintf("coreweave_object_storage_bucket.%s.name", "test_bucket")),
+		Name:                   types.StringValue("daily-report"),
+		Enabled:                types.BoolValue(true),
+		IncludedObjectVersions: types.StringValue("Latest"),
+		Schedule:               &objectstorage.ScheduleModel{Frequency: types.StringValue("Daily")},
+		Destination: &objectstorage.DestinationModel{
+			Bucket: &objectstorage.BucketModel{
+				BucketArn: types.StringValue(destArn),
+				Format:    types.StringValue("CSV"),
+			},
+		},
+	}
+
+	config := objectstorage.MustRenderBucketResource(ctx, "test_bucket", &bucket) +
+		objectstorage.MustRenderBucketInventoryResource(ctx, "test_inv_invalid", &inv)
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: provider.TestProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				// PlanOnly: the OneOf validator rejects "Latest" during plan, so the
+				// step fails before anything is created — no backend interaction and
+				// nothing to destroy.
+				Config:      config,
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile(`(?s)included_object_versions.*must be one of`),
+			},
+		},
 	})
 }
 

--- a/coreweave/object_storage/resource_bucket_inventory_unit_test.go
+++ b/coreweave/object_storage/resource_bucket_inventory_unit_test.go
@@ -247,8 +247,8 @@ func TestInventorySchema_IncludedObjectVersionsValidator(t *testing.T) {
 		wantErr bool
 	}{
 		"All is valid":          {"All", false},
-		"Latest is valid":       {"Latest", false},
-		"Current is rejected":   {"Current", true}, // AWS enum value, not the documented CAIOS value
+		"Current is value":      {"Current", false},
+		"Latest is rejected":    {"Latest", true},
 		"arbitrary rejected":    {"Everything", true},
 		"empty string rejected": {"", true},
 	}

--- a/docs/resources/object_storage_bucket_inventory.md
+++ b/docs/resources/object_storage_bucket_inventory.md
@@ -57,7 +57,7 @@ resource "coreweave_object_storage_bucket_inventory" "default" {
 ### Required
 
 - `bucket` (String) Name of source bucket to which the inventory configuration applies
-- `included_object_versions` (String) Specifies which object versions are included in the inventory results. Valid values are `All` and `Latest`.
+- `included_object_versions` (String) Specifies which object versions are included in the inventory results. Valid values are `All` and `Current`.
 - `name` (String) Name of the inventory configuration. Must be unique within the bucket.
 
 ### Optional


### PR DESCRIPTION
## What

The `coreweave_object_storage_bucket_inventory` resource validated and documented `included_object_versions` as accepting `All` and `Latest`. `Latest` is not a valid value, the S3 inventory API (and the underlying AWS SDK enum,
`InventoryIncludedObjectVersions`) only accepts `All` and `Current`. Any config using `Latest` would pass Terraform side validation and then be rejected by the backend.

This corrects the accepted value to `Current`. The CAIOS documentation that listed `Latest` was incorrect.

## Changes

- **Schema** (`resource_bucket_inventory.go`): `OneOf` validator and the attribute description now use `All` / `Current` instead of `All` / `Latest`.
- **Docs** (`docs/resources/object_storage_bucket_inventory.md`): regenerated description to match.
- **Unit test** (`resource_bucket_inventory_unit_test.go`): the validator table now asserts `Current` is accepted and `Latest` is rejected 
- **Acceptance test** (`resource_bucket_inventory_test.go`):
  - Updated `TestBucketInventoryBasic` to use `Current`.
  - Added `TestBucketInventoryIncludedObjectVersions`, which creates with `Current`, asserts a no-op re-apply, updates in place to `All`, and asserts a second no-op, verifying both valid values round-trip through the API and that switching between them is an in-place update (not a replace).


## Testing

- `go vet ./coreweave/object_storage/` passes.
- Unit tests pass.
- Acceptance tests (`TF_ACC=1`) require a live object-storage endpoint.