### PR TITLE
ci(renovate): skip AWS SDK changelog generation

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -114,6 +114,11 @@
       "groupName": "hashicorp-tools",
       "semanticCommitType": "ci",
       "semanticCommitScope": "tools"
+    },
+    // Sampled run 30042197044 shows AWS SDK changelog generation dominating runtime before a GraphQL timeout.
+    {
+      "matchSourceUrls": ["https://github.com/aws/aws-sdk-go-v2"],
+      "fetchChangeLogs": "off"
     }
   ]
 }

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -115,7 +115,7 @@
       "semanticCommitType": "ci",
       "semanticCommitScope": "tools"
     },
-    // Sampled run 30042197044 shows AWS SDK changelog generation dominating runtime before a GraphQL timeout.
+    // AWS SDK changelog generation repeatedly dominates run time and encounters GitHub GraphQL timeouts.
     {
       "matchSourceUrls": ["https://github.com/aws/aws-sdk-go-v2"],
       "fetchChangeLogs": "off"


### PR DESCRIPTION
Disable Renovate changelog fetching for packages sourced from the AWS SDK for Go v2 monorepo. This keeps dependency updates enabled while avoiding the repeated changelog-generation path implicated in the slowest sampled scheduled runs.

## Why

The sampled runs support a high-confidence, falsifiable theory that AWS SDK changelog generation is the dominant recurring bottleneck, with GitHub GraphQL failures magnifying the delay:

- [Run 30042197044](https://github.com/coreweave/terraform-provider-coreweave/actions/runs/30042197044) spent 788,402 ms processing the repository. AWS grouped-PR changelog fetching began around 20:29:05Z; GitHub GraphQL returned 504 around 20:30:57Z, Renovate shrank its page size, the next `aws/aws-sdk-go-v2` repository event was around 20:40:45Z, and processing finished around 20:41:50Z. The generated PR body then exceeded GitHub's 58,000-character limit and was truncated.
- [Run 30034092554](https://github.com/coreweave/terraform-provider-coreweave/actions/runs/30034092554) showed a similar GraphQL 502 during AWS changelog work; repository processing took 486,129 ms, with the AWS phase occupying most of the run.
- [Run 30025685655](https://github.com/coreweave/terraform-provider-coreweave/actions/runs/30025685655) took 894,396 ms, with AWS changelog work spanning roughly 13 minutes.
- [Run 30021733186](https://github.com/coreweave/terraform-provider-coreweave/actions/runs/30021733186) provides a comparative baseline: AWS tag lookup failed quickly and repository processing took 177,120 ms. The failure is not desirable; this is timing evidence only.

The oversized PR body demonstrates changelog volume, but it is not claimed to cause the missing minutes: the delay precedes truncation. In the latest slow run, `gomodTidy` was skipped because no package files changed and post-upgrade tasks were skipped, so it is not the persistent bottleneck shown there.

Renovate's [changelog documentation](https://docs.renovatebot.com/key-concepts/changelogs/) says changelogs are fetched from a dependency's source URL and specifically recommends overriding `fetchChangeLogs` to `off` for matching packages when fetching causes problems.

## Design

The late package rule matches only the exact source URL `https://github.com/aws/aws-sdk-go-v2` and sets `fetchChangeLogs` to `off`. This scopes the opt-out to the AWS SDK v2 monorepo rather than disabling changelogs globally or matching package names that may have different source repositories. The existing `github.com/aws/smithy-go` grouping is intentionally unchanged because its source URL was not established as the AWS SDK v2 monorepo.

This is a reversible, falsifiable mitigation. Subsequent scheduled runs should be compared with the sampled timings; a material reduction toward the shorter baseline would support the theory, while unchanged latency would point to another bottleneck.

## Validation

- `npx --yes --package renovate@43.279.0 renovate-config-validator .github/renovate.json5`
- Local Renovate extraction dry run confirmed the AWS SDK v2 module family is present; no full lookup was attempted because the local run requires a GitHub token.
- `git diff --check`
