### PR TITLE
feat(cks): expose tailscale tailnet_domain on cks_cluster

### DIFF
--- a/coreweave/cks/data_source_cluster.go
+++ b/coreweave/cks/data_source_cluster.go
@@ -179,6 +179,10 @@ func (d *ClusterDataSource) Schema(ctx context.Context, req datasource.SchemaReq
 						MarkdownDescription: "The Tailscale Client ID for the federated identity.",
 						Computed:            true,
 					},
+					"tailnet_domain": schema.StringAttribute{
+						MarkdownDescription: "The Tailscale Tailnet DNS name assigned to the cluster. Populated by the Tailscale operator after the cluster becomes ready.",
+						Computed:            true,
+					},
 				},
 			},
 			"kubelet": schema.StringAttribute{

--- a/coreweave/cks/flatten_test.go
+++ b/coreweave/cks/flatten_test.go
@@ -1,0 +1,68 @@
+package cks
+
+import (
+	"testing"
+
+	cksv1beta1 "buf.build/gen/go/coreweave/cks/protocolbuffers/go/coreweave/cks/v1beta1"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestSetTailscale(t *testing.T) {
+	tests := []struct {
+		name         string
+		tailscale    *cksv1beta1.Tailscale
+		wantNil      bool
+		wantClientID types.String
+		wantDomain   types.String
+	}{
+		{
+			name:      "no tailscale configured",
+			tailscale: nil,
+			wantNil:   true,
+		},
+		{
+			// The API may keep the Tailscale message populated with only an
+			// output-only tailnet_domain after the client_id is cleared; the
+			// block is required to carry a client_id, so treat this as unset.
+			name:      "empty client_id is treated as unset",
+			tailscale: &cksv1beta1.Tailscale{ClientId: "", TailnetDomain: "my-cluster.tailnet.ts.net"},
+			wantNil:   true,
+		},
+		{
+			name:         "domain not yet assigned is null",
+			tailscale:    &cksv1beta1.Tailscale{ClientId: "client-123"},
+			wantClientID: types.StringValue("client-123"),
+			wantDomain:   types.StringNull(),
+		},
+		{
+			name:         "domain assigned",
+			tailscale:    &cksv1beta1.Tailscale{ClientId: "client-123", TailnetDomain: "my-cluster.tailnet.ts.net"},
+			wantClientID: types.StringValue("client-123"),
+			wantDomain:   types.StringValue("my-cluster.tailnet.ts.net"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var model ClusterResourceModel
+			model.setTailscale(&cksv1beta1.Cluster{Tailscale: tt.tailscale})
+
+			if tt.wantNil {
+				if model.Tailscale != nil {
+					t.Fatalf("expected Tailscale to be nil, got %+v", model.Tailscale)
+				}
+				return
+			}
+
+			if model.Tailscale == nil {
+				t.Fatal("expected Tailscale to be non-nil")
+			}
+			if !model.Tailscale.ClientID.Equal(tt.wantClientID) {
+				t.Errorf("client_id: got %v, want %v", model.Tailscale.ClientID, tt.wantClientID)
+			}
+			if !model.Tailscale.TailnetDomain.Equal(tt.wantDomain) {
+				t.Errorf("tailnet_domain: got %v, want %v", model.Tailscale.TailnetDomain, tt.wantDomain)
+			}
+		})
+	}
+}

--- a/coreweave/cks/resource_cluster.go
+++ b/coreweave/cks/resource_cluster.go
@@ -57,7 +57,8 @@ type ClusterResource struct {
 }
 
 type TailscaleResourceModel struct {
-	ClientID types.String `tfsdk:"client_id"`
+	ClientID      types.String `tfsdk:"client_id"`
+	TailnetDomain types.String `tfsdk:"tailnet_domain"`
 }
 
 type AuthWebhookResourceModel struct {
@@ -332,7 +333,17 @@ func (c *ClusterResourceModel) Set(cluster *cksv1beta1.Cluster) {
 
 func (c *ClusterResourceModel) setTailscale(cluster *cksv1beta1.Cluster) {
 	if cluster.Tailscale != nil && cluster.Tailscale.ClientId != "" {
-		c.Tailscale = &TailscaleResourceModel{ClientID: types.StringValue(cluster.Tailscale.ClientId)}
+		// tailnet_domain is OUTPUT_ONLY and assigned asynchronously by the
+		// Tailscale operator. Preserve a null (rather than an empty string) until
+		// it is assigned so consumers can distinguish "not yet assigned".
+		tailnetDomain := types.StringNull()
+		if cluster.Tailscale.TailnetDomain != "" {
+			tailnetDomain = types.StringValue(cluster.Tailscale.TailnetDomain)
+		}
+		c.Tailscale = &TailscaleResourceModel{
+			ClientID:      types.StringValue(cluster.Tailscale.ClientId),
+			TailnetDomain: tailnetDomain,
+		}
 	} else {
 		c.Tailscale = nil
 	}
@@ -1071,6 +1082,10 @@ func (r *ClusterResource) Schema(ctx context.Context, req resource.SchemaRequest
 							stringvalidator.LengthAtMost(255),
 							stringvalidator.RegexMatches(nonWhitespace, "must not be empty"),
 						},
+					},
+					"tailnet_domain": schema.StringAttribute{
+						Computed:            true,
+						MarkdownDescription: "The Tailscale Tailnet DNS name assigned to the cluster. Populated by the Tailscale operator after the cluster becomes ready.",
 					},
 				},
 			},

--- a/docs/data-sources/cks_cluster.md
+++ b/docs/data-sources/cks_cluster.md
@@ -93,3 +93,4 @@ Read-Only:
 Read-Only:
 
 - `client_id` (String) The Tailscale Client ID for the federated identity.
+- `tailnet_domain` (String) The Tailscale Tailnet DNS name assigned to the cluster. Populated by the Tailscale operator after the cluster becomes ready.

--- a/docs/resources/cks_cluster.md
+++ b/docs/resources/cks_cluster.md
@@ -173,7 +173,7 @@ Required:
 
 Read-Only:
 
-- `tailnet_domain` (String) The Tailscale Tailnet DNS name assigned to the cluster. Populated after the cluster becomes ready.
+- `tailnet_domain` (String) The Tailscale Tailnet DNS name assigned to the cluster. Populated by the Tailscale operator after the cluster becomes ready.
 
 ## Import
 

--- a/docs/resources/cks_cluster.md
+++ b/docs/resources/cks_cluster.md
@@ -171,6 +171,10 @@ Required:
 
 - `client_id` (String) The Tailscale Client ID for the federated identity.
 
+Read-Only:
+
+- `tailnet_domain` (String) The Tailscale Tailnet DNS name assigned to the cluster. Populated after the cluster becomes ready.
+
 ## Import
 
 Import is supported using the following syntax:


### PR DESCRIPTION
## What

Exposes the Tailscale `tailnet_domain` (the server-assigned Tailnet DNS name) as a computed attribute on the `coreweave_cks_cluster` resource and data source, under the existing `tailscale` block. `client_id` was already wired; this surfaces the read-only domain the Tailscale operator assigns once the cluster is ready.

## Details

- `tailnet_domain` is `OUTPUT_ONLY` in the CKS API, so it's `Computed`. No `go.mod` bump needed - the pinned buf.build SDK already includes it.
- The operator populates it asynchronously, so `setTailscale` stores `null` (not `""`) until it's assigned, letting consumers distinguish "not yet assigned".
- No `UseStateForUnknown`: the value is async/mutable, so the plan stays "known after apply" on changes and every apply stays consistent. `tailscaleChanged` compares only `client_id`, so the async domain never triggers a spurious update.

## Tests

- Added `TestSetTailscale` unit test covering unset / empty-client-id / unassigned-domain (null) / assigned-domain cases.
- `go build`, `go vet`, and `go test ./coreweave/cks/` pass. Docs regenerated via `make generate`.
- Acceptance tests (`TF_ACC=1`) not run locally.