### PR TITLE
ci(renovate): group Google genproto modules

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -84,7 +84,6 @@
     {
       "matchManagers": ["gomod"],
       "matchPackageNames": ["google.golang.org/genproto/googleapis/**"],
-      "matchDepTypes": ["require", "indirect"],
       "enabled": true,
       "groupName": "google.golang.org/genproto/googleapis",
       "minimumGroupSize": 2

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -82,6 +82,14 @@
       "sourceUrl": "https://github.com/golang/go"
     },
     {
+      "matchManagers": ["gomod"],
+      "matchPackageNames": ["google.golang.org/genproto/googleapis/**"],
+      "matchDepTypes": ["require", "indirect"],
+      "enabled": true,
+      "groupName": "google.golang.org/genproto/googleapis",
+      "minimumGroupSize": 2
+    },
+    {
       "matchPackageNames": ["buf.build/gen/go/coreweave/cks/**"],
       "groupName": "buf.build/coreweave/cks",
       "semanticCommitType": "deps",


### PR DESCRIPTION
Groups the Google genproto `api` and `rpc` modules so Renovate updates their matching pseudo-versions together instead of raising another single-module update like #196.

## Design

The rule enables indirect updates only for `google.golang.org/genproto/googleapis/**` and requires two available updates before creating the group. This keeps unrelated indirect modules disabled while preventing a one-module branch; Go module requirements are already exact, so `rangeStrategy: pin` would not bind the sibling modules.

## Caveats

The existing RPC-only PR #196 remains open until Renovate reconciles it after this configuration lands.
