### PR TITLE
ci(renovate): enforce minimum release age, group go

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -144,13 +144,6 @@
       "fetchChangeLogs": "off"
     },
     {
-      "matchDepNames": [
-        "ghcr.io/coreweave/**",
-        "buf.build/gen/go/coreweave/**"
-      ],
-      "minimumReleaseAge": "0 days"
-    },
-    {
       "matchPackageNames": [
         "ghcr.io/coreweave/**",
         "buf.build/gen/go/coreweave/**"
@@ -159,9 +152,8 @@
     },
     {
       "matchManagers": ["gomod", "mise"],
-      "matchPackageNames": ["go"],
+      "matchPackageNames": ["go", "golang/go"],
       "groupName": "go",
-      "minimumGroupSize": 3,
       "minimumReleaseAge": "0 days"
     }
   ]

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -158,13 +158,10 @@
       "minimumReleaseAge": "0 days"
     },
     {
-      "matchDatasources": ["docker", "golang-version"],
-      "matchPackageNames": ["go", "golang"],
-      "minimumReleaseAge": "0 days"
-    },
-    {
-      "matchManagers": ["mise"],
+      "matchManagers": ["gomod", "mise"],
       "matchPackageNames": ["go"],
+      "groupName": "go",
+      "minimumGroupSize": 3,
       "minimumReleaseAge": "0 days"
     }
   ]

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -161,6 +161,11 @@
       "matchDatasources": ["docker", "golang-version"],
       "matchPackageNames": ["go", "golang"],
       "minimumReleaseAge": "0 days"
+    },
+    {
+      "matchManagers": ["mise"],
+      "matchPackageNames": ["go"],
+      "minimumReleaseAge": "0 days"
     }
   ]
 }

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -14,6 +14,8 @@
   "postUpdateOptions": ["gomodTidy"],
   "rebaseWhen": "conflicted",
   "commitBodyTable": true,
+  "minimumReleaseAge": "7 days",
+  "internalChecksFilter": "strict",
   "customManagers": [
     {
       "customType": "regex",
@@ -140,6 +142,25 @@
     {
       "matchSourceUrls": ["https://github.com/aws/aws-sdk-go-v2"],
       "fetchChangeLogs": "off"
+    },
+    {
+      "matchDepNames": [
+        "ghcr.io/coreweave/**",
+        "buf.build/gen/go/coreweave/**"
+      ],
+      "minimumReleaseAge": "0 days"
+    },
+    {
+      "matchPackageNames": [
+        "ghcr.io/coreweave/**",
+        "buf.build/gen/go/coreweave/**"
+      ],
+      "minimumReleaseAge": "0 days"
+    },
+    {
+      "matchDatasources": ["docker", "golang-version"],
+      "matchPackageNames": ["go", "golang"],
+      "minimumReleaseAge": "0 days"
     }
   ]
 }


### PR DESCRIPTION
Adds a seven-day release-age gate to dependency update automation while keeping immediately available updates for dependency categories used by the repository.

## Changes

- Require updates to be seven days old before Renovate proposes them.
- Keep strict internal-check filtering enabled.
- Preserve immediate handling only for the repository's CI image, generated modules, and Go-version updates.

## Validation

- Strict Renovate configuration validation
- `git diff --check`
