### PR TITLE
ci(mise): remove unused tools

### DIFF
--- a/.config/mise.toml
+++ b/.config/mise.toml
@@ -3,19 +3,8 @@
 # https://github.com/jdx/mise/pull/6231
 [tools]
 go = "1.25.6"
-# make sure go is installed before go tools
-"go:golang.org/x/tools/cmd/godoc" = "v0.30.0"
-"go:golang.org/x/tools/cmd/goimports" = "v0.48.0"
-"ubi:daltonsw/prism" = "1.3.0"
 golangci-lint = "2.5.0"
-"github:goreleaser/goreleaser-pro" = "2.12.6"
-lychee = "0.24.2"
-shellcheck = "0.11.0"
-shfmt = "3.13.1"
-typos = "1.48.0"
-yamlfmt = "0.21.0"
 terraform = "1.15.8"
-"github:cli/cli" = "2.87.3"
 
 # go backend is experimental
 [settings]


### PR DESCRIPTION
Removes mise-managed tools that have no tracked repository consumers, including Prism. Go, `golangci-lint`, and Terraform remain pinned because the build, lint, and generation workflows invoke them.

## Why

The removed tools were installed by the common mise setup in every CI job without being executed. GoReleaser remains provided by `goreleaser-action`, which installs and invokes its own binary.

## Validation

- `make generate`
- `make test`
- Parsed the reduced config in isolation and resolved the three retained tools at their pinned versions
- `git diff --check`
- GitHub Actions passed build, snapshot build, generation, lint, and tests at `f374fb8`

## Caveats

A local clean-cache `make lint` reports 65 findings in unchanged Go files: 50 `goconst` and 15 `prealloc`. GitHub Actions lint passes at the same commit.
