### PR TITLE
ci(renovate): fix Go version updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -74,14 +74,16 @@
       "matchDatasources": ["github-tags"],
       "matchPackageNames": ["golang/go"],
       "overrideDatasource": "golang-version",
-      "overridePackageName": "go"
+      "overridePackageName": "go",
+      "extractVersion": "^(?<version>\\S+)$"
     },
     {
       "matchPackageNames": ["go"],
       "matchDatasources": ["golang-version"],
       "semanticCommitType": "deps",
       "semanticCommitScope": null,
-      "sourceUrl": "https://github.com/golang/go"
+      "sourceUrl": "https://github.com/golang/go",
+      "changelogUrl": "https://go.dev/doc/devel/release#go{{newMajor}}.{{newMinor}}.0"
     },
     {
       "matchManagers": ["gomod"],


### PR DESCRIPTION
This updates Renovate’s Go metadata so native mise and Go module version updates use the `golang-version` datasource consistently and show version-specific official release notes.

## Changes

- Normalize bare versions from the existing `golang/go` GitHub-tags override.
- Link Go updates to the corresponding Go release-history section.
- Preserve the existing grouping of `.config/mise.toml`, `go.mod`, and `tools/go.mod` without adding a custom regex manager.

## Validation

- `renovate-config-validator --strict .github/renovate.json5`
- `git diff --check`
