### PR TITLE
chore: fix golangci-lint findings

### DIFF
--- a/coreweave/cks/data_source_cluster.go
+++ b/coreweave/cks/data_source_cluster.go
@@ -94,11 +94,11 @@ func (d *ClusterDataSource) Schema(ctx context.Context, req datasource.SchemaReq
 				MarkdownDescription: "The Kubernetes Service NodePort range.",
 				Computed:            true,
 				Attributes: map[string]schema.Attribute{
-					"start": schema.Int32Attribute{
+					schemaKeyStart: schema.Int32Attribute{
 						MarkdownDescription: "Start of the NodePort range.",
 						Computed:            true,
 					},
-					"end": schema.Int32Attribute{
+					schemaKeyEnd: schema.Int32Attribute{
 						MarkdownDescription: "End of the NodePort range.",
 						Computed:            true,
 					},
@@ -112,11 +112,11 @@ func (d *ClusterDataSource) Schema(ctx context.Context, req datasource.SchemaReq
 				MarkdownDescription: "The OIDC configuration of the cluster.",
 				Computed:            true,
 				Attributes: map[string]schema.Attribute{
-					"issuer_url": schema.StringAttribute{
+					schemaKeyIssuerURL: schema.StringAttribute{
 						MarkdownDescription: "The issuer URL of the OIDC configuration.",
 						Computed:            true,
 					},
-					"client_id": schema.StringAttribute{
+					schemaKeyClientID: schema.StringAttribute{
 						MarkdownDescription: "The client ID of the OIDC configuration.",
 						Computed:            true,
 					},
@@ -126,7 +126,7 @@ func (d *ClusterDataSource) Schema(ctx context.Context, req datasource.SchemaReq
 				MarkdownDescription: "The authentication webhook configuration of the cluster.",
 				Computed:            true,
 				Attributes: map[string]schema.Attribute{
-					"server": schema.StringAttribute{
+					schemaKeyServer: schema.StringAttribute{
 						MarkdownDescription: "The server URL of the authentication webhook.",
 						Computed:            true,
 					},
@@ -140,7 +140,7 @@ func (d *ClusterDataSource) Schema(ctx context.Context, req datasource.SchemaReq
 				MarkdownDescription: "The authorization webhook configuration of the cluster.",
 				Computed:            true,
 				Attributes: map[string]schema.Attribute{
-					"server": schema.StringAttribute{
+					schemaKeyServer: schema.StringAttribute{
 						MarkdownDescription: "The server URL of the authorization webhook.",
 						Computed:            true,
 					},
@@ -175,7 +175,7 @@ func (d *ClusterDataSource) Schema(ctx context.Context, req datasource.SchemaReq
 				MarkdownDescription: "Tailscale configuration for the cluster. Enables cluster access over a Tailscale VPN.",
 				Computed:            true,
 				Attributes: map[string]schema.Attribute{
-					"client_id": schema.StringAttribute{
+					schemaKeyClientID: schema.StringAttribute{
 						MarkdownDescription: "The Tailscale Client ID for the federated identity.",
 						Computed:            true,
 					},

--- a/coreweave/cks/resource_cluster.go
+++ b/coreweave/cks/resource_cluster.go
@@ -248,27 +248,27 @@ func (c *ClusterResourceModel) Set(cluster *cksv1beta1.Cluster) {
 		if !nodePortEmpty(cluster.Network.ServiceNodePortRange) {
 			c.NodePortRange = types.ObjectValueMust(
 				map[string]attr.Type{
-					"start": types.Int32Type,
-					"end":   types.Int32Type,
+					schemaKeyStart: types.Int32Type,
+					schemaKeyEnd:   types.Int32Type,
 				},
 				map[string]attr.Value{
-					"start": types.Int32Value(cluster.Network.ServiceNodePortRange.Start),
-					"end":   types.Int32Value(cluster.Network.ServiceNodePortRange.End),
+					schemaKeyStart: types.Int32Value(cluster.Network.ServiceNodePortRange.Start),
+					schemaKeyEnd:   types.Int32Value(cluster.Network.ServiceNodePortRange.End),
 				},
 			)
 		} else {
 			// if the plan value is null/unknown & the API returns empty, preserve null
 			// otherwise set to null based on API response
 			c.NodePortRange = types.ObjectNull(map[string]attr.Type{
-				"start": types.Int32Type,
-				"end":   types.Int32Type,
+				schemaKeyStart: types.Int32Type,
+				schemaKeyEnd:   types.Int32Type,
 			})
 		}
 	} else {
 		// if network is nil, ensure node_port_range is properly null
 		c.NodePortRange = types.ObjectNull(map[string]attr.Type{
-			"start": types.Int32Type,
-			"end":   types.Int32Type,
+			schemaKeyStart: types.Int32Type,
+			schemaKeyEnd:   types.Int32Type,
 		})
 	}
 
@@ -423,8 +423,8 @@ func (c *ClusterResourceModel) NodePorts() *cksv1beta1.PortRange {
 		return nil
 	}
 	attrs := c.NodePortRange.Attributes()
-	startAttr, okStart := attrs["start"].(types.Int32)
-	endAttr, okEnd := attrs["end"].(types.Int32)
+	startAttr, okStart := attrs[schemaKeyStart].(types.Int32)
+	endAttr, okEnd := attrs[schemaKeyEnd].(types.Int32)
 	if !okStart || !okEnd {
 		return nil
 	}
@@ -773,10 +773,10 @@ func requireReplaceIfNodePortRangeShrink(ctx context.Context, req planmodifier.O
 	sAttrs := stateObj.Attributes()
 	pAttrs := planObj.Attributes()
 
-	sStart, sStartOK := sAttrs["start"].(types.Int32)
-	sEnd, sEndOK := sAttrs["end"].(types.Int32)
-	pStart, pStartOK := pAttrs["start"].(types.Int32)
-	pEnd, pEndOK := pAttrs["end"].(types.Int32)
+	sStart, sStartOK := sAttrs[schemaKeyStart].(types.Int32)
+	sEnd, sEndOK := sAttrs[schemaKeyEnd].(types.Int32)
+	pStart, pStartOK := pAttrs[schemaKeyStart].(types.Int32)
+	pEnd, pEndOK := pAttrs[schemaKeyEnd].(types.Int32)
 	if !sStartOK || !sEndOK || !pStartOK || !pEndOK {
 		return
 	}
@@ -931,11 +931,11 @@ func (r *ClusterResource) Schema(ctx context.Context, req resource.SchemaRequest
 					objectplanmodifier.RequiresReplaceIf(requireReplaceIfNodePortRangeShrink, "", "Field `node_port_range` only requires replacement when the planned range shrinks the existing range."),
 				},
 				Attributes: map[string]schema.Attribute{
-					"start": schema.Int32Attribute{
+					schemaKeyStart: schema.Int32Attribute{
 						Computed: true,
 						Optional: true,
 					},
-					"end": schema.Int32Attribute{
+					schemaKeyEnd: schema.Int32Attribute{
 						Computed: true,
 						Optional: true,
 					},
@@ -949,7 +949,7 @@ func (r *ClusterResource) Schema(ctx context.Context, req resource.SchemaRequest
 				Optional:            true,
 				MarkdownDescription: "Authentication webhook configuration for the cluster.",
 				Attributes: map[string]schema.Attribute{
-					"server": schema.StringAttribute{
+					schemaKeyServer: schema.StringAttribute{
 						Required:            true,
 						MarkdownDescription: "The URL of the webhook server.",
 					},
@@ -963,7 +963,7 @@ func (r *ClusterResource) Schema(ctx context.Context, req resource.SchemaRequest
 				Optional:            true,
 				MarkdownDescription: "Authorization webhook configuration for the cluster.",
 				Attributes: map[string]schema.Attribute{
-					"server": schema.StringAttribute{
+					schemaKeyServer: schema.StringAttribute{
 						Required:            true,
 						MarkdownDescription: "The URL of the webhook server.",
 					},
@@ -977,11 +977,11 @@ func (r *ClusterResource) Schema(ctx context.Context, req resource.SchemaRequest
 				MarkdownDescription: "OpenID Connect (OIDC) configuration for authentication to the api-server.",
 				Optional:            true,
 				Attributes: map[string]schema.Attribute{
-					"issuer_url": schema.StringAttribute{
+					schemaKeyIssuerURL: schema.StringAttribute{
 						Required:            true,
 						MarkdownDescription: "The URL of the OIDC issuer.",
 					},
-					"client_id": schema.StringAttribute{
+					schemaKeyClientID: schema.StringAttribute{
 						Required:            true,
 						MarkdownDescription: "The client ID for the OIDC client.",
 					},
@@ -1064,7 +1064,7 @@ func (r *ClusterResource) Schema(ctx context.Context, req resource.SchemaRequest
 				Optional:            true,
 				MarkdownDescription: "Tailscale configuration for the cluster. Enables cluster access via a Tailscale VPN.",
 				Attributes: map[string]schema.Attribute{
-					"client_id": schema.StringAttribute{
+					schemaKeyClientID: schema.StringAttribute{
 						Required:            true,
 						MarkdownDescription: "The Tailscale Client ID for the federated identity.",
 						Validators: []validator.String{
@@ -1140,7 +1140,7 @@ func (r *ClusterResource) Create(ctx context.Context, req resource.CreateRequest
 			}))
 			if err != nil {
 				tflog.Error(ctx, "failed to fetch cluster resource", map[string]interface{}{
-					"error": err,
+					logKeyError: err,
 				})
 				return nil, cksv1beta1.Cluster_STATUS_UNSPECIFIED.String(), err
 			}
@@ -1242,7 +1242,7 @@ func (r *ClusterResource) Update(ctx context.Context, req resource.UpdateRequest
 			}))
 			if err != nil {
 				tflog.Error(ctx, "failed to fetch cluster resource", map[string]interface{}{
-					"error": err.Error(),
+					logKeyError: err.Error(),
 				})
 				return nil, cksv1beta1.Cluster_STATUS_UNSPECIFIED.String(), err
 			}
@@ -1307,7 +1307,7 @@ func (r *ClusterResource) Delete(ctx context.Context, req resource.DeleteRequest
 				}
 
 				tflog.Error(ctx, "failed to fetch cluster resource", map[string]interface{}{
-					"error": err.Error(),
+					logKeyError: err.Error(),
 				})
 				return nil, cksv1beta1.Cluster_STATUS_UNSPECIFIED.String(), err
 			}
@@ -1373,12 +1373,12 @@ func MustRenderClusterResource(ctx context.Context, resourceName string, cluster
 
 	if !cluster.NodePortRange.IsNull() && !cluster.NodePortRange.IsUnknown() {
 		attrs := cluster.NodePortRange.Attributes()
-		startAttr, okStart := attrs["start"].(types.Int32)
-		endAttr, okEnd := attrs["end"].(types.Int32)
+		startAttr, okStart := attrs[schemaKeyStart].(types.Int32)
+		endAttr, okEnd := attrs[schemaKeyEnd].(types.Int32)
 		if okStart && okEnd {
 			resourceBody.SetAttributeValue("node_port_range", cty.ObjectVal(map[string]cty.Value{
-				"start": cty.NumberIntVal(int64(startAttr.ValueInt32())),
-				"end":   cty.NumberIntVal(int64(endAttr.ValueInt32())),
+				schemaKeyStart: cty.NumberIntVal(int64(startAttr.ValueInt32())),
+				schemaKeyEnd:   cty.NumberIntVal(int64(endAttr.ValueInt32())),
 			}))
 		}
 	}
@@ -1389,15 +1389,15 @@ func MustRenderClusterResource(ctx context.Context, resourceName string, cluster
 	// authn/authz webhooks
 	if cluster.AuthNWebhook != nil {
 		resourceBody.SetAttributeValue("authn_webhook", cty.ObjectVal(map[string]cty.Value{
-			"server": cty.StringVal(cluster.AuthNWebhook.Server.ValueString()),
-			"ca":     stringOrNull(cluster.AuthNWebhook.CA),
+			schemaKeyServer: cty.StringVal(cluster.AuthNWebhook.Server.ValueString()),
+			"ca":            stringOrNull(cluster.AuthNWebhook.CA),
 		}))
 	}
 
 	if cluster.AuthZWebhook != nil {
 		resourceBody.SetAttributeValue("authz_webhook", cty.ObjectVal(map[string]cty.Value{
-			"server": cty.StringVal(cluster.AuthZWebhook.Server.ValueString()),
-			"ca":     stringOrNull(cluster.AuthZWebhook.CA),
+			schemaKeyServer: cty.StringVal(cluster.AuthZWebhook.Server.ValueString()),
+			"ca":            stringOrNull(cluster.AuthZWebhook.CA),
 		}))
 	}
 
@@ -1407,7 +1407,7 @@ func MustRenderClusterResource(ctx context.Context, resourceName string, cluster
 
 	if cluster.Tailscale != nil {
 		resourceBody.SetAttributeValue("tailscale", cty.ObjectVal(map[string]cty.Value{
-			"client_id": cty.StringVal(cluster.Tailscale.ClientID.ValueString()),
+			schemaKeyClientID: cty.StringVal(cluster.Tailscale.ClientID.ValueString()),
 		}))
 	}
 
@@ -1490,8 +1490,8 @@ func setOIDCAttrIfPresent(ctx context.Context, b *hclwrite.Body, oidc *OidcResou
 	}
 
 	b.SetAttributeValue("oidc", cty.ObjectVal(map[string]cty.Value{
-		"issuer_url":          stringOrNull(oidc.IssuerURL),
-		"client_id":           stringOrNull(oidc.ClientID),
+		schemaKeyIssuerURL:    stringOrNull(oidc.IssuerURL),
+		schemaKeyClientID:     stringOrNull(oidc.ClientID),
 		"username_claim":      stringOrNull(oidc.UsernameClaim),
 		"username_prefix":     stringOrNull(oidc.UsernamePrefix),
 		"groups_claim":        stringOrNull(oidc.GroupsClaim),

--- a/coreweave/cks/resource_cluster_test.go
+++ b/coreweave/cks/resource_cluster_test.go
@@ -35,6 +35,11 @@ const (
 	AuditPolicyB64       = "ewogICJhcGlWZXJzaW9uIjogImF1ZGl0Lms4cy5pby92MSIsCiAgImtpbmQiOiAiUG9saWN5IiwKICAib21pdFN0YWdlcyI6IFsKICAgICJSZXF1ZXN0UmVjZWl2ZWQiCiAgXSwKICAicnVsZXMiOiBbCiAgICB7CiAgICAgICJsZXZlbCI6ICJSZXF1ZXN0UmVzcG9uc2UiLAogICAgICAicmVzb3VyY2VzIjogWwogICAgICAgIHsKICAgICAgICAgICJncm91cCI6ICIiLAogICAgICAgICAgInJlc291cmNlcyI6IFsKICAgICAgICAgICAgInBvZHMiCiAgICAgICAgICBdCiAgICAgICAgfQogICAgICBdCiAgICB9LAogICAgewogICAgICAibGV2ZWwiOiAiTWV0YWRhdGEiLAogICAgICAicmVzb3VyY2VzIjogWwogICAgICAgIHsKICAgICAgICAgICJncm91cCI6ICIiLAogICAgICAgICAgInJlc291cmNlcyI6IFsKICAgICAgICAgICAgInBvZHMvbG9nIiwKICAgICAgICAgICAgInBvZHMvc3RhdHVzIgogICAgICAgICAgXQogICAgICAgIH0KICAgICAgXQogICAgfSwKICAgIHsKICAgICAgImxldmVsIjogIk5vbmUiLAogICAgICAicmVzb3VyY2VzIjogWwogICAgICAgIHsKICAgICAgICAgICJncm91cCI6ICIiLAogICAgICAgICAgInJlc291cmNlcyI6IFsKICAgICAgICAgICAgImNvbmZpZ21hcHMiCiAgICAgICAgICBdLAogICAgICAgICAgInJlc291cmNlTmFtZXMiOiBbCiAgICAgICAgICAgICJjb250cm9sbGVyLWxlYWRlciIKICAgICAgICAgIF0KICAgICAgICB9CiAgICAgIF0KICAgIH0sCiAgICB7CiAgICAgICJsZXZlbCI6ICJOb25lIiwKICAgICAgInVzZXJzIjogWwogICAgICAgICJzeXN0ZW06a3ViZS1wcm94eSIKICAgICAgXSwKICAgICAgInZlcmJzIjogWwogICAgICAgICJ3YXRjaCIKICAgICAgXSwKICAgICAgInJlc291cmNlcyI6IFsKICAgICAgICB7CiAgICAgICAgICAiZ3JvdXAiOiAiIiwKICAgICAgICAgICJyZXNvdXJjZXMiOiBbCiAgICAgICAgICAgICJlbmRwb2ludHMiLAogICAgICAgICAgICAic2VydmljZXMiCiAgICAgICAgICBdCiAgICAgICAgfQogICAgICBdCiAgICB9LAogICAgewogICAgICAibGV2ZWwiOiAiTm9uZSIsCiAgICAgICJ1c2VyR3JvdXBzIjogWwogICAgICAgICJzeXN0ZW06YXV0aGVudGljYXRlZCIKICAgICAgXSwKICAgICAgIm5vblJlc291cmNlVVJMcyI6IFsKICAgICAgICAiL2FwaSoiLAogICAgICAgICIvdmVyc2lvbiIKICAgICAgXQogICAgfSwKICAgIHsKICAgICAgImxldmVsIjogIlJlcXVlc3QiLAogICAgICAicmVzb3VyY2VzIjogWwogICAgICAgIHsKICAgICAgICAgICJncm91cCI6ICIiLAogICAgICAgICAgInJlc291cmNlcyI6IFsKICAgICAgICAgICAgImNvbmZpZ21hcHMiCiAgICAgICAgICBdCiAgICAgICAgfQogICAgICBdLAogICAgICAibmFtZXNwYWNlcyI6IFsKICAgICAgICAia3ViZS1zeXN0ZW0iCiAgICAgIF0KICAgIH0sCiAgICB7CiAgICAgICJsZXZlbCI6ICJNZXRhZGF0YSIsCiAgICAgICJyZXNvdXJjZXMiOiBbCiAgICAgICAgewogICAgICAgICAgImdyb3VwIjogIiIsCiAgICAgICAgICAicmVzb3VyY2VzIjogWwogICAgICAgICAgICAic2VjcmV0cyIsCiAgICAgICAgICAgICJjb25maWdtYXBzIgogICAgICAgICAgXQogICAgICAgIH0KICAgICAgXQogICAgfSwKICAgIHsKICAgICAgImxldmVsIjogIlJlcXVlc3QiLAogICAgICAicmVzb3VyY2VzIjogWwogICAgICAgIHsKICAgICAgICAgICJncm91cCI6ICIiCiAgICAgICAgfSwKICAgICAgICB7CiAgICAgICAgICAiZ3JvdXAiOiAiZXh0ZW5zaW9ucyIKICAgICAgICB9CiAgICAgIF0KICAgIH0sCiAgICB7CiAgICAgICJsZXZlbCI6ICJNZXRhZGF0YSIsCiAgICAgICJvbWl0U3RhZ2VzIjogWwogICAgICAgICJSZXF1ZXN0UmVjZWl2ZWQiCiAgICAgIF0KICAgIH0KICBdCn0K"
 	ExampleCAB64         = "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURnekNDQW11Z0F3SUJBZ0lRVGhhQitUNmdtdVVYN3dXZi9XUitmekFOQmdrcWhraUc5dzBCQVFzRkFEQUEKTUI0WERUSTBNRFl5TlRJeE1UY3pNVm9YRFRJME1Ea3lNekl4TVRjek1Wb3dBRENDQVNJd0RRWUpLb1pJaHZjTgpBUUVCQlFBRGdnRVBBRENDQVFvQ2dnRUJBT240VkVpRWJoL29GRkoxcG1QZXZxb1pBbWtVUjRqeWd5Y0MvRFhCCmVEWjYxd1NzV1FPU21peFg1bDZDd1FXNzdkV3NRVGhsU0RqN003RytxYjZCWHBSUWcrMndJOFVsVHp6Y0NpM0UKN1pib2M2LzI1YXd3NVpLOW1GVWVGWlBWemI4ZHNuVUFkbmFNa2V2ckFGQXNoL0NmSEh0cThzSUZnOVF2SWJnUApNRFJJcnZnSmlGY1NLS1E5clgxOWkzcFY3ZE9UaGxaYW11UWRGUjhGSVgyQ3BVQithajdSWkdMTFFra3AzMzhUCjFTRk5hK3V1THk3Mlh6MldIdEdqOTE5OFVENFFTRzByd2JUYXEvQVdxNjcvblhRS2FOQ2xHYzlGajNRSjU2NEUKK3cvWXBvK1krc053OXY0M1NVSVdyQXRMNGRicHNadlBEK0FKS1RDRXArUExZWlVDQXdFQUFhT0IrRENCOVRBTwpCZ05WSFE4QkFmOEVCQU1DQmFBd0RBWURWUjBUQVFIL0JBSXdBRENCMUFZRFZSMFJBUUgvQklISk1JSEdnaVJsCmVHVmpkWFJ2Y2kxcllYUmhiRzluTFdWNFpXTjFkRzl5TFhKbFkyOXVZMmxzWlhLQ0xHVjRaV04xZEc5eUxXdGgKZEdGc2IyY3RaWGhsWTNWMGIzSXRjbVZqYjI1amFXeGxjaTVyWVhSaGJHOW5nakJsZUdWamRYUnZjaTFyWVhSaApiRzluTFdWNFpXTjFkRzl5TFhKbFkyOXVZMmxzWlhJdWEyRjBZV3h2Wnk1emRtT0NQbVY0WldOMWRHOXlMV3RoCmRHRnNiMmN0WlhobFkzVjBiM0l0Y21WamIyNWphV3hsY2k1cllYUmhiRzluTG5OMll5NWpiSFZ6ZEdWeUxteHYKWTJGc01BMEdDU3FHU0liM0RRRUJDd1VBQTRJQkFRQlEvQ2JBdEFCQkZORUE5d1hYaE9vYUNrRFY1dTc3VFlzMQpFV2FJcFJFNjV5QmVtTDc2eXpYeEtoc2RmR3RJSmJ0THBWS1lUYlpBVTQrem9IS1NVTWs4REY4bXN0dGhOMWQ5CnR6a1d4ZXZ3UGViL2NtMVZVWlBzWkxvNnFRblJRUFJCUXc0dFpWdkhTWmtsSjBVb2lvVk5zOWJJY3ZQZ2Z4UW0KNkhDU3NEWU9sWnlPRHlrY045U21nbFZtVWFNeVkxMGcrL3BWRzg4WkRyLy9zdUI1ZERPaktUcDNGbjRPSGR0VwpnRmpuY3RVOEV4Zk5YNTR1Yndja2ZTMGdiOXRtejcyaHN3OU5KaTV2QXlMS2ZIcmxNNTJTeWhwUVZKbkpPYzF6ClhqQVlLTHE1M1E1TGt3RXBZMXpkL21XdVhkRWswWldZcHlXemk3WWN4UXQreUJkWVNJQzEKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo="
 	AcceptanceTestPrefix = "test-acc-"
+	schemaKeyStart       = "start"
+	schemaKeyEnd         = "end"
+	schemaKeyIssuerURL   = "issuer_url"
+	schemaKeyClientID    = "client_id"
+	schemaKeyServer      = "server"
 )
 
 func deleteCluster(ctx context.Context, client *coreweave.Client, cluster *cksv1beta1.Cluster) error {
@@ -299,8 +304,9 @@ func createClusterTestStep(ctx context.Context, t *testing.T, config testStepCon
 		}
 
 		// internal lb cidrs
-		internalLbCidrs := []knownvalue.Check{}
-		for _, c := range config.cluster.InternalLbCidrNames(ctx) {
+		internalLbCidrNames := config.cluster.InternalLbCidrNames(ctx)
+		internalLbCidrs := make([]knownvalue.Check, 0, len(internalLbCidrNames))
+		for _, c := range internalLbCidrNames {
 			internalLbCidrs = append(internalLbCidrs, knownvalue.StringExact(c))
 		}
 		statechecks = append(statechecks, statecheck.ExpectKnownValue(config.Resources.FullResourceName, tfjsonpath.New("internal_lb_cidr_names"), knownvalue.ListExact(internalLbCidrs)))
@@ -308,8 +314,8 @@ func createClusterTestStep(ctx context.Context, t *testing.T, config testStepCon
 		// oidc
 		if config.cluster.Oidc != nil {
 			oidc := map[string]knownvalue.Check{
-				"issuer_url":          stringOrNull(config.cluster.Oidc.IssuerURL),
-				"client_id":           stringOrNull(config.cluster.Oidc.ClientID),
+				schemaKeyIssuerURL:    stringOrNull(config.cluster.Oidc.IssuerURL),
+				schemaKeyClientID:     stringOrNull(config.cluster.Oidc.ClientID),
 				"username_claim":      stringOrNull(config.cluster.Oidc.UsernameClaim),
 				"username_prefix":     stringOrNull(config.cluster.Oidc.UsernamePrefix),
 				"groups_claim":        stringOrNull(config.cluster.Oidc.GroupsClaim),
@@ -327,7 +333,7 @@ func createClusterTestStep(ctx context.Context, t *testing.T, config testStepCon
 					t.FailNow()
 				}
 
-				checks := []knownvalue.Check{}
+				checks := make([]knownvalue.Check, 0, len(algs))
 				for _, a := range algs {
 					checks = append(checks, knownvalue.StringExact(a.ValueString()))
 				}
@@ -339,16 +345,16 @@ func createClusterTestStep(ctx context.Context, t *testing.T, config testStepCon
 		// webhooks
 		if config.cluster.AuthNWebhook != nil {
 			authn := map[string]knownvalue.Check{
-				"server": knownvalue.StringExact(config.cluster.AuthNWebhook.Server.ValueString()),
-				"ca":     stringOrNull(config.cluster.AuthNWebhook.CA),
+				schemaKeyServer: knownvalue.StringExact(config.cluster.AuthNWebhook.Server.ValueString()),
+				"ca":            stringOrNull(config.cluster.AuthNWebhook.CA),
 			}
 			statechecks = append(statechecks, statecheck.ExpectKnownValue(config.Resources.FullResourceName, tfjsonpath.New("authn_webhook"), knownvalue.ObjectExact(authn)))
 		}
 
 		if config.cluster.AuthZWebhook != nil {
 			authz := map[string]knownvalue.Check{
-				"server": knownvalue.StringExact(config.cluster.AuthZWebhook.Server.ValueString()),
-				"ca":     stringOrNull(config.cluster.AuthZWebhook.CA),
+				schemaKeyServer: knownvalue.StringExact(config.cluster.AuthZWebhook.Server.ValueString()),
+				"ca":            stringOrNull(config.cluster.AuthZWebhook.CA),
 			}
 			statechecks = append(statechecks, statecheck.ExpectKnownValue(config.Resources.FullResourceName, tfjsonpath.New("authz_webhook"), knownvalue.ObjectExact(authz)))
 		}
@@ -356,11 +362,11 @@ func createClusterTestStep(ctx context.Context, t *testing.T, config testStepCon
 		// node_port_range
 		if !config.cluster.NodePortRange.IsNull() && !config.cluster.NodePortRange.IsUnknown() {
 			attrs := config.cluster.NodePortRange.Attributes()
-			if s, ok := attrs["start"].(types.Int32); ok && !s.IsNull() && !s.IsUnknown() {
-				statechecks = append(statechecks, statecheck.ExpectKnownValue(config.Resources.FullResourceName, tfjsonpath.New("node_port_range").AtMapKey("start"), knownvalue.Int64Exact(int64(s.ValueInt32()))))
+			if s, ok := attrs[schemaKeyStart].(types.Int32); ok && !s.IsNull() && !s.IsUnknown() {
+				statechecks = append(statechecks, statecheck.ExpectKnownValue(config.Resources.FullResourceName, tfjsonpath.New("node_port_range").AtMapKey(schemaKeyStart), knownvalue.Int64Exact(int64(s.ValueInt32()))))
 			}
-			if e, ok := attrs["end"].(types.Int32); ok && !e.IsNull() && !e.IsUnknown() {
-				statechecks = append(statechecks, statecheck.ExpectKnownValue(config.Resources.FullResourceName, tfjsonpath.New("node_port_range").AtMapKey("end"), knownvalue.Int64Exact(int64(e.ValueInt32()))))
+			if e, ok := attrs[schemaKeyEnd].(types.Int32); ok && !e.IsNull() && !e.IsUnknown() {
+				statechecks = append(statechecks, statecheck.ExpectKnownValue(config.Resources.FullResourceName, tfjsonpath.New("node_port_range").AtMapKey(schemaKeyEnd), knownvalue.Int64Exact(int64(e.ValueInt32()))))
 			}
 		}
 
@@ -380,7 +386,7 @@ func createClusterTestStep(ctx context.Context, t *testing.T, config testStepCon
 
 		// tailscale
 		if config.cluster.Tailscale != nil {
-			statechecks = append(statechecks, statecheck.ExpectKnownValue(config.Resources.FullResourceName, tfjsonpath.New("tailscale").AtMapKey("client_id"), knownvalue.StringExact(config.cluster.Tailscale.ClientID.ValueString())))
+			statechecks = append(statechecks, statecheck.ExpectKnownValue(config.Resources.FullResourceName, tfjsonpath.New("tailscale").AtMapKey(schemaKeyClientID), knownvalue.StringExact(config.cluster.Tailscale.ClientID.ValueString())))
 		} else {
 			statechecks = append(statechecks, statecheck.ExpectKnownValue(config.Resources.FullResourceName, tfjsonpath.New("tailscale"), knownvalue.Null()))
 		}
@@ -415,22 +421,22 @@ func TestClusterResource(t *testing.T) {
 
 	vpc := defaultVpc(config.ClusterName, zone)
 	npTypes := map[string]attr.Type{
-		"start": types.Int32Type,
-		"end":   types.Int32Type,
+		schemaKeyStart: types.Int32Type,
+		schemaKeyEnd:   types.Int32Type,
 	}
 	npVals := map[string]attr.Value{
-		"start": types.Int32Value(30000),
-		"end":   types.Int32Value(39534),
+		schemaKeyStart: types.Int32Value(30000),
+		schemaKeyEnd:   types.Int32Value(39534),
 	}
 	np, _ := types.ObjectValue(npTypes, npVals)
 	npLargeVals := map[string]attr.Value{
-		"start": types.Int32Value(30000),
-		"end":   types.Int32Value(60000),
+		schemaKeyStart: types.Int32Value(30000),
+		schemaKeyEnd:   types.Int32Value(60000),
 	}
 	npLarge, _ := types.ObjectValue(npTypes, npLargeVals)
 	npSmallVals := map[string]attr.Value{
-		"start": types.Int32Value(30000),
-		"end":   types.Int32Value(34534),
+		schemaKeyStart: types.Int32Value(30000),
+		schemaKeyEnd:   types.Int32Value(34534),
 	}
 	npSmall, _ := types.ObjectValue(npTypes, npSmallVals)
 	// Non-lexicographic order (lex would be: internal-lb-cidr, internal-lb-cidr-0, internal-lb-cidr-2)
@@ -575,8 +581,8 @@ func TestClusterResource(t *testing.T) {
 				statecheck.ExpectKnownValue(config.FullDataSourceName, tfjsonpath.New("public"), knownvalue.Bool(initial.Public.ValueBool())),
 				statecheck.ExpectKnownValue(config.FullDataSourceName, tfjsonpath.New("pod_cidr_name"), knownvalue.StringExact(initial.PodCidrName.ValueString())),
 				statecheck.ExpectKnownValue(config.FullDataSourceName, tfjsonpath.New("service_cidr_name"), knownvalue.StringExact(initial.ServiceCidrName.ValueString())),
-				statecheck.ExpectKnownValue(config.FullDataSourceName, tfjsonpath.New("node_port_range").AtMapKey("start"), knownvalue.NotNull()),
-				statecheck.ExpectKnownValue(config.FullDataSourceName, tfjsonpath.New("node_port_range").AtMapKey("end"), knownvalue.NotNull()),
+				statecheck.ExpectKnownValue(config.FullDataSourceName, tfjsonpath.New("node_port_range").AtMapKey(schemaKeyStart), knownvalue.NotNull()),
+				statecheck.ExpectKnownValue(config.FullDataSourceName, tfjsonpath.New("node_port_range").AtMapKey(schemaKeyEnd), knownvalue.NotNull()),
 			},
 		},
 		createClusterTestStep(ctx, t, testStepConfig{
@@ -654,12 +660,12 @@ func TestClusterResource_V6FieldsCreateOnly(t *testing.T) {
 		},
 	)
 	npTypes := map[string]attr.Type{
-		"start": types.Int32Type,
-		"end":   types.Int32Type,
+		schemaKeyStart: types.Int32Type,
+		schemaKeyEnd:   types.Int32Type,
 	}
 	npVals := map[string]attr.Value{
-		"start": types.Int32Value(30000),
-		"end":   types.Int32Value(39534),
+		schemaKeyStart: types.Int32Value(30000),
+		schemaKeyEnd:   types.Int32Value(39534),
 	}
 	np, _ := types.ObjectValue(npTypes, npVals)
 

--- a/coreweave/cks/schema_constants.go
+++ b/coreweave/cks/schema_constants.go
@@ -1,0 +1,10 @@
+package cks
+
+const (
+	schemaKeyStart     = "start"
+	schemaKeyEnd       = "end"
+	schemaKeyIssuerURL = "issuer_url"
+	schemaKeyClientID  = "client_id"
+	schemaKeyServer    = "server"
+	logKeyError        = "error"
+)

--- a/coreweave/cks/update_mask_test.go
+++ b/coreweave/cks/update_mask_test.go
@@ -29,8 +29,8 @@ func TestBuildUpdateRequest(t *testing.T) {
 				types.StringValue("cidr-1"),
 			}),
 			NodePortRange: types.ObjectNull(map[string]attr.Type{
-				"start": types.Int32Type,
-				"end":   types.Int32Type,
+				schemaKeyStart: types.Int32Type,
+				schemaKeyEnd:   types.Int32Type,
 			}),
 			AuditPolicy:          types.StringNull(),
 			AdditionalServerSans: types.SetNull(types.StringType),

--- a/coreweave/inference/data_source_inference_capacity_claim_parameters.go
+++ b/coreweave/inference/data_source_inference_capacity_claim_parameters.go
@@ -29,7 +29,7 @@ type CapacityClaimParametersDataSourceModel struct {
 }
 
 var zoneInstanceTypesAttrTypes = map[string]attr.Type{
-	"instance_types": types.SetType{ElemType: types.StringType},
+	schemaKeyInstanceTypes: types.SetType{ElemType: types.StringType},
 }
 
 func (d *CapacityClaimParametersDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
@@ -45,7 +45,7 @@ func (d *CapacityClaimParametersDataSource) Schema(_ context.Context, _ datasour
 				MarkdownDescription: "Available instance types per zone (keyed by zone name).",
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
-						"instance_types": schema.SetAttribute{
+						schemaKeyInstanceTypes: schema.SetAttribute{
 							Computed:            true,
 							ElementType:         types.StringType,
 							MarkdownDescription: "Instance type IDs that can be claimed in this zone.",
@@ -93,7 +93,7 @@ func (d *CapacityClaimParametersDataSource) Read(ctx context.Context, _ datasour
 			typeVals[i] = types.StringValue(id)
 		}
 		obj, diags := types.ObjectValue(zoneInstanceTypesAttrTypes, map[string]attr.Value{
-			"instance_types": types.SetValueMust(types.StringType, typeVals),
+			schemaKeyInstanceTypes: types.SetValueMust(types.StringType, typeVals),
 		})
 		resp.Diagnostics.Append(diags...)
 		if resp.Diagnostics.HasError() {

--- a/coreweave/inference/data_source_inference_deployment_parameters.go
+++ b/coreweave/inference/data_source_inference_deployment_parameters.go
@@ -34,15 +34,15 @@ type InferenceDeploymentParametersDataSourceModel struct {
 
 var (
 	runtimeVersionsAttrTypes = map[string]attr.Type{
-		"versions": types.ListType{ElemType: types.StringType},
+		schemaKeyVersions: types.ListType{ElemType: types.StringType},
 	}
 
 	runtimeConfigOptionsAttrTypes = map[string]attr.Type{
-		"allowed_keys": types.ListType{ElemType: types.StringType},
+		schemaKeyAllowedKeys: types.ListType{ElemType: types.StringType},
 	}
 
 	engineEnvOptionsAttrTypes = map[string]attr.Type{
-		"allowed_names": types.ListType{ElemType: types.StringType},
+		schemaKeyAllowedNames: types.ListType{ElemType: types.StringType},
 	}
 )
 
@@ -64,7 +64,7 @@ func (d *InferenceDeploymentParametersDataSource) Schema(_ context.Context, _ da
 				MarkdownDescription: "Available runtime versions per engine (keyed by engine name).",
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
-						"versions": schema.ListAttribute{
+						schemaKeyVersions: schema.ListAttribute{
 							Computed:            true,
 							ElementType:         types.StringType,
 							MarkdownDescription: "Available semver versions for the engine, sorted by the API.",
@@ -77,7 +77,7 @@ func (d *InferenceDeploymentParametersDataSource) Schema(_ context.Context, _ da
 				MarkdownDescription: "Available runtime config options per engine (keyed by engine name).",
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
-						"allowed_keys": schema.ListAttribute{
+						schemaKeyAllowedKeys: schema.ListAttribute{
 							Computed:            true,
 							ElementType:         types.StringType,
 							MarkdownDescription: "Configuration keys accepted by the engine's `engine_config` field.",
@@ -90,7 +90,7 @@ func (d *InferenceDeploymentParametersDataSource) Schema(_ context.Context, _ da
 				MarkdownDescription: "Available engine environment variable options per engine (keyed by engine name).",
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
-						"allowed_names": schema.ListAttribute{
+						schemaKeyAllowedNames: schema.ListAttribute{
 							Computed:            true,
 							ElementType:         types.StringType,
 							MarkdownDescription: "Environment variable names accepted by the engine's `engine_env` field.",
@@ -98,7 +98,7 @@ func (d *InferenceDeploymentParametersDataSource) Schema(_ context.Context, _ da
 					},
 				},
 			},
-			"instance_types": schema.SetAttribute{
+			schemaKeyInstanceTypes: schema.SetAttribute{
 				Computed:            true,
 				ElementType:         types.StringType,
 				MarkdownDescription: "Available instance types for deployments.",
@@ -151,7 +151,7 @@ func (d *InferenceDeploymentParametersDataSource) Read(ctx context.Context, _ da
 				versionVals[i] = types.StringValue(v)
 			}
 			obj, diags := types.ObjectValue(runtimeVersionsAttrTypes, map[string]attr.Value{
-				"versions": types.ListValueMust(types.StringType, versionVals),
+				schemaKeyVersions: types.ListValueMust(types.StringType, versionVals),
 			})
 			resp.Diagnostics.Append(diags...)
 			if resp.Diagnostics.HasError() {
@@ -171,7 +171,7 @@ func (d *InferenceDeploymentParametersDataSource) Read(ctx context.Context, _ da
 				keyVals[i] = types.StringValue(k)
 			}
 			obj, diags := types.ObjectValue(runtimeConfigOptionsAttrTypes, map[string]attr.Value{
-				"allowed_keys": types.ListValueMust(types.StringType, keyVals),
+				schemaKeyAllowedKeys: types.ListValueMust(types.StringType, keyVals),
 			})
 			resp.Diagnostics.Append(diags...)
 			if resp.Diagnostics.HasError() {
@@ -191,7 +191,7 @@ func (d *InferenceDeploymentParametersDataSource) Read(ctx context.Context, _ da
 				nameVals[i] = types.StringValue(name)
 			}
 			obj, diags := types.ObjectValue(engineEnvOptionsAttrTypes, map[string]attr.Value{
-				"allowed_names": types.ListValueMust(types.StringType, nameVals),
+				schemaKeyAllowedNames: types.ListValueMust(types.StringType, nameVals),
 			})
 			resp.Diagnostics.Append(diags...)
 			if resp.Diagnostics.HasError() {

--- a/coreweave/inference/data_source_inference_gateway_parameters.go
+++ b/coreweave/inference/data_source_inference_gateway_parameters.go
@@ -36,7 +36,7 @@ func (d *GatewayParametersDataSource) Schema(_ context.Context, _ datasource.Sch
 	resp.Schema = schema.Schema{
 		MarkdownDescription: "Retrieve available [gateway](https://docs.coreweave.com/products/inference/gateways) parameters for CoreWeave Managed Inference.",
 		Attributes: map[string]schema.Attribute{
-			"zones": schema.SetAttribute{
+			schemaKeyZones: schema.SetAttribute{
 				Computed:            true,
 				ElementType:         types.StringType,
 				MarkdownDescription: "Available zones for inference gateways.",

--- a/coreweave/inference/resource_inference_capacity_claim.go
+++ b/coreweave/inference/resource_inference_capacity_claim.go
@@ -81,51 +81,51 @@ func (r *InferenceCapacityClaimResource) Schema(_ context.Context, _ resource.Sc
 				MarkdownDescription: "The unique identifier of the capacity claim.",
 				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
-			"organization_id": schema.StringAttribute{
+			schemaKeyOrganizationID: schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "The organization ID that owns the capacity claim.",
 				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
-			"status": schema.StringAttribute{
+			schemaKeyStatus: schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "The current status of the capacity claim. See the [Inference API overview](https://docs.coreweave.com/products/inference/reference/api-overview#status-values) for status values.",
 				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
-			"created_at": schema.StringAttribute{
+			schemaKeyCreatedAt: schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "RFC3339 timestamp of when the capacity claim was created.",
 				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
-			"updated_at": schema.StringAttribute{
+			schemaKeyUpdatedAt: schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "RFC3339 timestamp of when the capacity claim was last updated.",
 				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
-			"conditions": schema.ListNestedAttribute{
+			schemaKeyConditions: schema.ListNestedAttribute{
 				Computed:            true,
 				MarkdownDescription: "Detailed status conditions for the capacity claim.",
 				PlanModifiers:       []planmodifier.List{listplanmodifier.UseStateForUnknown()},
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
-						"type": schema.StringAttribute{
+						schemaKeyType: schema.StringAttribute{
 							Computed:            true,
-							MarkdownDescription: "The condition type (e.g. `Ready`, `Progressing`).",
+							MarkdownDescription: conditionTypeDescription,
 						},
-						"status": schema.StringAttribute{
+						schemaKeyStatus: schema.StringAttribute{
 							Computed:            true,
-							MarkdownDescription: "The condition status (`True`, `False`, or `Unknown`).",
+							MarkdownDescription: conditionStatusDescription,
 						},
-						"last_update_time": schema.StringAttribute{
+						schemaKeyLastUpdateTime: schema.StringAttribute{
 							Computed:            true,
-							MarkdownDescription: "RFC3339 timestamp of the last condition transition.",
+							MarkdownDescription: lastTransitionTimeDescription,
 						},
-						"reason": schema.StringAttribute{
+						schemaKeyReason: schema.StringAttribute{
 							Computed:            true,
-							MarkdownDescription: "A short, machine-readable reason for the condition's last transition.",
+							MarkdownDescription: lastTransitionReasonDescription,
 						},
-						"message": schema.StringAttribute{
+						schemaKeyMessage: schema.StringAttribute{
 							Computed:            true,
-							MarkdownDescription: "A human-readable message about the condition's last transition.",
+							MarkdownDescription: lastTransitionMessageDescription,
 						},
 					},
 				},
@@ -140,7 +140,7 @@ func (r *InferenceCapacityClaimResource) Schema(_ context.Context, _ resource.Sc
 				MarkdownDescription: "The number of instances pending allocation.",
 				PlanModifiers:       []planmodifier.Int64{int64planmodifier.UseStateForUnknown()},
 			},
-			"name": schema.StringAttribute{
+			schemaKeyName: schema.StringAttribute{
 				Required:            true,
 				MarkdownDescription: "The name of the capacity claim. Must be a valid hostname label.",
 				PlanModifiers:       []planmodifier.String{stringplanmodifier.RequiresReplace()},
@@ -172,7 +172,7 @@ func (r *InferenceCapacityClaimResource) Schema(_ context.Context, _ resource.Sc
 							stringvalidator.OneOf(coreweave.EnumValues(inferencev1.CapacityType_name, true)...),
 						},
 					},
-					"zones": schema.SetAttribute{
+					schemaKeyZones: schema.SetAttribute{
 						ElementType:         types.StringType,
 						Required:            true,
 						MarkdownDescription: "The availability zones where the capacity claim may use resources from (e.g. `US-WEST-04A`). At least one is required.",
@@ -248,7 +248,7 @@ func (r *InferenceCapacityClaimResource) Create(ctx context.Context, req resourc
 				Id: claimID,
 			}))
 			if err != nil {
-				tflog.Error(ctx, "failed to poll capacity claim", map[string]interface{}{"error": err.Error()})
+				tflog.Error(ctx, "failed to poll capacity claim", map[string]interface{}{logKeyError: err.Error()})
 				return nil, inferencev1.Status_STATUS_UNSPECIFIED.String(), err
 			}
 			cc := getResp.Msg.GetCapacityClaim()
@@ -354,7 +354,7 @@ func (r *InferenceCapacityClaimResource) Update(ctx context.Context, req resourc
 				Id: claimID,
 			}))
 			if err != nil {
-				tflog.Error(ctx, "failed to poll capacity claim", map[string]interface{}{"error": err.Error()})
+				tflog.Error(ctx, "failed to poll capacity claim", map[string]interface{}{logKeyError: err.Error()})
 				return nil, inferencev1.Status_STATUS_UNSPECIFIED.String(), err
 			}
 			cc := getResp.Msg.GetCapacityClaim()
@@ -429,7 +429,7 @@ func (r *InferenceCapacityClaimResource) Delete(ctx context.Context, req resourc
 				if coreweave.IsNotFoundError(err) {
 					return struct{}{}, deletedState, nil
 				}
-				tflog.Error(ctx, "failed to poll capacity claim deletion", map[string]interface{}{"error": err.Error()})
+				tflog.Error(ctx, "failed to poll capacity claim deletion", map[string]interface{}{logKeyError: err.Error()})
 				return nil, inferencev1.Status_STATUS_UNSPECIFIED.String(), err
 			}
 			cc := getResp.Msg.GetCapacityClaim()

--- a/coreweave/inference/resource_inference_capacity_claim_test.go
+++ b/coreweave/inference/resource_inference_capacity_claim_test.go
@@ -49,9 +49,9 @@ func TestSetFromCapacityClaim_Fields(t *testing.T) {
 
 	cc := (inferencev1.CapacityClaim_builder{
 		Spec: (inferencev1.CapacityClaimSpec_builder{
-			Id:             "cc-123",
+			Id:             testCapacityClaimID,
 			Name:           "my-capacity-claim",
-			OrganizationId: "org-456",
+			OrganizationId: testCapacityClaimOrganizationID,
 			Resources: (inferencev1.CapacityClaimResources_builder{
 				InstanceId:    testInstanceType,
 				InstanceCount: 3,
@@ -67,7 +67,7 @@ func TestSetFromCapacityClaim_Fields(t *testing.T) {
 			PendingInstances:   1,
 			Conditions: []*inferencev1.Condition{
 				(inferencev1.Condition_builder{
-					Type:           "Ready",
+					Type:           conditionTypeReady,
 					Status:         inferencev1.Condition_STATUS_TRUE,
 					LastUpdateTime: now,
 					Reason:         "AllAllocated",
@@ -83,14 +83,14 @@ func TestSetFromCapacityClaim_Fields(t *testing.T) {
 		t.Fatalf("SetFromCapacityClaim returned errors: %v", diags)
 	}
 
-	if m.ID.ValueString() != "cc-123" {
-		t.Errorf("ID: got %q, want %q", m.ID.ValueString(), "cc-123")
+	if m.ID.ValueString() != testCapacityClaimID {
+		t.Errorf("ID: got %q, want %q", m.ID.ValueString(), testCapacityClaimID)
 	}
 	if m.Name.ValueString() != "my-capacity-claim" {
 		t.Errorf("Name: got %q, want %q", m.Name.ValueString(), "my-capacity-claim")
 	}
-	if m.OrganizationID.ValueString() != "org-456" {
-		t.Errorf("OrganizationID: got %q, want %q", m.OrganizationID.ValueString(), "org-456")
+	if m.OrganizationID.ValueString() != testCapacityClaimOrganizationID {
+		t.Errorf("OrganizationID: got %q, want %q", m.OrganizationID.ValueString(), testCapacityClaimOrganizationID)
 	}
 	if m.Status.ValueString() != inferencev1.Status_STATUS_UNSPECIFIED.String() {
 		t.Errorf("Status: got %q, want %q", m.Status.ValueString(), inferencev1.Status_STATUS_UNSPECIFIED.String())
@@ -150,9 +150,9 @@ func TestSetFromCapacityClaim_PreserveStatusFields(t *testing.T) {
 	base := func(status inferencev1.Status, name, condReason string, allocated, pending uint32, updatedAt *timestamppb.Timestamp) *inferencev1.CapacityClaim {
 		return (inferencev1.CapacityClaim_builder{
 			Spec: (inferencev1.CapacityClaimSpec_builder{
-				Id:             "cc-123",
+				Id:             testCapacityClaimID,
 				Name:           name,
-				OrganizationId: "org-456",
+				OrganizationId: testCapacityClaimOrganizationID,
 				Resources: (inferencev1.CapacityClaimResources_builder{
 					InstanceId:    testInstanceType,
 					InstanceCount: 3,
@@ -167,7 +167,7 @@ func TestSetFromCapacityClaim_PreserveStatusFields(t *testing.T) {
 				PendingInstances:   pending,
 				Conditions: []*inferencev1.Condition{
 					(inferencev1.Condition_builder{
-						Type:   "Ready",
+						Type:   conditionTypeReady,
 						Status: inferencev1.Condition_STATUS_TRUE,
 						Reason: condReason,
 					}).Build(),
@@ -380,7 +380,7 @@ func TestInferenceCapacityClaim(t *testing.T) {
 						statecheck.ExpectKnownValue(fullResourceName, tfjsonpath.New("name"), knownvalue.StringExact(name)),
 						statecheck.ExpectKnownValue(fullResourceName, tfjsonpath.New("id"), knownvalue.NotNull()),
 						statecheck.ExpectKnownValue(fullResourceName, tfjsonpath.New("organization_id"), knownvalue.NotNull()),
-						statecheck.ExpectKnownValue(fullResourceName, tfjsonpath.New("status"), knownvalue.NotNull()),
+						statecheck.ExpectKnownValue(fullResourceName, tfjsonpath.New(schemaKeyStatus), knownvalue.NotNull()),
 						statecheck.ExpectKnownValue(fullResourceName, tfjsonpath.New("created_at"), knownvalue.NotNull()),
 						statecheck.ExpectKnownValue(fullResourceName, tfjsonpath.New("allocated_instances"), knownvalue.NotNull()),
 						statecheck.ExpectKnownValue(fullResourceName, tfjsonpath.New("pending_instances"), knownvalue.NotNull()),
@@ -414,7 +414,7 @@ func TestInferenceCapacityClaim(t *testing.T) {
 					// Server-observed fields are intentionally not refreshed into state on
 					// Update (see setFromCapacityClaim preserveStatusFields); a fresh import
 					// Read legitimately observes newer values, so they can't be verified here.
-					ImportStateVerifyIgnore: []string{"status", "updated_at", "conditions", "allocated_instances", "pending_instances"},
+					ImportStateVerifyIgnore: []string{schemaKeyStatus, schemaKeyUpdatedAt, schemaKeyConditions, "allocated_instances", "pending_instances"},
 				},
 			},
 		})

--- a/coreweave/inference/resource_inference_deployment.go
+++ b/coreweave/inference/resource_inference_deployment.go
@@ -63,11 +63,11 @@ var (
 	)
 
 	conditionAttrTypes = map[string]attr.Type{
-		"type":             types.StringType,
-		"status":           types.StringType,
-		"last_update_time": types.StringType,
-		"reason":           types.StringType,
-		"message":          types.StringType,
+		schemaKeyType:           types.StringType,
+		schemaKeyStatus:         types.StringType,
+		schemaKeyLastUpdateTime: types.StringType,
+		schemaKeyReason:         types.StringType,
+		schemaKeyMessage:        types.StringType,
 	}
 
 	errDeploymentFailed = errors.New("inference deployment entered a failed state")
@@ -84,11 +84,11 @@ func conditionsListFromStatus(conds []*inferencev1.Condition) (types.List, diag.
 			lastUpdate = c.GetLastUpdateTime().AsTime().Format(time.RFC3339)
 		}
 		condObj, diags := types.ObjectValue(conditionAttrTypes, map[string]attr.Value{
-			"type":             types.StringValue(c.GetType()),
-			"status":           types.StringValue(c.GetStatus().String()),
-			"last_update_time": types.StringValue(lastUpdate),
-			"reason":           types.StringValue(c.GetReason()),
-			"message":          types.StringValue(c.GetMessage()),
+			schemaKeyType:           types.StringValue(c.GetType()),
+			schemaKeyStatus:         types.StringValue(c.GetStatus().String()),
+			schemaKeyLastUpdateTime: types.StringValue(lastUpdate),
+			schemaKeyReason:         types.StringValue(c.GetReason()),
+			schemaKeyMessage:        types.StringValue(c.GetMessage()),
 		})
 		diagnostics.Append(diags...)
 		condVals[i] = condObj
@@ -179,56 +179,56 @@ func (r *InferenceDeploymentResource) Schema(_ context.Context, _ resource.Schem
 				MarkdownDescription: "The unique identifier of the deployment.",
 				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
-			"organization_id": schema.StringAttribute{
+			schemaKeyOrganizationID: schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "The organization ID that owns the deployment.",
 				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
-			"status": schema.StringAttribute{
+			schemaKeyStatus: schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "The current status of the deployment. See the [Inference API overview](https://docs.coreweave.com/products/inference/reference/api-overview) for status values.",
 				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
-			"created_at": schema.StringAttribute{
+			schemaKeyCreatedAt: schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "RFC3339 timestamp of when the deployment was created.",
 				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
-			"updated_at": schema.StringAttribute{
+			schemaKeyUpdatedAt: schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "RFC3339 timestamp of when the deployment was last updated.",
 				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
-			"conditions": schema.ListNestedAttribute{
+			schemaKeyConditions: schema.ListNestedAttribute{
 				Computed:            true,
 				MarkdownDescription: "Detailed status conditions for the deployment.",
 				PlanModifiers:       []planmodifier.List{listplanmodifier.UseStateForUnknown()},
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
-						"type": schema.StringAttribute{
+						schemaKeyType: schema.StringAttribute{
 							Computed:            true,
-							MarkdownDescription: "The condition type (e.g. `Ready`, `Progressing`).",
+							MarkdownDescription: conditionTypeDescription,
 						},
-						"status": schema.StringAttribute{
+						schemaKeyStatus: schema.StringAttribute{
 							Computed:            true,
-							MarkdownDescription: "The condition status (`True`, `False`, or `Unknown`).",
+							MarkdownDescription: conditionStatusDescription,
 						},
-						"last_update_time": schema.StringAttribute{
+						schemaKeyLastUpdateTime: schema.StringAttribute{
 							Computed:            true,
-							MarkdownDescription: "RFC3339 timestamp of the last condition transition.",
+							MarkdownDescription: lastTransitionTimeDescription,
 						},
-						"reason": schema.StringAttribute{
+						schemaKeyReason: schema.StringAttribute{
 							Computed:            true,
-							MarkdownDescription: "A short, machine-readable reason for the condition's last transition.",
+							MarkdownDescription: lastTransitionReasonDescription,
 						},
-						"message": schema.StringAttribute{
+						schemaKeyMessage: schema.StringAttribute{
 							Computed:            true,
-							MarkdownDescription: "A human-readable message about the condition's last transition.",
+							MarkdownDescription: lastTransitionMessageDescription,
 						},
 					},
 				},
 			},
-			"name": schema.StringAttribute{
+			schemaKeyName: schema.StringAttribute{
 				Required:            true,
 				MarkdownDescription: "The name of the deployment. Must be a valid hostname label.",
 				PlanModifiers:       []planmodifier.String{stringplanmodifier.RequiresReplace()},
@@ -304,7 +304,7 @@ func (r *InferenceDeploymentResource) Schema(_ context.Context, _ resource.Schem
 				Required:            true,
 				MarkdownDescription: "[Model](https://docs.coreweave.com/products/inference/models) configuration.",
 				Attributes: map[string]schema.Attribute{
-					"name": schema.StringAttribute{
+					schemaKeyName: schema.StringAttribute{
 						Required:            true,
 						MarkdownDescription: "The model name used in API requests (e.g. the `/models` endpoint). Length must be 4-63 characters.",
 						Validators: []validator.String{
@@ -371,12 +371,12 @@ func (r *InferenceDeploymentResource) Schema(_ context.Context, _ resource.Schem
 				Computed:            true,
 				MarkdownDescription: "Traffic configuration. Omit to accept the API default (weight 0, which normalizes to 100% when no other deployment shares the model name). After apply, `weight` is populated from the API.",
 				Default: objectdefault.StaticValue(types.ObjectValueMust(map[string]attr.Type{
-					"weight": types.Int64Type,
+					schemaKeyWeight: types.Int64Type,
 				}, map[string]attr.Value{
-					"weight": types.Int64Value(0),
+					schemaKeyWeight: types.Int64Value(0),
 				})),
 				Attributes: map[string]schema.Attribute{
-					"weight": schema.Int64Attribute{
+					schemaKeyWeight: schema.Int64Attribute{
 						Optional:            true,
 						Computed:            true,
 						MarkdownDescription: "Traffic weight (0-1000). Values are normalized into percentages across deployments with the same model name.",
@@ -452,7 +452,7 @@ func (r *InferenceDeploymentResource) Create(ctx context.Context, req resource.C
 				Id: deploymentID,
 			}))
 			if err != nil {
-				tflog.Error(ctx, "failed to poll deployment", map[string]interface{}{"error": err.Error()})
+				tflog.Error(ctx, "failed to poll deployment", map[string]interface{}{logKeyError: err.Error()})
 				return nil, inferencev1.Status_STATUS_UNSPECIFIED.String(), err
 			}
 			d := getResp.Msg.Deployment
@@ -556,7 +556,7 @@ func (r *InferenceDeploymentResource) Update(ctx context.Context, req resource.U
 				Id: deploymentID,
 			}))
 			if err != nil {
-				tflog.Error(ctx, "failed to poll deployment", map[string]interface{}{"error": err.Error()})
+				tflog.Error(ctx, "failed to poll deployment", map[string]interface{}{logKeyError: err.Error()})
 				return nil, inferencev1.Status_STATUS_UNSPECIFIED.String(), err
 			}
 			d := getResp.Msg.Deployment
@@ -633,7 +633,7 @@ func (r *InferenceDeploymentResource) Delete(ctx context.Context, req resource.D
 				if coreweave.IsNotFoundError(err) {
 					return struct{}{}, deletedState, nil
 				}
-				tflog.Error(ctx, "failed to poll deployment deletion", map[string]interface{}{"error": err.Error()})
+				tflog.Error(ctx, "failed to poll deployment deletion", map[string]interface{}{logKeyError: err.Error()})
 				return nil, inferencev1.Status_STATUS_UNSPECIFIED.String(), err
 			}
 			d := getResp.Msg.Deployment

--- a/coreweave/inference/resource_inference_deployment_test.go
+++ b/coreweave/inference/resource_inference_deployment_test.go
@@ -114,18 +114,18 @@ func TestInferenceDeployment_SetFromDeployment_NullPreservation(t *testing.T) {
 	// Build a minimal proto deployment with no optional fields set.
 	d := &inferencev1.Deployment{
 		Spec: &inferencev1.DeploymentSpec{
-			Id:   "test-id",
-			Name: "my-llm",
+			Id:   testDeploymentID,
+			Name: testDeploymentName,
 			Runtime: &inferencev1.DeploymentRuntime{
-				Engine:  "vllm",
+				Engine:  testDeploymentEngine,
 				Version: "",
 			},
 			Resources: &inferencev1.DeploymentResources{
-				InstanceType: "H100_80GB_SXM5",
+				InstanceType: testDeploymentInstanceType,
 				GpuCount:     1,
 			},
 			Model: &inferencev1.DeploymentModel{
-				Name:   "meta-llama/Llama-3.1-8B",
+				Name:   testDeploymentModelName,
 				Bucket: "my-bucket",
 				Path:   "models/llama",
 			},
@@ -190,7 +190,7 @@ func TestInferenceDeployment_SetFromDeployment_NullPreservation(t *testing.T) {
 	}
 
 	// Required fields should always be populated.
-	if m.ID.ValueString() != "test-id" {
+	if m.ID.ValueString() != testDeploymentID {
 		t.Errorf("ID: expected 'test-id', got %q", m.ID.ValueString())
 	}
 	if m.Resources.GpuCount.ValueInt64() != 1 {
@@ -213,11 +213,11 @@ func TestSetFromDeployment_PreserveStatusFields(t *testing.T) {
 	base := func(status inferencev1.Status, name, condReason string, updatedAt *timestamppb.Timestamp) *inferencev1.Deployment {
 		return &inferencev1.Deployment{
 			Spec: &inferencev1.DeploymentSpec{
-				Id:        "test-id",
+				Id:        testDeploymentID,
 				Name:      name,
-				Runtime:   &inferencev1.DeploymentRuntime{Engine: "vllm"},
-				Resources: &inferencev1.DeploymentResources{InstanceType: "H100_80GB_SXM5", GpuCount: 1},
-				Model:     &inferencev1.DeploymentModel{Name: "meta-llama/Llama-3.1-8B"},
+				Runtime:   &inferencev1.DeploymentRuntime{Engine: testDeploymentEngine},
+				Resources: &inferencev1.DeploymentResources{InstanceType: testDeploymentInstanceType, GpuCount: 1},
+				Model:     &inferencev1.DeploymentModel{Name: testDeploymentModelName},
 				Autoscaling: &inferencev1.DeploymentAutoscaling{
 					Min: 1,
 					Max: 4,
@@ -228,13 +228,13 @@ func TestSetFromDeployment_PreserveStatusFields(t *testing.T) {
 				Status:    status,
 				UpdatedAt: updatedAt,
 				Conditions: []*inferencev1.Condition{
-					{Type: "Ready", Status: inferencev1.Condition_STATUS_TRUE, Reason: condReason},
+					{Type: conditionTypeReady, Status: inferencev1.Condition_STATUS_TRUE, Reason: condReason},
 				},
 			},
 		}
 	}
 
-	prior := base(inferencev1.Status_STATUS_READY, "my-llm", "AsExpected", timestamppb.New(time.Unix(1000, 0).UTC()))
+	prior := base(inferencev1.Status_STATUS_READY, testDeploymentName, "AsExpected", timestamppb.New(time.Unix(1000, 0).UTC()))
 	fresh := base(inferencev1.Status_STATUS_UPDATING, "my-llm-renamed", "Reconciling", timestamppb.New(time.Unix(2000, 0).UTC()))
 
 	// Seed the model with prior-state values (what the plan holds on Update).
@@ -283,20 +283,20 @@ func TestInferenceDeployment_SetFromDeployment_RuntimeMaps(t *testing.T) {
 
 	d := &inferencev1.Deployment{
 		Spec: &inferencev1.DeploymentSpec{
-			Id:   "test-id",
-			Name: "my-llm",
+			Id:   testDeploymentID,
+			Name: testDeploymentName,
 			Runtime: &inferencev1.DeploymentRuntime{
-				Engine: "vllm",
+				Engine: testDeploymentEngine,
 				EngineEnv: map[string]string{
-					"VLLM_LOGGING_LEVEL": "INFO",
+					"VLLM_LOGGING_LEVEL": testLogLevelInfo,
 				},
 			},
 			Resources: &inferencev1.DeploymentResources{
-				InstanceType: "H100_80GB_SXM5",
+				InstanceType: testDeploymentInstanceType,
 				GpuCount:     1,
 			},
 			Model: &inferencev1.DeploymentModel{
-				Name:   "meta-llama/Llama-3.1-8B",
+				Name:   testDeploymentModelName,
 				Bucket: "my-bucket",
 				Path:   "models/llama",
 			},
@@ -330,7 +330,7 @@ func TestInferenceDeployment_SetFromDeployment_RuntimeMaps(t *testing.T) {
 	if diags.HasError() {
 		t.Fatalf("EngineEnv ElementsAs returned errors: %v", diags)
 	}
-	if got := engineEnv["VLLM_LOGGING_LEVEL"]; got != "INFO" {
+	if got := engineEnv["VLLM_LOGGING_LEVEL"]; got != testLogLevelInfo {
 		t.Errorf("Runtime.EngineEnv[\"VLLM_LOGGING_LEVEL\"]: got %q, want 'INFO'", got)
 	}
 }
@@ -342,21 +342,21 @@ func TestInferenceDeployment_ToCreateRequest_OptionalFields(t *testing.T) {
 	gwIds := types.SetValueMust(types.StringType, []attr.Value{types.StringValue("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")})
 
 	m := &inference.InferenceDeploymentResourceModel{
-		Name:       types.StringValue("my-llm"),
+		Name:       types.StringValue(testDeploymentName),
 		GatewayIds: gwIds,
 		Disabled:   types.BoolValue(false),
 		Runtime: &inference.RuntimeModel{
-			Engine:       types.StringValue("vllm"),
+			Engine:       types.StringValue(testDeploymentEngine),
 			Version:      types.StringNull(),
 			EngineConfig: types.MapNull(types.StringType),
 			EngineEnv:    types.MapNull(types.StringType),
 		},
 		Resources: &inference.ResourcesModel{
-			InstanceType: types.StringValue("H100_80GB_SXM5"),
+			InstanceType: types.StringValue(testDeploymentInstanceType),
 			GpuCount:     types.Int64Value(1),
 		},
 		Model: &inference.DeploymentModelConfig{
-			Name:   types.StringValue("meta-llama/Llama-3.1-8B"),
+			Name:   types.StringValue(testDeploymentModelName),
 			Bucket: types.StringValue("my-bucket"),
 			Path:   types.StringValue("models/llama"),
 		},
@@ -377,7 +377,7 @@ func TestInferenceDeployment_ToCreateRequest_OptionalFields(t *testing.T) {
 		t.Fatalf("ToCreateRequest returned errors: %v", diags)
 	}
 
-	if req.Name != "my-llm" {
+	if req.Name != testDeploymentName {
 		t.Errorf("Name: got %q, want 'my-llm'", req.Name)
 	}
 	if req.Runtime.Version != "" {
@@ -407,26 +407,26 @@ func TestInferenceDeployment_ToUpdateRequest_Fields(t *testing.T) {
 	gwIds := types.SetValueMust(types.StringType, []attr.Value{types.StringValue("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")})
 	ccList, _ := types.ListValueFrom(ctx, types.StringType, []string{"CAPACITY_CLASS_RESERVED"})
 	engineEnv := types.MapValueMust(types.StringType, map[string]attr.Value{
-		"VLLM_LOGGING_LEVEL": types.StringValue("INFO"),
+		"VLLM_LOGGING_LEVEL": types.StringValue(testLogLevelInfo),
 	})
 
 	m := &inference.InferenceDeploymentResourceModel{
 		ID:         types.StringValue("deploy-123"),
-		Name:       types.StringValue("my-llm"),
+		Name:       types.StringValue(testDeploymentName),
 		GatewayIds: gwIds,
 		Disabled:   types.BoolValue(true),
 		Runtime: &inference.RuntimeModel{
-			Engine:       types.StringValue("vllm"),
+			Engine:       types.StringValue(testDeploymentEngine),
 			Version:      types.StringValue("1.0.0"),
 			EngineConfig: types.MapNull(types.StringType),
 			EngineEnv:    engineEnv,
 		},
 		Resources: &inference.ResourcesModel{
-			InstanceType: types.StringValue("H100_80GB_SXM5"),
+			InstanceType: types.StringValue(testDeploymentInstanceType),
 			GpuCount:     types.Int64Value(2),
 		},
 		Model: &inference.DeploymentModelConfig{
-			Name:   types.StringValue("meta-llama/Llama-3.1-8B"),
+			Name:   types.StringValue(testDeploymentModelName),
 			Bucket: types.StringValue("my-bucket"),
 			Path:   types.StringValue("models/llama"),
 		},
@@ -450,7 +450,7 @@ func TestInferenceDeployment_ToUpdateRequest_Fields(t *testing.T) {
 	if req.Id != "deploy-123" {
 		t.Errorf("Id: got %q, want 'deploy-123'", req.Id)
 	}
-	if req.Name != "my-llm" {
+	if req.Name != testDeploymentName {
 		t.Errorf("Name: got %q, want 'my-llm'", req.Name)
 	}
 	if !req.Disabled {
@@ -459,7 +459,7 @@ func TestInferenceDeployment_ToUpdateRequest_Fields(t *testing.T) {
 	if req.Runtime.Version != "1.0.0" {
 		t.Errorf("Runtime.Version: got %q, want '1.0.0'", req.Runtime.Version)
 	}
-	if got := req.Runtime.EngineEnv["VLLM_LOGGING_LEVEL"]; got != "INFO" {
+	if got := req.Runtime.EngineEnv["VLLM_LOGGING_LEVEL"]; got != testLogLevelInfo {
 		t.Errorf("Runtime.EngineEnv[\"VLLM_LOGGING_LEVEL\"]: got %q, want 'INFO'", got)
 	}
 	if req.Resources.GpuCount != 2 {
@@ -721,7 +721,7 @@ func TestInferenceDeployment(t *testing.T) {
 					Config: inferenceDeploymentConfig(name, preferredZone, preferredInstance),
 					ConfigStateChecks: []statecheck.StateCheck{
 						statecheck.ExpectKnownValue(fullResourceName, tfjsonpath.New("name"), knownvalue.StringExact(name)),
-						statecheck.ExpectKnownValue(fullResourceName, tfjsonpath.New("status"), knownvalue.StringExact("STATUS_READY")),
+						statecheck.ExpectKnownValue(fullResourceName, tfjsonpath.New(schemaKeyStatus), knownvalue.StringExact("STATUS_READY")),
 						statecheck.ExpectKnownValue(fullResourceName, tfjsonpath.New("disabled"), knownvalue.Bool(false)),
 						statecheck.ExpectKnownValue(fullResourceName, tfjsonpath.New("id"), knownvalue.NotNull()),
 						statecheck.ExpectKnownValue(fullResourceName, tfjsonpath.New("organization_id"), knownvalue.NotNull()),
@@ -759,7 +759,7 @@ func TestInferenceDeployment(t *testing.T) {
 					// Server-observed fields are intentionally not refreshed into state on
 					// Update (see setFromDeployment preserveStatusFields); a fresh import Read
 					// legitimately observes newer values, so they can't be verified here.
-					ImportStateVerifyIgnore: []string{"status", "updated_at", "conditions"},
+					ImportStateVerifyIgnore: []string{schemaKeyStatus, schemaKeyUpdatedAt, schemaKeyConditions},
 				},
 			},
 		})

--- a/coreweave/inference/resource_inference_gateway.go
+++ b/coreweave/inference/resource_inference_gateway.go
@@ -109,51 +109,51 @@ func (r *InferenceGatewayResource) Schema(_ context.Context, _ resource.SchemaRe
 				MarkdownDescription: "The unique identifier of the gateway.",
 				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
-			"organization_id": schema.StringAttribute{
+			schemaKeyOrganizationID: schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "The organization ID that owns the gateway.",
 				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
-			"status": schema.StringAttribute{
+			schemaKeyStatus: schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "The current status of the gateway. See the [Inference API overview](https://docs.coreweave.com/products/inference/reference/api-overview) for status values.",
 				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
-			"created_at": schema.StringAttribute{
+			schemaKeyCreatedAt: schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "RFC3339 timestamp of when the gateway was created.",
 				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
-			"updated_at": schema.StringAttribute{
+			schemaKeyUpdatedAt: schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "RFC3339 timestamp of when the gateway was last updated.",
 				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
-			"conditions": schema.ListNestedAttribute{
+			schemaKeyConditions: schema.ListNestedAttribute{
 				Computed:            true,
 				MarkdownDescription: "Detailed status conditions for the gateway.",
 				PlanModifiers:       []planmodifier.List{listplanmodifier.UseStateForUnknown()},
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
-						"type": schema.StringAttribute{
+						schemaKeyType: schema.StringAttribute{
 							Computed:            true,
-							MarkdownDescription: "The condition type (e.g. `Ready`, `Progressing`).",
+							MarkdownDescription: conditionTypeDescription,
 						},
-						"status": schema.StringAttribute{
+						schemaKeyStatus: schema.StringAttribute{
 							Computed:            true,
-							MarkdownDescription: "The condition status (`True`, `False`, or `Unknown`).",
+							MarkdownDescription: conditionStatusDescription,
 						},
-						"last_update_time": schema.StringAttribute{
+						schemaKeyLastUpdateTime: schema.StringAttribute{
 							Computed:            true,
-							MarkdownDescription: "RFC3339 timestamp of the last condition transition.",
+							MarkdownDescription: lastTransitionTimeDescription,
 						},
-						"reason": schema.StringAttribute{
+						schemaKeyReason: schema.StringAttribute{
 							Computed:            true,
-							MarkdownDescription: "A short, machine-readable reason for the condition's last transition.",
+							MarkdownDescription: lastTransitionReasonDescription,
 						},
-						"message": schema.StringAttribute{
+						schemaKeyMessage: schema.StringAttribute{
 							Computed:            true,
-							MarkdownDescription: "A human-readable message about the condition's last transition.",
+							MarkdownDescription: lastTransitionMessageDescription,
 						},
 					},
 				},
@@ -163,12 +163,12 @@ func (r *InferenceGatewayResource) Schema(_ context.Context, _ resource.SchemaRe
 				ElementType:         types.StringType,
 				MarkdownDescription: "The endpoint URIs for the gateway.",
 			},
-			"name": schema.StringAttribute{
+			schemaKeyName: schema.StringAttribute{
 				Required:            true,
 				MarkdownDescription: "The human-readable name of the gateway.",
 				PlanModifiers:       []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
-			"zones": schema.SetAttribute{
+			schemaKeyZones: schema.SetAttribute{
 				ElementType:         types.StringType,
 				Required:            true,
 				MarkdownDescription: "The zones to make the gateway available in. Limits where deployments associated with the gateway may exist.",
@@ -338,7 +338,7 @@ func (r *InferenceGatewayResource) Create(ctx context.Context, req resource.Crea
 				Id: gatewayID,
 			}))
 			if err != nil {
-				tflog.Error(ctx, "failed to poll gateway", map[string]interface{}{"error": err.Error()})
+				tflog.Error(ctx, "failed to poll gateway", map[string]interface{}{logKeyError: err.Error()})
 				return nil, inferencev1.Status_STATUS_UNSPECIFIED.String(), err
 			}
 			gw := getResp.Msg.Gateway
@@ -442,7 +442,7 @@ func (r *InferenceGatewayResource) Update(ctx context.Context, req resource.Upda
 				Id: gatewayID,
 			}))
 			if err != nil {
-				tflog.Error(ctx, "failed to poll gateway", map[string]interface{}{"error": err.Error()})
+				tflog.Error(ctx, "failed to poll gateway", map[string]interface{}{logKeyError: err.Error()})
 				return nil, inferencev1.Status_STATUS_UNSPECIFIED.String(), err
 			}
 			gw := getResp.Msg.Gateway
@@ -519,7 +519,7 @@ func (r *InferenceGatewayResource) Delete(ctx context.Context, req resource.Dele
 				if coreweave.IsNotFoundError(err) {
 					return struct{}{}, deletedState, nil
 				}
-				tflog.Error(ctx, "failed to poll gateway deletion", map[string]interface{}{"error": err.Error()})
+				tflog.Error(ctx, "failed to poll gateway deletion", map[string]interface{}{logKeyError: err.Error()})
 				return nil, inferencev1.Status_STATUS_UNSPECIFIED.String(), err
 			}
 			gw := getResp.Msg.Gateway

--- a/coreweave/inference/resource_inference_gateway_test.go
+++ b/coreweave/inference/resource_inference_gateway_test.go
@@ -43,10 +43,10 @@ func TestSetFromGateway_CoreWeaveAuth(t *testing.T) {
 
 	gw := &inferencev1.Gateway{
 		Spec: &inferencev1.GatewaySpec{
-			Id:             "gw-123",
+			Id:             testGatewayID,
 			Name:           "test-gw",
-			OrganizationId: "org-abc",
-			Zones:          []string{"US-EAST-04A"},
+			OrganizationId: testGatewayOrganizationID,
+			Zones:          []string{testGatewayZone},
 			Auth: &inferencev1.GatewaySpec_CoreWeaveAuth{
 				CoreWeaveAuth: &inferencev1.CoreWeaveAuth{},
 			},
@@ -73,8 +73,8 @@ func TestSetFromGateway_CoreWeaveAuth(t *testing.T) {
 	if m.Auth.WeightsAndBiases != nil {
 		t.Error("Auth.WeightsAndBiases: expected nil")
 	}
-	if m.ID.ValueString() != "gw-123" {
-		t.Errorf("ID: got %q, want %q", m.ID.ValueString(), "gw-123")
+	if m.ID.ValueString() != testGatewayID {
+		t.Errorf("ID: got %q, want %q", m.ID.ValueString(), testGatewayID)
 	}
 }
 
@@ -90,10 +90,10 @@ func TestSetFromGateway_PreserveStatusFields(t *testing.T) {
 	base := func(status inferencev1.Status, name, condReason string, updatedAt *timestamppb.Timestamp) *inferencev1.Gateway {
 		return &inferencev1.Gateway{
 			Spec: &inferencev1.GatewaySpec{
-				Id:             "gw-123",
+				Id:             testGatewayID,
 				Name:           name,
-				OrganizationId: "org-abc",
-				Zones:          []string{"US-EAST-04A"},
+				OrganizationId: testGatewayOrganizationID,
+				Zones:          []string{testGatewayZone},
 				Auth: &inferencev1.GatewaySpec_CoreWeaveAuth{
 					CoreWeaveAuth: &inferencev1.CoreWeaveAuth{},
 				},
@@ -107,7 +107,7 @@ func TestSetFromGateway_PreserveStatusFields(t *testing.T) {
 				Status:    status,
 				UpdatedAt: updatedAt,
 				Conditions: []*inferencev1.Condition{
-					{Type: "Ready", Status: inferencev1.Condition_STATUS_TRUE, Reason: condReason},
+					{Type: conditionTypeReady, Status: inferencev1.Condition_STATUS_TRUE, Reason: condReason},
 				},
 			},
 		}
@@ -164,12 +164,12 @@ func TestSetFromGateway_WeightsAndBiasesAuth(t *testing.T) {
 		Spec: &inferencev1.GatewaySpec{
 			Id:             "gw-456",
 			Name:           "wandb-gw",
-			OrganizationId: "org-abc",
-			Zones:          []string{"US-EAST-04A"},
+			OrganizationId: testGatewayOrganizationID,
+			Zones:          []string{testGatewayZone},
 			Auth: &inferencev1.GatewaySpec_WeightsAndBiasesAuth{
 				WeightsAndBiasesAuth: &inferencev1.WeightsAndBiasesAuth{
 					ApiKey:             "secret-key",
-					ServerUrl:          "https://wandb.example.com",
+					ServerUrl:          testWandBServerURL,
 					EnableUsageReports: true,
 					EnableRateLimiting: false,
 				},
@@ -211,8 +211,8 @@ func TestSetFromGateway_WeightsAndBiasesAuth(t *testing.T) {
 	if m.Auth.WeightsAndBiases.APIKey.ValueString() != "secret-key" {
 		t.Errorf("Auth.WeightsAndBiases.ApiKey: got %q, want %q", m.Auth.WeightsAndBiases.APIKey.ValueString(), "secret-key")
 	}
-	if m.Auth.WeightsAndBiases.ServerURL.ValueString() != "https://wandb.example.com" {
-		t.Errorf("Auth.WeightsAndBiases.ServerUrl: got %q, want %q", m.Auth.WeightsAndBiases.ServerURL.ValueString(), "https://wandb.example.com")
+	if m.Auth.WeightsAndBiases.ServerURL.ValueString() != testWandBServerURL {
+		t.Errorf("Auth.WeightsAndBiases.ServerUrl: got %q, want %q", m.Auth.WeightsAndBiases.ServerURL.ValueString(), testWandBServerURL)
 	}
 	if !m.Auth.WeightsAndBiases.EnableUsageReports.ValueBool() {
 		t.Error("Auth.WeightsAndBiases.EnableUsageReports: expected true")
@@ -229,8 +229,8 @@ func TestSetFromGateway_NullPreservation(t *testing.T) {
 		Spec: &inferencev1.GatewaySpec{
 			Id:             "gw-789",
 			Name:           "null-gw",
-			OrganizationId: "org-abc",
-			Zones:          []string{"US-EAST-04A"},
+			OrganizationId: testGatewayOrganizationID,
+			Zones:          []string{testGatewayZone},
 			Auth: &inferencev1.GatewaySpec_WeightsAndBiasesAuth{
 				WeightsAndBiasesAuth: &inferencev1.WeightsAndBiasesAuth{
 					// All zero values — should remain null in state.
@@ -297,7 +297,7 @@ func TestSetFromGateway_BodyBasedRouting(t *testing.T) {
 		Spec: &inferencev1.GatewaySpec{
 			Id:    "gw-body",
 			Name:  "body-gw",
-			Zones: []string{"US-EAST-04A"},
+			Zones: []string{testGatewayZone},
 			Auth: &inferencev1.GatewaySpec_CoreWeaveAuth{
 				CoreWeaveAuth: &inferencev1.CoreWeaveAuth{},
 			},
@@ -339,7 +339,7 @@ func TestSetFromGateway_HeaderBasedRouting(t *testing.T) {
 		Spec: &inferencev1.GatewaySpec{
 			Id:    "gw-header",
 			Name:  "header-gw",
-			Zones: []string{"US-EAST-04A"},
+			Zones: []string{testGatewayZone},
 			Auth: &inferencev1.GatewaySpec_CoreWeaveAuth{
 				CoreWeaveAuth: &inferencev1.CoreWeaveAuth{},
 			},
@@ -381,7 +381,7 @@ func TestSetFromGateway_PathBasedRouting(t *testing.T) {
 		Spec: &inferencev1.GatewaySpec{
 			Id:    "gw-path",
 			Name:  "path-gw",
-			Zones: []string{"US-EAST-04A"},
+			Zones: []string{testGatewayZone},
 			Auth: &inferencev1.GatewaySpec_CoreWeaveAuth{
 				CoreWeaveAuth: &inferencev1.CoreWeaveAuth{},
 			},
@@ -417,7 +417,7 @@ func TestToCreateGatewayRequest_CoreWeaveAuth(t *testing.T) {
 	ctx := t.Context()
 	m := &inference.InferenceGatewayResourceModel{
 		Name:  types.StringValue("cw-auth-gw"),
-		Zones: types.SetValueMust(types.StringType, []attr.Value{types.StringValue("US-EAST-04A")}),
+		Zones: types.SetValueMust(types.StringType, []attr.Value{types.StringValue(testGatewayZone)}),
 		Auth: &inference.GatewayAuthModel{
 			CoreWeave: &inference.CoreWeaveAuthModel{},
 		},
@@ -452,11 +452,11 @@ func TestToCreateGatewayRequest_WandBAuth(t *testing.T) {
 	ctx := t.Context()
 	m := &inference.InferenceGatewayResourceModel{
 		Name:  types.StringValue("wandb-auth-gw"),
-		Zones: types.SetValueMust(types.StringType, []attr.Value{types.StringValue("US-EAST-04A")}),
+		Zones: types.SetValueMust(types.StringType, []attr.Value{types.StringValue(testGatewayZone)}),
 		Auth: &inference.GatewayAuthModel{
 			WeightsAndBiases: &inference.WeightsAndBiasesAuthModel{
 				APIKey:             types.StringValue("my-api-key"),
-				ServerURL:          types.StringValue("https://wandb.example.com"),
+				ServerURL:          types.StringValue(testWandBServerURL),
 				EnableUsageReports: types.BoolValue(true),
 				EnableRateLimiting: types.BoolValue(false),
 			},
@@ -480,8 +480,8 @@ func TestToCreateGatewayRequest_WandBAuth(t *testing.T) {
 	if wbAuth.WeightsAndBiasesAuth.GetApiKey() != "my-api-key" {
 		t.Errorf("Auth.WandB.ApiKey: got %q, want %q", wbAuth.WeightsAndBiasesAuth.GetApiKey(), "my-api-key")
 	}
-	if wbAuth.WeightsAndBiasesAuth.GetServerUrl() != "https://wandb.example.com" {
-		t.Errorf("Auth.WandB.ServerUrl: got %q, want %q", wbAuth.WeightsAndBiasesAuth.GetServerUrl(), "https://wandb.example.com")
+	if wbAuth.WeightsAndBiasesAuth.GetServerUrl() != testWandBServerURL {
+		t.Errorf("Auth.WandB.ServerUrl: got %q, want %q", wbAuth.WeightsAndBiasesAuth.GetServerUrl(), testWandBServerURL)
 	}
 	if !wbAuth.WeightsAndBiasesAuth.GetEnableUsageReports() {
 		t.Error("Auth.WandB.EnableUsageReports: expected true")
@@ -501,7 +501,7 @@ func TestToCreateGatewayRequest_AllRoutingTypes(t *testing.T) {
 
 		m := &inference.InferenceGatewayResourceModel{
 			Name:  types.StringValue("body-gw"),
-			Zones: types.SetValueMust(types.StringType, []attr.Value{types.StringValue("US-EAST-04A")}),
+			Zones: types.SetValueMust(types.StringType, []attr.Value{types.StringValue(testGatewayZone)}),
 			Auth: &inference.GatewayAuthModel{
 				CoreWeave: &inference.CoreWeaveAuthModel{},
 			},
@@ -531,7 +531,7 @@ func TestToCreateGatewayRequest_AllRoutingTypes(t *testing.T) {
 
 		m := &inference.InferenceGatewayResourceModel{
 			Name:  types.StringValue("header-gw"),
-			Zones: types.SetValueMust(types.StringType, []attr.Value{types.StringValue("US-EAST-04A")}),
+			Zones: types.SetValueMust(types.StringType, []attr.Value{types.StringValue(testGatewayZone)}),
 			Auth: &inference.GatewayAuthModel{
 				CoreWeave: &inference.CoreWeaveAuthModel{},
 			},
@@ -561,7 +561,7 @@ func TestToCreateGatewayRequest_AllRoutingTypes(t *testing.T) {
 
 		m := &inference.InferenceGatewayResourceModel{
 			Name:  types.StringValue("path-gw"),
-			Zones: types.SetValueMust(types.StringType, []attr.Value{types.StringValue("US-EAST-04A")}),
+			Zones: types.SetValueMust(types.StringType, []attr.Value{types.StringValue(testGatewayZone)}),
 			Auth: &inference.GatewayAuthModel{
 				CoreWeave: &inference.CoreWeaveAuthModel{},
 			},
@@ -736,7 +736,7 @@ func TestInferenceGateway(t *testing.T) {
 						statecheck.ExpectKnownValue(fullResourceName, tfjsonpath.New("name"), knownvalue.StringExact(name)),
 						statecheck.ExpectKnownValue(fullResourceName, tfjsonpath.New("id"), knownvalue.NotNull()),
 						statecheck.ExpectKnownValue(fullResourceName, tfjsonpath.New("organization_id"), knownvalue.NotNull()),
-						statecheck.ExpectKnownValue(fullResourceName, tfjsonpath.New("status"), knownvalue.NotNull()),
+						statecheck.ExpectKnownValue(fullResourceName, tfjsonpath.New(schemaKeyStatus), knownvalue.NotNull()),
 						statecheck.ExpectKnownValue(fullResourceName, tfjsonpath.New("created_at"), knownvalue.NotNull()),
 						statecheck.ExpectKnownValue(fullResourceName, tfjsonpath.New("routing").AtMapKey("body_based").AtMapKey("api_type"), knownvalue.StringExact("API_TYPE_OPENAI")),
 					},
@@ -765,7 +765,7 @@ func TestInferenceGateway(t *testing.T) {
 					// Server-observed fields are intentionally not refreshed into state on
 					// Update (see setFromGateway preserveStatusFields); a fresh import Read
 					// legitimately observes newer values, so they can't be verified here.
-					ImportStateVerifyIgnore: []string{"status", "updated_at", "conditions"},
+					ImportStateVerifyIgnore: []string{schemaKeyStatus, schemaKeyUpdatedAt, schemaKeyConditions},
 				},
 			},
 		})

--- a/coreweave/inference/resource_inference_integration_test.go
+++ b/coreweave/inference/resource_inference_integration_test.go
@@ -146,11 +146,11 @@ func TestInferenceReservedCapacity(t *testing.T) {
 					Config: inferenceIntegrationConfig(name, preferredZone, preferredInstance),
 					ConfigStateChecks: []statecheck.StateCheck{
 						statecheck.ExpectKnownValue(ccResource, tfjsonpath.New("id"), knownvalue.NotNull()),
-						statecheck.ExpectKnownValue(ccResource, tfjsonpath.New("status"), knownvalue.NotNull()),
+						statecheck.ExpectKnownValue(ccResource, tfjsonpath.New(schemaKeyStatus), knownvalue.NotNull()),
 						statecheck.ExpectKnownValue(ccResource, tfjsonpath.New("allocated_instances"), knownvalue.NotNull()),
 						statecheck.ExpectKnownValue(ccResource, tfjsonpath.New("resources").AtMapKey("capacity_type"), knownvalue.StringExact("CAPACITY_TYPE_CUSTOMER")),
 						statecheck.ExpectKnownValue(gwResource, tfjsonpath.New("id"), knownvalue.NotNull()),
-						statecheck.ExpectKnownValue(depResource, tfjsonpath.New("status"), knownvalue.StringExact("STATUS_READY")),
+						statecheck.ExpectKnownValue(depResource, tfjsonpath.New(schemaKeyStatus), knownvalue.StringExact("STATUS_READY")),
 						statecheck.ExpectKnownValue(depResource, tfjsonpath.New("autoscaling").AtMapKey("capacity_classes"), knownvalue.ListExact([]knownvalue.Check{knownvalue.StringExact("CAPACITY_CLASS_RESERVED")})),
 						statecheck.ExpectKnownValue(depResource, tfjsonpath.New("autoscaling").AtMapKey("priority"), knownvalue.Int64Exact(100)),
 						statecheck.ExpectKnownValue(depResource, tfjsonpath.New("traffic").AtMapKey("weight"), knownvalue.Int64Exact(0)),

--- a/coreweave/inference/schema_constants.go
+++ b/coreweave/inference/schema_constants.go
@@ -1,0 +1,26 @@
+package inference
+
+const (
+	schemaKeyInstanceTypes           = "instance_types"
+	schemaKeyAllowedKeys             = "allowed_keys"
+	schemaKeyAllowedNames            = "allowed_names"
+	schemaKeyVersions                = "versions"
+	schemaKeyZones                   = "zones"
+	schemaKeyWeight                  = "weight"
+	schemaKeyOrganizationID          = "organization_id"
+	schemaKeyStatus                  = "status"
+	schemaKeyCreatedAt               = "created_at"
+	schemaKeyUpdatedAt               = "updated_at"
+	schemaKeyConditions              = "conditions"
+	schemaKeyType                    = "type"
+	schemaKeyLastUpdateTime          = "last_update_time"
+	schemaKeyReason                  = "reason"
+	schemaKeyMessage                 = "message"
+	schemaKeyName                    = "name"
+	logKeyError                      = "error"
+	conditionTypeDescription         = "The condition type (e.g. `Ready`, `Progressing`)."
+	conditionStatusDescription       = "The condition status (`True`, `False`, or `Unknown`)."
+	lastTransitionTimeDescription    = "RFC3339 timestamp of the last condition transition."
+	lastTransitionReasonDescription  = "A short, machine-readable reason for the condition's last transition."
+	lastTransitionMessageDescription = "A human-readable message about the condition's last transition."
+)

--- a/coreweave/inference/schema_constants_test.go
+++ b/coreweave/inference/schema_constants_test.go
@@ -1,0 +1,21 @@
+package inference_test
+
+const (
+	schemaKeyConditions             = "conditions"
+	schemaKeyStatus                 = "status"
+	schemaKeyUpdatedAt              = "updated_at"
+	testCapacityClaimID             = "cc-123"
+	testCapacityClaimOrganizationID = "org-456"
+	conditionTypeReady              = "Ready"
+	testDeploymentID                = "test-id"
+	testDeploymentName              = "my-llm"
+	testDeploymentEngine            = "vllm"
+	testDeploymentInstanceType      = "H100_80GB_SXM5"
+	testDeploymentModelName         = "meta-llama/Llama-3.1-8B"
+	testLogLevelInfo                = "INFO"
+	testGatewayID                   = "gw-123"
+	testGatewayOrganizationID       = "org-abc"
+	testGatewayZone                 = "US-EAST-04A"
+	testWandBServerURL              = "https://wandb.example.com"
+	inferenceDeploymentResourceType = "coreweave_inference_deployment"
+)

--- a/coreweave/inference/sweeper_test.go
+++ b/coreweave/inference/sweeper_test.go
@@ -72,8 +72,8 @@ func inferenceModelPath() string {
 }
 
 func init() {
-	resource.AddTestSweepers("coreweave_inference_deployment", &resource.Sweeper{
-		Name:         "coreweave_inference_deployment",
+	resource.AddTestSweepers(inferenceDeploymentResourceType, &resource.Sweeper{
+		Name:         inferenceDeploymentResourceType,
 		Dependencies: []string{},
 		F: func(r string) error {
 			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
@@ -126,7 +126,7 @@ func init() {
 
 	resource.AddTestSweepers("coreweave_inference_capacity_claim", &resource.Sweeper{
 		Name:         "coreweave_inference_capacity_claim",
-		Dependencies: []string{"coreweave_inference_deployment"},
+		Dependencies: []string{inferenceDeploymentResourceType},
 		F: func(r string) error {
 			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
 			defer cancel()
@@ -178,7 +178,7 @@ func init() {
 
 	resource.AddTestSweepers("coreweave_inference_gateway", &resource.Sweeper{
 		Name:         "coreweave_inference_gateway",
-		Dependencies: []string{"coreweave_inference_deployment"},
+		Dependencies: []string{inferenceDeploymentResourceType},
 		F: func(r string) error {
 			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
 			defer cancel()

--- a/coreweave/networking/data_source_vpc.go
+++ b/coreweave/networking/data_source_vpc.go
@@ -42,7 +42,7 @@ func (d *VpcDataSource) Schema(ctx context.Context, req datasource.SchemaRequest
 				MarkdownDescription: "The ID of the VPC.",
 				Required:            true,
 			},
-			"name": schema.StringAttribute{
+			schemaKeyName: schema.StringAttribute{
 				MarkdownDescription: "The name of the VPC.",
 				Computed:            true,
 			},
@@ -55,10 +55,10 @@ func (d *VpcDataSource) Schema(ctx context.Context, req datasource.SchemaRequest
 				Computed:            true,
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
-						"name": schema.StringAttribute{
+						schemaKeyName: schema.StringAttribute{
 							Computed: true,
 						},
-						"value": schema.StringAttribute{
+						schemaKeyValue: schema.StringAttribute{
 							Computed: true,
 						},
 					},
@@ -74,28 +74,28 @@ func (d *VpcDataSource) Schema(ctx context.Context, req datasource.SchemaRequest
 				Computed:            true,
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
-						"name": schema.StringAttribute{
+						schemaKeyName: schema.StringAttribute{
 							MarkdownDescription: "The user-specified name of the host prefix.",
 							Computed:            true,
 						},
-						"type": schema.StringAttribute{
+						schemaKeyType: schema.StringAttribute{
 							MarkdownDescription: "Controls network connectivity from the prefix to the host.",
 							Computed:            true,
 						},
-						"prefixes": schema.ListAttribute{
+						schemaKeyPrefixes: schema.ListAttribute{
 							MarkdownDescription: "The VPC-wide aggregates from which host-specific prefixes are allocated. May be IPv4 or IPv6.",
 							ElementType:         cidrtypes.IPPrefixType{},
 							Computed:            true,
 						},
-						"ipam": schema.SingleNestedAttribute{
+						schemaKeyIPAM: schema.SingleNestedAttribute{
 							MarkdownDescription: "The configuration for a secondary host prefix.",
 							Computed:            true,
 							Attributes: map[string]schema.Attribute{
-								"prefix_length": schema.Int32Attribute{
+								schemaKeyPrefixLength: schema.Int32Attribute{
 									MarkdownDescription: "The desired length for each Node's allocation from the VPC-wide aggregate prefix.",
 									Computed:            true,
 								},
-								"gateway_address_policy": schema.StringAttribute{
+								schemaKeyGatewayAddressPolicy: schema.StringAttribute{
 									MarkdownDescription: "Describes which IP address from the prefix is allocated to the network gateway.",
 									Computed:            true,
 								},
@@ -108,7 +108,7 @@ func (d *VpcDataSource) Schema(ctx context.Context, req datasource.SchemaRequest
 				MarkdownDescription: "Settings affecting traffic entering the VPC.",
 				Computed:            true,
 				Attributes: map[string]schema.Attribute{
-					"disable_public_services": schema.BoolAttribute{
+					schemaKeyDisablePublicServices: schema.BoolAttribute{
 						MarkdownDescription: "True if the VPC will prevent public prefixes advertised from Nodes from being imported into public-facing networks, making them inaccessible from the Internet. False otherwise.",
 						Computed:            true,
 					},
@@ -118,7 +118,7 @@ func (d *VpcDataSource) Schema(ctx context.Context, req datasource.SchemaRequest
 				MarkdownDescription: "Settings affecting traffic leaving the VPC.",
 				Computed:            true,
 				Attributes: map[string]schema.Attribute{
-					"disable_public_access": schema.BoolAttribute{
+					schemaKeyDisablePublicAccess: schema.BoolAttribute{
 						MarkdownDescription: "True if the VPC is blocked from consuming public Internet. False otherwise.",
 						Computed:            true,
 					},

--- a/coreweave/networking/resource_vpc.go
+++ b/coreweave/networking/resource_vpc.go
@@ -42,15 +42,15 @@ var (
 
 var hostPrefixObjectType = types.ObjectType{
 	AttrTypes: map[string]attr.Type{
-		"name": types.StringType,
-		"type": types.StringType,
-		"prefixes": types.ListType{
+		schemaKeyName: types.StringType,
+		schemaKeyType: types.StringType,
+		schemaKeyPrefixes: types.ListType{
 			ElemType: cidrtypes.IPPrefixType{},
 		},
-		"ipam": types.ObjectType{
+		schemaKeyIPAM: types.ObjectType{
 			AttrTypes: map[string]attr.Type{
-				"prefix_length":          types.Int32Type,
-				"gateway_address_policy": types.StringType,
+				schemaKeyPrefixLength:         types.Int32Type,
+				schemaKeyGatewayAddressPolicy: types.StringType,
 			},
 		},
 	},
@@ -444,7 +444,7 @@ func (r *VpcResource) Schema(ctx context.Context, req resource.SchemaRequest, re
 					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
-			"name": schema.StringAttribute{
+			schemaKeyName: schema.StringAttribute{
 				Required:            true,
 				MarkdownDescription: "The name of the VPC. Must not be longer than 30 characters.",
 				PlanModifiers: []planmodifier.String{
@@ -463,10 +463,10 @@ func (r *VpcResource) Schema(ctx context.Context, req resource.SchemaRequest, re
 				MarkdownDescription: "A list of additional prefixes associated with the VPC. For example, CKS clusters use these prefixes for Pod and service CIDR ranges.",
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
-						"name": schema.StringAttribute{
+						schemaKeyName: schema.StringAttribute{
 							Required: true,
 						},
-						"value": schema.StringAttribute{
+						schemaKeyValue: schema.StringAttribute{
 							Required: true,
 						},
 					},
@@ -495,28 +495,28 @@ func (r *VpcResource) Schema(ctx context.Context, req resource.SchemaRequest, re
 				},
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
-						"name": schema.StringAttribute{
+						schemaKeyName: schema.StringAttribute{
 							Required:            true,
 							MarkdownDescription: "The user-specified name of the host prefix.",
 						},
-						"type": schema.StringAttribute{
+						schemaKeyType: schema.StringAttribute{
 							Required:            true,
 							MarkdownDescription: fmt.Sprintf("Controls network connectivity from the prefix to the host. Must be one of: %s.", coreweave.EnumMarkdownValues(networkingv1beta1.HostPrefix_Type_name, true)),
 						},
-						"prefixes": schema.ListAttribute{
+						schemaKeyPrefixes: schema.ListAttribute{
 							Required:            true,
 							MarkdownDescription: "The VPC-wide aggregates from which host-specific prefixes are allocated. May be IPv4 or IPv6.",
 							ElementType:         cidrtypes.IPPrefixType{},
 						},
-						"ipam": schema.SingleNestedAttribute{
+						schemaKeyIPAM: schema.SingleNestedAttribute{
 							Optional:            true,
 							MarkdownDescription: "The configuration for a secondary host prefix.",
 							Attributes: map[string]schema.Attribute{
-								"prefix_length": schema.Int32Attribute{
+								schemaKeyPrefixLength: schema.Int32Attribute{
 									Required:            true,
 									MarkdownDescription: "The desired length for each Node's allocation from the VPC-wide aggregate prefix.",
 								},
-								"gateway_address_policy": schema.StringAttribute{
+								schemaKeyGatewayAddressPolicy: schema.StringAttribute{
 									Optional:            true,
 									Computed:            true,
 									Default:             stringdefault.StaticString(networkingv1beta1.IPAddressManagementPolicy_UNSPECIFIED.String()),
@@ -532,15 +532,15 @@ func (r *VpcResource) Schema(ctx context.Context, req resource.SchemaRequest, re
 				Computed:            true,
 				MarkdownDescription: "Settings affecting traffic entering the VPC.",
 				Attributes: map[string]schema.Attribute{
-					"disable_public_services": schema.BoolAttribute{
+					schemaKeyDisablePublicServices: schema.BoolAttribute{
 						Optional:            true,
 						MarkdownDescription: "Specifies whether the VPC should prevent public prefixes advertised from Nodes from being imported into public-facing networks, making them inaccessible from the Internet.",
 					},
 				},
 				Default: objectdefault.StaticValue(types.ObjectValueMust(map[string]attr.Type{
-					"disable_public_services": types.BoolType,
+					schemaKeyDisablePublicServices: types.BoolType,
 				}, map[string]attr.Value{
-					"disable_public_services": types.BoolValue(false),
+					schemaKeyDisablePublicServices: types.BoolValue(false),
 				})),
 			},
 			"egress": schema.SingleNestedAttribute{
@@ -548,15 +548,15 @@ func (r *VpcResource) Schema(ctx context.Context, req resource.SchemaRequest, re
 				Computed:            true,
 				MarkdownDescription: "Settings affecting traffic leaving the VPC.",
 				Attributes: map[string]schema.Attribute{
-					"disable_public_access": schema.BoolAttribute{
+					schemaKeyDisablePublicAccess: schema.BoolAttribute{
 						Optional:            true,
 						MarkdownDescription: "Specifies whether the VPC should be blocked from consuming public Internet.",
 					},
 				},
 				Default: objectdefault.StaticValue(types.ObjectValueMust(map[string]attr.Type{
-					"disable_public_access": types.BoolType,
+					schemaKeyDisablePublicAccess: types.BoolType,
 				}, map[string]attr.Value{
-					"disable_public_access": types.BoolValue(false),
+					schemaKeyDisablePublicAccess: types.BoolValue(false),
 				})),
 			},
 			"dhcp": schema.SingleNestedAttribute{
@@ -640,7 +640,7 @@ func (r *VpcResource) Create(ctx context.Context, req resource.CreateRequest, re
 			}))
 			if err != nil {
 				tflog.Error(ctx, "failed to fetch vpc resource", map[string]interface{}{
-					"error": err,
+					logKeyError: err,
 				})
 				return nil, networkingv1beta1.VPC_STATUS_UNSPECIFIED.String(), err
 			}
@@ -732,7 +732,7 @@ func (r *VpcResource) Update(ctx context.Context, req resource.UpdateRequest, re
 			}))
 			if err != nil {
 				tflog.Error(ctx, "failed to fetch vpc resource", map[string]interface{}{
-					"error": err.Error(),
+					logKeyError: err.Error(),
 				})
 				return nil, networkingv1beta1.VPC_STATUS_UNSPECIFIED.String(), err
 			}
@@ -801,7 +801,7 @@ func (r *VpcResource) Delete(ctx context.Context, req resource.DeleteRequest, re
 				}
 
 				tflog.Error(ctx, "failed to fetch vpc", map[string]interface{}{
-					"error": err.Error(),
+					logKeyError: err.Error(),
 				})
 				return nil, networkingv1beta1.VPC_STATUS_UNSPECIFIED.String(), err
 			}
@@ -830,22 +830,22 @@ func hostPrefixToCtyValue(hp HostPrefixResourceModel) cty.Value {
 	}
 
 	hpObj := map[string]cty.Value{
-		"name":     cty.StringVal(hp.Name.ValueString()),
-		"type":     cty.StringVal(hp.Type.ValueString()),
-		"prefixes": cty.SetVal(prefixValues),
+		schemaKeyName:     cty.StringVal(hp.Name.ValueString()),
+		schemaKeyType:     cty.StringVal(hp.Type.ValueString()),
+		schemaKeyPrefixes: cty.SetVal(prefixValues),
 	}
 
 	// Add IPAM only if present - omit null fields for cleaner HCL rendering, to accept them as "true nils"
 	if hp.IPAM != nil {
 		ipamObj := map[string]cty.Value{
-			"prefix_length": cty.NumberIntVal(int64(hp.IPAM.PrefixLength.ValueInt32())),
+			schemaKeyPrefixLength: cty.NumberIntVal(int64(hp.IPAM.PrefixLength.ValueInt32())),
 		}
 
 		if !hp.IPAM.GatewayAddressPolicy.IsNull() && !hp.IPAM.GatewayAddressPolicy.IsUnknown() {
-			ipamObj["gateway_address_policy"] = cty.StringVal(hp.IPAM.GatewayAddressPolicy.ValueString())
+			ipamObj[schemaKeyGatewayAddressPolicy] = cty.StringVal(hp.IPAM.GatewayAddressPolicy.ValueString())
 		}
 
-		hpObj["ipam"] = cty.ObjectVal(ipamObj)
+		hpObj[schemaKeyIPAM] = cty.ObjectVal(ipamObj)
 	}
 
 	return cty.ObjectVal(hpObj)
@@ -860,18 +860,18 @@ func MustRenderVpcResource(ctx context.Context, resourceName string, vpc *VpcRes
 	resource := body.AppendNewBlock("resource", []string{"coreweave_networking_vpc", resourceName})
 	resourceBody := resource.Body()
 
-	resourceBody.SetAttributeValue("name", cty.StringVal(vpc.Name.ValueString()))
+	resourceBody.SetAttributeValue(schemaKeyName, cty.StringVal(vpc.Name.ValueString()))
 	resourceBody.SetAttributeValue("zone", cty.StringVal(vpc.Zone.ValueString()))
 
 	if vpc.Ingress != nil {
 		resourceBody.SetAttributeValue("ingress", cty.ObjectVal(map[string]cty.Value{
-			"disable_public_services": cty.BoolVal(vpc.Ingress.DisablePublicServices.ValueBool()),
+			schemaKeyDisablePublicServices: cty.BoolVal(vpc.Ingress.DisablePublicServices.ValueBool()),
 		}))
 	}
 
 	if vpc.Egress != nil {
 		resourceBody.SetAttributeValue("egress", cty.ObjectVal(map[string]cty.Value{
-			"disable_public_access": cty.BoolVal(vpc.Egress.DisablePublicAccess.ValueBool()),
+			schemaKeyDisablePublicAccess: cty.BoolVal(vpc.Egress.DisablePublicAccess.ValueBool()),
 		}))
 	}
 
@@ -901,8 +901,8 @@ func MustRenderVpcResource(ctx context.Context, resourceName string, vpc *VpcRes
 	vpcPrefixes := make([]cty.Value, len(vpc.VpcPrefixes))
 	for i, p := range vpc.VpcPrefixes {
 		vpcPrefixes[i] = cty.ObjectVal(map[string]cty.Value{
-			"name":  cty.StringVal(p.Name.ValueString()),
-			"value": cty.StringVal(p.Value.ValueString()),
+			schemaKeyName:  cty.StringVal(p.Name.ValueString()),
+			schemaKeyValue: cty.StringVal(p.Value.ValueString()),
 		})
 	}
 

--- a/coreweave/networking/resource_vpc_test.go
+++ b/coreweave/networking/resource_vpc_test.go
@@ -33,7 +33,16 @@ import (
 const (
 	AcceptanceTestPrefix = "test-acc-vpc-"
 
-	defaultPrimaryHostPrefixName = "host primary"
+	defaultPrimaryHostPrefixName   = "host primary"
+	schemaKeyName                  = "name"
+	schemaKeyValue                 = "value"
+	schemaKeyType                  = "type"
+	schemaKeyPrefixes              = "prefixes"
+	schemaKeyIPAM                  = "ipam"
+	schemaKeyPrefixLength          = "prefix_length"
+	schemaKeyGatewayAddressPolicy  = "gateway_address_policy"
+	schemaKeyDisablePublicServices = "disable_public_services"
+	schemaKeyDisablePublicAccess   = "disable_public_access"
 )
 
 func init() {
@@ -178,19 +187,19 @@ func hostPrefixObjectExact(t *testing.T, hp networking.HostPrefixResourceModel) 
 	}
 
 	obj := map[string]knownvalue.Check{
-		"name":     knownvalue.StringExact(hp.Name.ValueString()),
-		"type":     knownvalue.StringExact(hp.Type.ValueString()),
-		"prefixes": knownvalue.ListExact(prefixes),
-		"ipam":     knownvalue.Null(),
+		schemaKeyName:     knownvalue.StringExact(hp.Name.ValueString()),
+		schemaKeyType:     knownvalue.StringExact(hp.Type.ValueString()),
+		schemaKeyPrefixes: knownvalue.ListExact(prefixes),
+		schemaKeyIPAM:     knownvalue.Null(),
 	}
 	if hp.IPAM != nil {
 		policy := networkingv1beta1.IPAddressManagementPolicy_UNSPECIFIED.String()
 		if !hp.IPAM.GatewayAddressPolicy.IsNull() && !hp.IPAM.GatewayAddressPolicy.IsUnknown() {
 			policy = hp.IPAM.GatewayAddressPolicy.ValueString()
 		}
-		obj["ipam"] = knownvalue.ObjectExact(map[string]knownvalue.Check{
-			"prefix_length":          knownvalue.Int32Exact(hp.IPAM.PrefixLength.ValueInt32()),
-			"gateway_address_policy": knownvalue.StringExact(policy),
+		obj[schemaKeyIPAM] = knownvalue.ObjectExact(map[string]knownvalue.Check{
+			schemaKeyPrefixLength:         knownvalue.Int32Exact(hp.IPAM.PrefixLength.ValueInt32()),
+			schemaKeyGatewayAddressPolicy: knownvalue.StringExact(policy),
 		})
 	}
 	return knownvalue.ObjectExact(obj)
@@ -208,7 +217,7 @@ func defaultExpectedValues(t *testing.T, resourceAddress string, m *networking.V
 	stateChecks = append(stateChecks,
 		statecheck.ExpectKnownValue(resourceAddress, tfjsonpath.New("id"), knownvalue.NotNull()),
 		statecheck.ExpectKnownValue(resourceAddress, tfjsonpath.New("zone"), knownvalue.StringExact(m.Zone.ValueString())),
-		statecheck.ExpectKnownValue(resourceAddress, tfjsonpath.New("name"), knownvalue.StringExact(m.Name.ValueString())),
+		statecheck.ExpectKnownValue(resourceAddress, tfjsonpath.New(schemaKeyName), knownvalue.StringExact(m.Name.ValueString())),
 	)
 
 	// NOTE: this uses a common pattern that validates attributes based on the definition of the correct behavior.
@@ -255,8 +264,8 @@ func defaultExpectedValues(t *testing.T, resourceAddress string, m *networking.V
 		setChecks := make([]knownvalue.Check, len(m.VpcPrefixes))
 		for i, vp := range m.VpcPrefixes {
 			setChecks[i] = knownvalue.ObjectExact(map[string]knownvalue.Check{
-				"name":  knownvalue.StringExact(vp.Name.ValueString()),
-				"value": knownvalue.StringExact(vp.Value.ValueString()),
+				schemaKeyName:  knownvalue.StringExact(vp.Name.ValueString()),
+				schemaKeyValue: knownvalue.StringExact(vp.Value.ValueString()),
 			})
 		}
 		stateChecks = append(stateChecks, statecheck.ExpectKnownValue(resourceAddress, tfjsonpath.New("vpc_prefixes"), knownvalue.SetExact(setChecks)))
@@ -265,18 +274,18 @@ func defaultExpectedValues(t *testing.T, resourceAddress string, m *networking.V
 	// Full ingress objects are validated for backwards compatibility.
 	expectedIngressObj := make(map[string]knownvalue.Check)
 	if m.Ingress == nil {
-		expectedIngressObj["disable_public_services"] = knownvalue.Bool(false)
+		expectedIngressObj[schemaKeyDisablePublicServices] = knownvalue.Bool(false)
 	} else {
-		expectedIngressObj["disable_public_services"] = knownvalue.Bool(m.Ingress.DisablePublicServices.ValueBool())
+		expectedIngressObj[schemaKeyDisablePublicServices] = knownvalue.Bool(m.Ingress.DisablePublicServices.ValueBool())
 	}
 	stateChecks = append(stateChecks, statecheck.ExpectKnownValue(resourceAddress, tfjsonpath.New("ingress"), knownvalue.ObjectExact(expectedIngressObj)))
 
 	// Full egress objects are validated for backwards compatibility.
 	expectedEgressObj := make(map[string]knownvalue.Check)
 	if m.Egress == nil {
-		expectedEgressObj["disable_public_access"] = knownvalue.Bool(false)
+		expectedEgressObj[schemaKeyDisablePublicAccess] = knownvalue.Bool(false)
 	} else {
-		expectedEgressObj["disable_public_access"] = knownvalue.Bool(m.Egress.DisablePublicAccess.ValueBool())
+		expectedEgressObj[schemaKeyDisablePublicAccess] = knownvalue.Bool(m.Egress.DisablePublicAccess.ValueBool())
 	}
 	stateChecks = append(stateChecks, statecheck.ExpectKnownValue(resourceAddress, tfjsonpath.New("egress"), knownvalue.ObjectExact(expectedEgressObj)))
 
@@ -418,25 +427,25 @@ func TestVpcResource(t *testing.T) {
 						},
 					},
 					Check: resource.ComposeAggregateTestCheckFunc(
-						resource.TestCheckResourceAttr(fullResourceName, "name", initial.Name.ValueString()),
+						resource.TestCheckResourceAttr(fullResourceName, schemaKeyName, initial.Name.ValueString()),
 						resource.TestCheckResourceAttr(fullResourceName, "zone", initial.Zone.ValueString()),
 					),
 					ConfigStateChecks: slices.Concat(defaultExpectedValues(t, fullResourceName, &initial), []statecheck.StateCheck{
 						// Assert that with() worked for the attached host prefix.
 						statecheck.ExpectKnownValue(fullResourceName, tfjsonpath.New("host_prefixes"), knownvalue.SetPartial([]knownvalue.Check{
 							knownvalue.ObjectExact(map[string]knownvalue.Check{
-								"ipam": knownvalue.ObjectExact(map[string]knownvalue.Check{
-									"prefix_length":          knownvalue.Int32Exact(64),
-									"gateway_address_policy": knownvalue.StringExact(networkingv1beta1.IPAddressManagementPolicy_FIRST_IP.String()),
+								schemaKeyIPAM: knownvalue.ObjectExact(map[string]knownvalue.Check{
+									schemaKeyPrefixLength:         knownvalue.Int32Exact(64),
+									schemaKeyGatewayAddressPolicy: knownvalue.StringExact(networkingv1beta1.IPAddressManagementPolicy_FIRST_IP.String()),
 								}),
-								"name":     knownvalue.NotNull(),
-								"type":     knownvalue.StringExact(networkingv1beta1.HostPrefix_ATTACHED.String()),
-								"prefixes": knownvalue.NotNull(),
+								schemaKeyName:     knownvalue.NotNull(),
+								schemaKeyType:     knownvalue.StringExact(networkingv1beta1.HostPrefix_ATTACHED.String()),
+								schemaKeyPrefixes: knownvalue.NotNull(),
 							}),
 						})),
 						statecheck.ExpectKnownValue(fullResourceName, tfjsonpath.New("vpc_prefixes"), knownvalue.SetSizeExact(3)),
-						statecheck.ExpectKnownValue(fullResourceName, tfjsonpath.New("ingress").AtMapKey("disable_public_services"), knownvalue.Bool(false)),
-						statecheck.ExpectKnownValue(fullResourceName, tfjsonpath.New("egress").AtMapKey("disable_public_access"), knownvalue.Bool(false)),
+						statecheck.ExpectKnownValue(fullResourceName, tfjsonpath.New("ingress").AtMapKey(schemaKeyDisablePublicServices), knownvalue.Bool(false)),
+						statecheck.ExpectKnownValue(fullResourceName, tfjsonpath.New("egress").AtMapKey(schemaKeyDisablePublicAccess), knownvalue.Bool(false)),
 					}),
 				},
 				{
@@ -471,12 +480,12 @@ func TestVpcResource(t *testing.T) {
 						},
 					},
 					Check: resource.ComposeAggregateTestCheckFunc(
-						resource.TestCheckResourceAttr(fullResourceName, "name", update.Name.ValueString()),
+						resource.TestCheckResourceAttr(fullResourceName, schemaKeyName, update.Name.ValueString()),
 						resource.TestCheckResourceAttr(fullResourceName, "zone", update.Zone.ValueString()),
 					),
 					ConfigStateChecks: slices.Concat(defaultExpectedValues(t, fullResourceName, &update), []statecheck.StateCheck{
-						statecheck.ExpectKnownValue(fullResourceName, tfjsonpath.New("ingress").AtMapKey("disable_public_services"), knownvalue.Bool(true)),
-						statecheck.ExpectKnownValue(fullResourceName, tfjsonpath.New("egress").AtMapKey("disable_public_access"), knownvalue.Bool(true)),
+						statecheck.ExpectKnownValue(fullResourceName, tfjsonpath.New("ingress").AtMapKey(schemaKeyDisablePublicServices), knownvalue.Bool(true)),
+						statecheck.ExpectKnownValue(fullResourceName, tfjsonpath.New("egress").AtMapKey(schemaKeyDisablePublicAccess), knownvalue.Bool(true)),
 						statecheck.ExpectKnownValue(fullResourceName, tfjsonpath.New("vpc_prefixes"), knownvalue.SetSizeExact(4)),
 					}),
 				},
@@ -759,27 +768,27 @@ resource "coreweave_networking_vpc" %q {
 						},
 					},
 					Check: resource.ComposeAggregateTestCheckFunc(
-						resource.TestCheckResourceAttr(fullResourceName, "name", vpcName),
+						resource.TestCheckResourceAttr(fullResourceName, schemaKeyName, vpcName),
 						resource.TestCheckResourceAttr(fullResourceName, "zone", zone),
 						resource.TestCheckResourceAttr(fullResourceName, "vpc_prefixes.#", "3"),
 					),
 					ConfigStateChecks: []statecheck.StateCheck{
 						statecheck.ExpectKnownValue(fullResourceName, tfjsonpath.New("id"), knownvalue.NotNull()),
-						statecheck.ExpectKnownValue(fullResourceName, tfjsonpath.New("name"), knownvalue.StringExact(vpcName)),
+						statecheck.ExpectKnownValue(fullResourceName, tfjsonpath.New(schemaKeyName), knownvalue.StringExact(vpcName)),
 						statecheck.ExpectKnownValue(fullResourceName, tfjsonpath.New("zone"), knownvalue.StringExact(zone)),
 						statecheck.ExpectKnownValue(fullResourceName, tfjsonpath.New("vpc_prefixes"), knownvalue.SetSizeExact(3)),
 						statecheck.ExpectKnownValue(fullResourceName, tfjsonpath.New("vpc_prefixes"), knownvalue.SetPartial([]knownvalue.Check{
 							knownvalue.ObjectExact(map[string]knownvalue.Check{
-								"name":  knownvalue.StringExact("pod-cidr"),
-								"value": knownvalue.StringExact("10.244.0.0/16"),
+								schemaKeyName:  knownvalue.StringExact("pod-cidr"),
+								schemaKeyValue: knownvalue.StringExact("10.244.0.0/16"),
 							}),
 							knownvalue.ObjectExact(map[string]knownvalue.Check{
-								"name":  knownvalue.StringExact("service-cidr"),
-								"value": knownvalue.StringExact("10.96.0.0/16"),
+								schemaKeyName:  knownvalue.StringExact("service-cidr"),
+								schemaKeyValue: knownvalue.StringExact("10.96.0.0/16"),
 							}),
 							knownvalue.ObjectExact(map[string]knownvalue.Check{
-								"name":  knownvalue.StringExact("lb-cidr"),
-								"value": knownvalue.StringExact("10.20.0.0/22"),
+								schemaKeyName:  knownvalue.StringExact("lb-cidr"),
+								schemaKeyValue: knownvalue.StringExact("10.20.0.0/22"),
 							}),
 						})),
 					},
@@ -829,7 +838,7 @@ func TestHostPrefixReplace(t *testing.T) {
 						},
 					},
 					Check: resource.ComposeAggregateTestCheckFunc(
-						resource.TestCheckResourceAttr(fullResourceName, "name", initial.Name.ValueString()),
+						resource.TestCheckResourceAttr(fullResourceName, schemaKeyName, initial.Name.ValueString()),
 						resource.TestCheckResourceAttr(fullResourceName, "zone", initial.Zone.ValueString()),
 					),
 					ConfigStateChecks: slices.Concat(defaultExpectedValues(t, fullResourceName, initial), []statecheck.StateCheck{
@@ -847,7 +856,7 @@ func TestHostPrefixReplace(t *testing.T) {
 						},
 					},
 					Check: resource.ComposeAggregateTestCheckFunc(
-						resource.TestCheckResourceAttr(fullResourceName, "name", replace.Name.ValueString()),
+						resource.TestCheckResourceAttr(fullResourceName, schemaKeyName, replace.Name.ValueString()),
 						resource.TestCheckResourceAttr(fullResourceName, "zone", replace.Zone.ValueString()),
 					),
 					ConfigStateChecks: []statecheck.StateCheck{
@@ -891,19 +900,19 @@ func TestHostPrefixDefault(t *testing.T) {
 					},
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(fullResourceName, "name", vpc.Name.ValueString()),
+					resource.TestCheckResourceAttr(fullResourceName, schemaKeyName, vpc.Name.ValueString()),
 					resource.TestCheckResourceAttr(fullResourceName, "zone", vpc.Zone.ValueString()),
 				),
 				ConfigStateChecks: slices.Concat(defaultExpectedValues(t, fullResourceName, vpc), []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(fullResourceName, tfjsonpath.New("host_prefix"), knownvalue.NotNull()),
 					statecheck.ExpectKnownValue(fullResourceName, tfjsonpath.New("host_prefixes"), knownvalue.SetPartial([]knownvalue.Check{
 						knownvalue.ObjectExact(map[string]knownvalue.Check{
-							"name": knownvalue.StringExact(defaultPrimaryHostPrefixName),
-							"type": knownvalue.StringExact(networkingv1beta1.HostPrefix_PRIMARY.String()),
-							"prefixes": knownvalue.SetPartial([]knownvalue.Check{
+							schemaKeyName: knownvalue.StringExact(defaultPrimaryHostPrefixName),
+							schemaKeyType: knownvalue.StringExact(networkingv1beta1.HostPrefix_PRIMARY.String()),
+							schemaKeyPrefixes: knownvalue.SetPartial([]knownvalue.Check{
 								knownvalue.NotNull(),
 							}),
-							"ipam": knownvalue.Null(),
+							schemaKeyIPAM: knownvalue.Null(),
 						}),
 					})),
 				}),

--- a/coreweave/networking/schema_constants.go
+++ b/coreweave/networking/schema_constants.go
@@ -1,0 +1,14 @@
+package networking
+
+const (
+	schemaKeyName                  = "name"
+	schemaKeyValue                 = "value"
+	schemaKeyType                  = "type"
+	schemaKeyPrefixes              = "prefixes"
+	schemaKeyIPAM                  = "ipam"
+	schemaKeyPrefixLength          = "prefix_length"
+	schemaKeyGatewayAddressPolicy  = "gateway_address_policy"
+	schemaKeyDisablePublicServices = "disable_public_services"
+	schemaKeyDisablePublicAccess   = "disable_public_access"
+	logKeyError                    = "error"
+)

--- a/coreweave/object_storage/data_source_bucket_policy_document.go
+++ b/coreweave/object_storage/data_source_bucket_policy_document.go
@@ -231,7 +231,7 @@ func (d *BucketPolicyDocumentDataSource) Schema(ctx context.Context, req datasou
 							Optional:            true,
 							MarkdownDescription: "An optional statement identifier",
 						},
-						"effect": schema.StringAttribute{
+						schemaKeyEffect: schema.StringAttribute{
 							Optional:            true,
 							MarkdownDescription: "`Allow` or `Deny`",
 						},
@@ -370,12 +370,12 @@ func MustRenderBucketPolicyDocument(_ context.Context, name string, cfg *BucketP
 			sb.SetAttributeValue("sid", cty.StringVal(s.Sid.ValueString()))
 		}
 		if !s.Effect.IsNull() {
-			sb.SetAttributeValue("effect", cty.StringVal(s.Effect.ValueString()))
+			sb.SetAttributeValue(schemaKeyEffect, cty.StringVal(s.Effect.ValueString()))
 		}
 
 		// action list
 		if !s.Action.IsNull() {
-			var vals []cty.Value
+			vals := make([]cty.Value, 0, len(s.Action.Elements()))
 			for _, v := range s.Action.Elements() {
 				str := v.(types.String).ValueString()
 				vals = append(vals, cty.StringVal(str))
@@ -385,7 +385,7 @@ func MustRenderBucketPolicyDocument(_ context.Context, name string, cfg *BucketP
 
 		// resource list
 		if !s.Resource.IsNull() {
-			var vals []cty.Value
+			vals := make([]cty.Value, 0, len(s.Resource.Elements()))
 			for _, v := range s.Resource.Elements() {
 				str := v.(types.String).ValueString()
 				vals = append(vals, cty.StringVal(str))
@@ -399,7 +399,7 @@ func MustRenderBucketPolicyDocument(_ context.Context, name string, cfg *BucketP
 			for key, val := range s.Principal.Elements() {
 				// val is types.List
 				list := val.(types.List)
-				var elems []cty.Value
+				elems := make([]cty.Value, 0, len(list.Elements()))
 				for _, ev := range list.Elements() {
 					elems = append(elems, cty.StringVal(ev.(types.String).ValueString()))
 				}

--- a/coreweave/object_storage/resource_bucket.go
+++ b/coreweave/object_storage/resource_bucket.go
@@ -60,7 +60,7 @@ func (b *BucketResource) Schema(ctx context.Context, req resource.SchemaRequest,
 	resp.Schema = schema.Schema{
 		MarkdownDescription: "Buckets are the primary organizational containers for your data in CoreWeave AI Object Storage. Bucket names must be globally-unique and not begin with `cw-` or `vip-`, which are reserved for internal use. Learn more about [creating buckets](https://docs.coreweave.com/products/storage/object-storage/buckets/create-bucket).",
 		Attributes: map[string]schema.Attribute{
-			"name": schema.StringAttribute{
+			schemaKeyName: schema.StringAttribute{
 				Required:            true,
 				MarkdownDescription: "The bucket name. Must be globally unique and must not begin with `cw-` or `vip-`.",
 				PlanModifiers: []planmodifier.String{
@@ -596,7 +596,7 @@ func MustRenderBucketResource(ctx context.Context, resourceName string, bucket *
 	resource := body.AppendNewBlock("resource", []string{"coreweave_object_storage_bucket", resourceName})
 	resourceBody := resource.Body()
 
-	resourceBody.SetAttributeValue("name", cty.StringVal(bucket.Name.ValueString()))
+	resourceBody.SetAttributeValue(schemaKeyName, cty.StringVal(bucket.Name.ValueString()))
 	resourceBody.SetAttributeValue("zone", cty.StringVal(bucket.Zone.ValueString()))
 
 	if !bucket.Tags.IsNull() {

--- a/coreweave/object_storage/resource_bucket_inventory.go
+++ b/coreweave/object_storage/resource_bucket_inventory.go
@@ -105,14 +105,14 @@ func (r *BucketInventoryResource) Schema(ctx context.Context, req resource.Schem
 	resp.Schema = schema.Schema{
 		MarkdownDescription: "Manages a Coreweave AI Object Storage bucket inventory configuration. [Learn more about inventory reporting](https://docs.coreweave.com/products/storage/object-storage)",
 		Attributes: map[string]schema.Attribute{
-			"bucket": schema.StringAttribute{
+			schemaKeyBucket: schema.StringAttribute{
 				Required:            true,
 				MarkdownDescription: "Name of source bucket to which the inventory configuration applies",
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},
 			},
-			"name": schema.StringAttribute{
+			schemaKeyName: schema.StringAttribute{
 				Required:            true,
 				MarkdownDescription: "Name of the inventory configuration. Must be unique within the bucket.",
 				PlanModifiers:       []planmodifier.String{stringplanmodifier.RequiresReplace()},
@@ -136,7 +136,7 @@ func (r *BucketInventoryResource) Schema(ctx context.Context, req resource.Schem
 				MarkdownDescription: "List of optional fields to include in the inventory results",
 				Validators: []validator.Set{
 					setvalidator.SizeAtLeast(1),
-					setvalidator.ValueStringsAre(stringvalidator.OneOf("Size", "LastModifiedDate", "LastAccessedDate", "StorageClass", "ETag", "IsMultipartUploaded", "EncryptionStatus", "ChecksumAlgorithm")),
+					setvalidator.ValueStringsAre(stringvalidator.OneOf(inventoryOptionalFieldSize, "LastModifiedDate", inventoryOptionalFieldLastAccessedDate, "StorageClass", "ETag", "IsMultipartUploaded", "EncryptionStatus", "ChecksumAlgorithm")),
 				},
 			},
 		},
@@ -144,7 +144,7 @@ func (r *BucketInventoryResource) Schema(ctx context.Context, req resource.Schem
 			"filter": schema.SingleNestedBlock{
 				MarkdownDescription: "Limits the inventory report to objects matching a prefix.",
 				Attributes: map[string]schema.Attribute{
-					"prefix": schema.StringAttribute{
+					schemaKeyPrefix: schema.StringAttribute{
 						Optional:            true,
 						MarkdownDescription: "Source-object prefix to filter on.",
 					},
@@ -164,7 +164,7 @@ func (r *BucketInventoryResource) Schema(ctx context.Context, req resource.Schem
 			"destination": schema.SingleNestedBlock{
 				MarkdownDescription: "Where the inventory report is written. May be the same bucket as the source.",
 				Blocks: map[string]schema.Block{
-					"bucket": schema.SingleNestedBlock{
+					schemaKeyBucket: schema.SingleNestedBlock{
 						MarkdownDescription: "Destination bucket for the report (may equal the source bucket).",
 						Attributes: map[string]schema.Attribute{
 							"bucket_arn": schema.StringAttribute{
@@ -176,7 +176,7 @@ func (r *BucketInventoryResource) Schema(ctx context.Context, req resource.Schem
 								MarkdownDescription: "Output format: `CSV`, `TSV`, `JSON`, `ORC`, or `Parquet`.",
 								Validators:          []validator.String{stringvalidator.OneOf("CSV", "TSV", "JSON", "ORC", "Parquet")},
 							},
-							"prefix": schema.StringAttribute{
+							schemaKeyPrefix: schema.StringAttribute{
 								Optional:            true,
 								MarkdownDescription: "Prefix prepended to the report output path.",
 							},
@@ -384,9 +384,9 @@ func (r *BucketInventoryResource) Create(ctx context.Context, req resource.Creat
 		return
 	}
 	tflog.Debug(ctx, "creating inventory configuration for bucket", map[string]any{
-		"inventory": string(invJSON),
-		"bucket":    data.Bucket.ValueString(),
-		"id":        data.Name.ValueString(),
+		"inventory":     string(invJSON),
+		schemaKeyBucket: data.Bucket.ValueString(),
+		"id":            data.Name.ValueString(),
 	})
 
 	_, err = s3c.PutBucketInventoryConfiguration(ctx, &s3.PutBucketInventoryConfigurationInput{
@@ -662,7 +662,7 @@ func MustRenderBucketInventoryResource(ctx context.Context, name string, cfg *Bu
 	b := block.Body()
 
 	// bucket rendered as a raw reference token, not a quoted string.
-	b.SetAttributeRaw("bucket", hclwrite.Tokens{{Type: hclsyntax.TokenIdent, Bytes: []byte(cfg.Bucket.ValueString())}})
+	b.SetAttributeRaw(schemaKeyBucket, hclwrite.Tokens{{Type: hclsyntax.TokenIdent, Bytes: []byte(cfg.Bucket.ValueString())}})
 
 	// depends_on rendered as raw reference tokens (a list of resource addresses),
 	// so the destination bucket's policy is applied before the inventory service
@@ -679,7 +679,7 @@ func MustRenderBucketInventoryResource(ctx context.Context, name string, cfg *Bu
 		b.SetAttributeRaw("depends_on", toks)
 	}
 
-	b.SetAttributeValue("name", cty.StringVal(cfg.Name.ValueString()))
+	b.SetAttributeValue(schemaKeyName, cty.StringVal(cfg.Name.ValueString()))
 	if !cfg.Enabled.IsNull() {
 		b.SetAttributeValue("enabled", cty.BoolVal(cfg.Enabled.ValueBool()))
 	}
@@ -700,7 +700,7 @@ func MustRenderBucketInventoryResource(ctx context.Context, name string, cfg *Bu
 	if cfg.Filter != nil {
 		fb := b.AppendNewBlock("filter", nil).Body()
 		if !cfg.Filter.Prefix.IsNull() {
-			fb.SetAttributeValue("prefix", cty.StringVal(cfg.Filter.Prefix.ValueString()))
+			fb.SetAttributeValue(schemaKeyPrefix, cty.StringVal(cfg.Filter.Prefix.ValueString()))
 		}
 	}
 
@@ -711,12 +711,12 @@ func MustRenderBucketInventoryResource(ctx context.Context, name string, cfg *Bu
 
 	if cfg.Destination != nil && cfg.Destination.Bucket != nil {
 		db := b.AppendNewBlock("destination", nil).Body()
-		bb := db.AppendNewBlock("bucket", nil).Body()
+		bb := db.AppendNewBlock(schemaKeyBucket, nil).Body()
 		dest := cfg.Destination.Bucket
 		bb.SetAttributeValue("bucket_arn", cty.StringVal(dest.BucketArn.ValueString()))
 		bb.SetAttributeValue("format", cty.StringVal(dest.Format.ValueString()))
 		if !dest.Prefix.IsNull() {
-			bb.SetAttributeValue("prefix", cty.StringVal(dest.Prefix.ValueString()))
+			bb.SetAttributeValue(schemaKeyPrefix, cty.StringVal(dest.Prefix.ValueString()))
 		}
 		if !dest.AccountID.IsNull() {
 			bb.SetAttributeValue("account_id", cty.StringVal(dest.AccountID.ValueString()))

--- a/coreweave/object_storage/resource_bucket_inventory_test.go
+++ b/coreweave/object_storage/resource_bucket_inventory_test.go
@@ -65,11 +65,11 @@ func createInventoryTestStep(ctx context.Context, t *testing.T, opts inventoryTe
 	rs := fmt.Sprintf("coreweave_object_storage_bucket_inventory.%s", opts.resourceName)
 
 	checks := []statecheck.StateCheck{
-		statecheck.ExpectKnownValue(rs, tfjsonpath.New("name"), knownvalue.StringExact(inv.Name.ValueString())),
+		statecheck.ExpectKnownValue(rs, tfjsonpath.New(schemaKeyName), knownvalue.StringExact(inv.Name.ValueString())),
 		statecheck.ExpectKnownValue(rs, tfjsonpath.New("included_object_versions"), knownvalue.StringExact(inv.IncludedObjectVersions.ValueString())),
 		statecheck.ExpectKnownValue(rs, tfjsonpath.New("enabled"), knownvalue.Bool(inv.Enabled.ValueBool())),
 		statecheck.ExpectKnownValue(rs, tfjsonpath.New("schedule").AtMapKey("frequency"), knownvalue.StringExact(inv.Schedule.Frequency.ValueString())),
-		statecheck.ExpectKnownValue(rs, tfjsonpath.New("destination").AtMapKey("bucket").AtMapKey("format"), knownvalue.StringExact(inv.Destination.Bucket.Format.ValueString())),
+		statecheck.ExpectKnownValue(rs, tfjsonpath.New("destination").AtMapKey(schemaKeyBucket).AtMapKey("format"), knownvalue.StringExact(inv.Destination.Bucket.Format.ValueString())),
 	}
 
 	// optional_fields (set) — assert exact membership, including LastAccessedDate.
@@ -124,8 +124,8 @@ func TestBucketInventoryBasic(t *testing.T) {
 		Enabled:                types.BoolValue(true),
 		IncludedObjectVersions: types.StringValue("Current"),
 		OptionalFields: types.SetValueMust(types.StringType, []attr.Value{
-			types.StringValue("Size"),
-			types.StringValue("LastAccessedDate"),
+			types.StringValue(inventoryOptionalFieldSize),
+			types.StringValue(inventoryOptionalFieldLastAccessedDate),
 		}),
 		Schedule: &objectstorage.ScheduleModel{Frequency: types.StringValue("Daily")},
 		Destination: &objectstorage.DestinationModel{
@@ -140,8 +140,8 @@ func TestBucketInventoryBasic(t *testing.T) {
 	// (adds ETag) to prove a real diff is detected and applied.
 	updated := base
 	updated.OptionalFields = types.SetValueMust(types.StringType, []attr.Value{
-		types.StringValue("Size"),
-		types.StringValue("LastAccessedDate"),
+		types.StringValue(inventoryOptionalFieldSize),
+		types.StringValue(inventoryOptionalFieldLastAccessedDate),
 		types.StringValue("ETag"),
 	})
 	updated.Schedule = &objectstorage.ScheduleModel{Frequency: types.StringValue("Weekly")}
@@ -203,7 +203,7 @@ func TestBucketInventoryBasic(t *testing.T) {
 			ResourceName:                         rs,
 			ImportState:                          true,
 			ImportStateVerify:                    true,
-			ImportStateVerifyIdentifierAttribute: "name",
+			ImportStateVerifyIdentifierAttribute: schemaKeyName,
 			ImportStateId:                        fmt.Sprintf("%s:%s", bucket.Name.ValueString(), updated.Name.ValueString()),
 			ImportStateCheck: func([]*terraform.InstanceState) error {
 				t.Logf("completed coreweave_object_storage_bucket_inventory import step")
@@ -381,7 +381,7 @@ func TestBucketInventoryDisappears(t *testing.T) {
 		Enabled:                types.BoolValue(true),
 		IncludedObjectVersions: types.StringValue("All"),
 		OptionalFields: types.SetValueMust(types.StringType, []attr.Value{
-			types.StringValue("LastAccessedDate"),
+			types.StringValue(inventoryOptionalFieldLastAccessedDate),
 		}),
 		Schedule: &objectstorage.ScheduleModel{Frequency: types.StringValue("Daily")},
 		Destination: &objectstorage.DestinationModel{
@@ -454,8 +454,8 @@ func testAccCheckInventoryDestroy(ctx context.Context, t *testing.T) resource.Te
 			if rs.Type != "coreweave_object_storage_bucket_inventory" {
 				continue
 			}
-			bucket := rs.Primary.Attributes["bucket"]
-			id := rs.Primary.Attributes["name"]
+			bucket := rs.Primary.Attributes[schemaKeyBucket]
+			id := rs.Primary.Attributes[schemaKeyName]
 
 			_, err := s3c.GetBucketInventoryConfiguration(ctx, &s3.GetBucketInventoryConfigurationInput{
 				Bucket: aws.String(bucket),

--- a/coreweave/object_storage/resource_bucket_inventory_unit_test.go
+++ b/coreweave/object_storage/resource_bucket_inventory_unit_test.go
@@ -26,8 +26,8 @@ func fullInventoryModel() *BucketInventoryResourceModel {
 		Enabled:                types.BoolValue(true),
 		IncludedObjectVersions: types.StringValue("All"),
 		OptionalFields: types.SetValueMust(types.StringType, []attr.Value{
-			types.StringValue("Size"),
-			types.StringValue("LastAccessedDate"),
+			types.StringValue(inventoryOptionalFieldSize),
+			types.StringValue(inventoryOptionalFieldLastAccessedDate),
 		}),
 		Filter:   &InventoryFilterModel{Prefix: types.StringValue("logs/")},
 		Schedule: &ScheduleModel{Frequency: types.StringValue("Daily")},
@@ -75,7 +75,7 @@ func TestExpandInventoryConfiguration(t *testing.T) {
 	for _, f := range got.OptionalFields {
 		gotFields = append(gotFields, string(f))
 	}
-	require.ElementsMatch(t, []string{"Size", "LastAccessedDate"}, gotFields)
+	require.ElementsMatch(t, []string{inventoryOptionalFieldSize, inventoryOptionalFieldLastAccessedDate}, gotFields)
 }
 
 func TestExpandInventoryConfiguration_OmitsOptionalFieldsWhenNull(t *testing.T) {
@@ -111,7 +111,7 @@ func TestFlattenInventoryConfiguration(t *testing.T) {
 				AccountId: aws.String("123456789012"),
 			},
 		},
-		OptionalFields: []s3types.InventoryOptionalField{"Size", "LastAccessedDate"},
+		OptionalFields: []s3types.InventoryOptionalField{inventoryOptionalFieldSize, inventoryOptionalFieldLastAccessedDate},
 	}
 
 	// Bucket is not part of the API payload; simulate that it was already in state
@@ -140,7 +140,7 @@ func TestFlattenInventoryConfiguration(t *testing.T) {
 
 	var fields []string
 	require.False(t, data.OptionalFields.ElementsAs(ctx, &fields, false).HasError())
-	require.ElementsMatch(t, []string{"Size", "LastAccessedDate"}, fields)
+	require.ElementsMatch(t, []string{inventoryOptionalFieldSize, inventoryOptionalFieldLastAccessedDate}, fields)
 }
 
 func TestFlattenInventoryConfiguration_EmptyOptionalFieldsIsNull(t *testing.T) {
@@ -283,10 +283,10 @@ func TestInventorySchema_OptionalFieldsValidator(t *testing.T) {
 		wantErr bool
 	}{
 		// LastAccessedDate must be accepted — this is the crux of CFR-178.
-		"LastAccessedDate accepted":        {setOf("LastAccessedDate"), false},
-		"full superset accepted":           {setOf("Size", "LastModifiedDate", "LastAccessedDate", "StorageClass", "ETag", "IsMultipartUploaded", "EncryptionStatus", "ChecksumAlgorithm"), false},
+		"LastAccessedDate accepted":        {setOf(inventoryOptionalFieldLastAccessedDate), false},
+		"full superset accepted":           {setOf(inventoryOptionalFieldSize, "LastModifiedDate", inventoryOptionalFieldLastAccessedDate, "StorageClass", "ETag", "IsMultipartUploaded", "EncryptionStatus", "ChecksumAlgorithm"), false},
 		"unknown field rejected":           {setOf("Bogus"), true},
-		"one invalid among valid rejected": {setOf("Size", "NotAField"), true},
+		"one invalid among valid rejected": {setOf(inventoryOptionalFieldSize, "NotAField"), true},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
@@ -329,7 +329,7 @@ func TestInventorySchema_DestinationFormatValidator(t *testing.T) {
 	// format lives at destination.bucket.format (two levels of SingleNestedBlock).
 	destBlock, ok := inventorySchema(t).Blocks["destination"].(schema.SingleNestedBlock)
 	require.True(t, ok, "destination is not a SingleNestedBlock")
-	bucketBlock, ok := destBlock.Blocks["bucket"].(schema.SingleNestedBlock)
+	bucketBlock, ok := destBlock.Blocks[schemaKeyBucket].(schema.SingleNestedBlock)
 	require.True(t, ok, "destination.bucket is not a SingleNestedBlock")
 	formatAttr, ok := bucketBlock.Attributes["format"].(schema.StringAttribute)
 	require.True(t, ok, "destination.bucket.format is not a StringAttribute")

--- a/coreweave/object_storage/resource_bucket_lifecycle_configuration.go
+++ b/coreweave/object_storage/resource_bucket_lifecycle_configuration.go
@@ -133,7 +133,7 @@ func (r *BucketLifecycleResource) Schema(ctx context.Context, req resource.Schem
 	resp.Schema = schema.Schema{
 		MarkdownDescription: "Lifecycle configurations automate object management by defining actions applied to objects over time, such as expiring objects after a specified period or transitioning them to different storage tiers. This helps optimize storage costs and maintain data hygiene. [Learn more about S3-compatible lifecycle bucket configurations](https://docs.coreweave.com/products/storage/object-storage/reference/object-storage-s3#bucket-lifecycles).",
 		Attributes: map[string]schema.Attribute{
-			"bucket": schema.StringAttribute{
+			schemaKeyBucket: schema.StringAttribute{
 				Required:            true,
 				MarkdownDescription: "Name of the bucket to apply lifecycle configuration to",
 				PlanModifiers: []planmodifier.String{
@@ -153,7 +153,7 @@ func (r *BucketLifecycleResource) Schema(ctx context.Context, req resource.Schem
 								stringplanmodifier.UseStateForUnknown(),
 							},
 						},
-						"prefix": schema.StringAttribute{
+						schemaKeyPrefix: schema.StringAttribute{
 							Optional:            true,
 							MarkdownDescription: "Deprecated. Object key prefix to which the rule applies. CoreWeave AI Object Storage rejects requests that set this field; use `filter.prefix` instead.",
 							DeprecationMessage:  "Use filter.prefix instead. CoreWeave AI Object Storage now rejects PutBucketLifecycleConfiguration requests that include this deprecated S3 field, so the provider no longer sends it on the wire. Any value set here is retained in state for backwards compatibility (the rule's id is used to match a rule to its preserved value across refreshes; rules without an id rely on positional alignment) but is otherwise ignored.",
@@ -206,7 +206,7 @@ func (r *BucketLifecycleResource) Schema(ctx context.Context, req resource.Schem
 								"and": schema.SingleNestedBlock{
 									MarkdownDescription: "Configuration block used to apply a logical AND to two or more predicates. The Lifecycle Rule will apply to any object matching all the predicates configured inside the and block.",
 									Attributes: map[string]schema.Attribute{
-										"prefix": schema.StringAttribute{
+										schemaKeyPrefix: schema.StringAttribute{
 											Optional:            true,
 											MarkdownDescription: "Prefix identifying one or more objects to which the rule applies.",
 										},
@@ -227,7 +227,7 @@ func (r *BucketLifecycleResource) Schema(ctx context.Context, req resource.Schem
 								},
 							},
 							Attributes: map[string]schema.Attribute{
-								"prefix": schema.StringAttribute{
+								schemaKeyPrefix: schema.StringAttribute{
 									Optional:            true,
 									MarkdownDescription: "Prefix filter",
 								},
@@ -613,7 +613,7 @@ func (r *BucketLifecycleResource) Create(ctx context.Context, req resource.Creat
 		resp.Diagnostics.AddError("Failed to marshal lifecycle rules to JSON", err.Error())
 		return
 	}
-	tflog.Debug(ctx, "creating lifecycle rules for bucket", map[string]any{"rules": string(rulesJSON), "bucket": data.Bucket.ValueString()})
+	tflog.Debug(ctx, "creating lifecycle rules for bucket", map[string]any{"rules": string(rulesJSON), schemaKeyBucket: data.Bucket.ValueString()})
 	lifecycleConfig := &s3types.BucketLifecycleConfiguration{
 		Rules: rules,
 	}
@@ -911,7 +911,7 @@ func MustRenderBucketLifecycleConfigurationResource(ctx context.Context, name st
 	b := block.Body()
 
 	// bucket attribute
-	b.SetAttributeRaw("bucket", hclwrite.Tokens{{Type: hclsyntax.TokenIdent, Bytes: []byte(cfg.Bucket.ValueString())}})
+	b.SetAttributeRaw(schemaKeyBucket, hclwrite.Tokens{{Type: hclsyntax.TokenIdent, Bytes: []byte(cfg.Bucket.ValueString())}})
 
 	// rule blocks
 	for _, rule := range cfg.Rule {
@@ -922,7 +922,7 @@ func MustRenderBucketLifecycleConfigurationResource(ctx context.Context, name st
 			rb.SetAttributeValue("id", cty.StringVal(rule.ID.ValueString()))
 		}
 		if !rule.Prefix.IsNull() {
-			rb.SetAttributeValue("prefix", cty.StringVal(rule.Prefix.ValueString()))
+			rb.SetAttributeValue(schemaKeyPrefix, cty.StringVal(rule.Prefix.ValueString()))
 		}
 		rb.SetAttributeValue("status", cty.StringVal(rule.Status.ValueString()))
 
@@ -973,7 +973,7 @@ func MustRenderBucketLifecycleConfigurationResource(ctx context.Context, name st
 
 			// filter attrs
 			if !rule.Filter.Prefix.IsNull() {
-				fb.SetAttributeValue("prefix", cty.StringVal(rule.Filter.Prefix.ValueString()))
+				fb.SetAttributeValue(schemaKeyPrefix, cty.StringVal(rule.Filter.Prefix.ValueString()))
 			}
 			if !rule.Filter.ObjectSizeGreaterThan.IsNull() {
 				fb.SetAttributeValue("object_size_greater_than",
@@ -998,7 +998,7 @@ func MustRenderBucketLifecycleConfigurationResource(ctx context.Context, name st
 				and := fb.AppendNewBlock("and", nil).Body()
 
 				if !rule.Filter.And.Prefix.IsNull() {
-					and.SetAttributeValue("prefix", cty.StringVal(rule.Filter.And.Prefix.ValueString()))
+					and.SetAttributeValue(schemaKeyPrefix, cty.StringVal(rule.Filter.And.Prefix.ValueString()))
 				}
 
 				// tags as a map

--- a/coreweave/object_storage/resource_bucket_lifecycle_configuration_test.go
+++ b/coreweave/object_storage/resource_bucket_lifecycle_configuration_test.go
@@ -69,9 +69,9 @@ func createLifecycleTestStep(
 		checks = append(checks, idCheck)
 
 		// prefix (optional)
-		prefixCheck := statecheck.ExpectKnownValue(rs, ruleBase.AtMapKey("prefix"), knownvalue.Null())
+		prefixCheck := statecheck.ExpectKnownValue(rs, ruleBase.AtMapKey(schemaKeyPrefix), knownvalue.Null())
 		if !r.Prefix.IsNull() {
-			prefixCheck = statecheck.ExpectKnownValue(rs, ruleBase.AtMapKey("prefix"), knownvalue.StringExact(r.Prefix.ValueString()))
+			prefixCheck = statecheck.ExpectKnownValue(rs, ruleBase.AtMapKey(schemaKeyPrefix), knownvalue.StringExact(r.Prefix.ValueString()))
 		}
 		checks = append(checks, prefixCheck)
 
@@ -136,9 +136,9 @@ func createLifecycleTestStep(
 		filterCheck := statecheck.ExpectKnownValue(rs, ruleBase.AtMapKey("filter"), knownvalue.Null())
 		if r.Filter != nil {
 			filterCheck = statecheck.ExpectKnownValue(rs, ruleBase.AtMapKey("filter"), knownvalue.NotNull())
-			filterPrefixCheck := statecheck.ExpectKnownValue(rs, ruleBase.AtMapKey("filter").AtMapKey("prefix"), knownvalue.StringExact(r.Filter.Prefix.ValueString()))
+			filterPrefixCheck := statecheck.ExpectKnownValue(rs, ruleBase.AtMapKey("filter").AtMapKey(schemaKeyPrefix), knownvalue.StringExact(r.Filter.Prefix.ValueString()))
 			if r.Filter.Prefix.IsNull() {
-				filterPrefixCheck = statecheck.ExpectKnownValue(rs, ruleBase.AtMapKey("filter").AtMapKey("prefix"), knownvalue.Null())
+				filterPrefixCheck = statecheck.ExpectKnownValue(rs, ruleBase.AtMapKey("filter").AtMapKey(schemaKeyPrefix), knownvalue.Null())
 			}
 			checks = append(checks, filterPrefixCheck)
 
@@ -157,7 +157,7 @@ func createLifecycleTestStep(
 			filterAndCheck := statecheck.ExpectKnownValue(rs, ruleBase.AtMapKey("filter").AtMapKey("and"), knownvalue.Null())
 			if r.Filter.And != nil {
 				filterAndCheck = statecheck.ExpectKnownValue(rs, ruleBase.AtMapKey("filter").AtMapKey("and"), knownvalue.NotNull())
-				checks = append(checks, statecheck.ExpectKnownValue(rs, ruleBase.AtMapKey("filter").AtMapKey("and").AtMapKey("prefix"), knownvalue.StringExact(r.Filter.And.Prefix.ValueString())))
+				checks = append(checks, statecheck.ExpectKnownValue(rs, ruleBase.AtMapKey("filter").AtMapKey("and").AtMapKey(schemaKeyPrefix), knownvalue.StringExact(r.Filter.And.Prefix.ValueString())))
 				checks = append(checks, statecheck.ExpectKnownValue(rs, ruleBase.AtMapKey("filter").AtMapKey("and").AtMapKey("object_size_less_than"), knownvalue.Int64Exact(r.Filter.And.ObjectSizeLessThan.ValueInt64())))
 				checks = append(checks, statecheck.ExpectKnownValue(rs, ruleBase.AtMapKey("filter").AtMapKey("and").AtMapKey("object_size_greater_than"), knownvalue.Int64Exact(r.Filter.And.ObjectSizeGreaterThan.ValueInt64())))
 				tagMap := map[string]string{}
@@ -414,7 +414,7 @@ func TestBucketLifecycleConfiguration(t *testing.T) {
 			},
 			ResourceName:                         fmt.Sprintf("coreweave_object_storage_bucket_lifecycle_configuration.%s", resourceName),
 			ImportState:                          true,
-			ImportStateVerifyIdentifierAttribute: "name",
+			ImportStateVerifyIdentifierAttribute: schemaKeyName,
 			ImportStateId:                        bucket.Name.ValueString(),
 		},
 	}

--- a/coreweave/object_storage/resource_bucket_policy.go
+++ b/coreweave/object_storage/resource_bucket_policy.go
@@ -67,7 +67,7 @@ func (b *BucketPolicyResource) Schema(ctx context.Context, req resource.SchemaRe
 	resp.Schema = schema.Schema{
 		MarkdownDescription: "[Bucket access policies](https://docs.coreweave.com/products/storage/object-storage/auth-access/bucket-access/bucket-policies) allow you to define precise, S3-compatible access control for one bucket. These are optional, and are evaluated after organization access policies. See [Manage Bucket Policies](https://docs.coreweave.com/products/storage/object-storage/auth-access/bucket-access/manage-bucket-policies#example-policies) for examples and further information.",
 		Attributes: map[string]schema.Attribute{
-			"bucket": schema.StringAttribute{
+			schemaKeyBucket: schema.StringAttribute{
 				Required:            true,
 				MarkdownDescription: "The name of the bucket for which to apply this policy.",
 			},
@@ -304,7 +304,7 @@ func MustRenderBucketPolicyResource(_ context.Context, name string, cfg *BucketP
 	b := block.Body()
 
 	// bucket attribute
-	b.SetAttributeRaw("bucket", hclwrite.Tokens{{Type: hclsyntax.TokenIdent, Bytes: []byte(cfg.Bucket.ValueString())}})
+	b.SetAttributeRaw(schemaKeyBucket, hclwrite.Tokens{{Type: hclsyntax.TokenIdent, Bytes: []byte(cfg.Bucket.ValueString())}})
 	b.SetAttributeValue("policy", cty.StringVal(cfg.Policy.ValueString()))
 
 	var buf bytes.Buffer
@@ -327,7 +327,7 @@ func MustRenderBucketPolicyResourceWithDataSource(_ context.Context, name string
 	b := block.Body()
 
 	// bucket attribute
-	b.SetAttributeRaw("bucket", hclwrite.Tokens{{Type: hclsyntax.TokenIdent, Bytes: []byte(cfg.Bucket.ValueString())}})
+	b.SetAttributeRaw(schemaKeyBucket, hclwrite.Tokens{{Type: hclsyntax.TokenIdent, Bytes: []byte(cfg.Bucket.ValueString())}})
 	b.SetAttributeRaw("policy", hclwrite.Tokens{{Type: hclsyntax.TokenIdent, Bytes: []byte(cfg.Policy.ValueString())}})
 
 	var buf bytes.Buffer

--- a/coreweave/object_storage/resource_bucket_policy_test.go
+++ b/coreweave/object_storage/resource_bucket_policy_test.go
@@ -74,7 +74,7 @@ func createBucketPolicyTestStep(ctx context.Context, t *testing.T, opts bucketPo
 	fullConfig := bucketConfig + policyConfig + dataSourceConfig
 	rs := fmt.Sprintf("coreweave_object_storage_bucket_policy.%s", opts.resourceName)
 	checks := []statecheck.StateCheck{
-		statecheck.ExpectKnownValue(rs, tfjsonpath.New("bucket"), knownvalue.StringExact(opts.bucket.Name.ValueString())),
+		statecheck.ExpectKnownValue(rs, tfjsonpath.New(schemaKeyBucket), knownvalue.StringExact(opts.bucket.Name.ValueString())),
 		statecheck.ExpectKnownValue(rs, tfjsonpath.New("policy"), policyCheck),
 	}
 
@@ -127,7 +127,7 @@ func TestBucketPolicyResourceRaw(t *testing.T) {
 			},
 			ResourceName:                         fmt.Sprintf("coreweave_object_storage_bucket_policy.%s", resourceName),
 			ImportState:                          true,
-			ImportStateVerifyIdentifierAttribute: "name",
+			ImportStateVerifyIdentifierAttribute: schemaKeyName,
 			ImportStateId:                        bucket.Name.ValueString(),
 		},
 	}
@@ -236,7 +236,7 @@ func TestBucketPolicyResourceDocument(t *testing.T) {
 			},
 			ResourceName:                         fmt.Sprintf("coreweave_object_storage_bucket_policy.%s", resourceName),
 			ImportState:                          true,
-			ImportStateVerifyIdentifierAttribute: "name",
+			ImportStateVerifyIdentifierAttribute: schemaKeyName,
 			ImportStateId:                        bucket.Name.ValueString(),
 		},
 	}

--- a/coreweave/object_storage/resource_bucket_settings.go
+++ b/coreweave/object_storage/resource_bucket_settings.go
@@ -158,7 +158,7 @@ func (b *BucketSettingsResource) Schema(ctx context.Context, req resource.Schema
 	resp.Schema = schema.Schema{
 		Description: "Manage settings for a CoreWeave AI Object Storage bucket.",
 		Attributes: map[string]schema.Attribute{
-			"bucket": schema.StringAttribute{
+			schemaKeyBucket: schema.StringAttribute{
 				Description: "The name of the bucket to manage settings for.",
 				Required:    true,
 				PlanModifiers: []planmodifier.String{
@@ -228,7 +228,7 @@ func MustRenderBucketSettingsResource(_ context.Context, name string, settings *
 	resourceBody := resource.Body()
 
 	// bucket attribute
-	resourceBody.SetAttributeRaw("bucket", hclwrite.Tokens{{Type: hclsyntax.TokenIdent, Bytes: []byte(settings.Bucket.ValueString())}})
+	resourceBody.SetAttributeRaw(schemaKeyBucket, hclwrite.Tokens{{Type: hclsyntax.TokenIdent, Bytes: []byte(settings.Bucket.ValueString())}})
 
 	// audit_logging_enabled attribute
 	if !settings.AuditLoggingEnabled.IsNull() {

--- a/coreweave/object_storage/resource_bucket_settings_test.go
+++ b/coreweave/object_storage/resource_bucket_settings_test.go
@@ -58,7 +58,7 @@ func createBucketSettingsTestStep(ctx context.Context, t *testing.T, opts bucket
 
 	rs := fmt.Sprintf("coreweave_object_storage_bucket_settings.%s", opts.resourceName)
 	checks := []statecheck.StateCheck{
-		statecheck.ExpectKnownValue(rs, tfjsonpath.New("bucket"), knownvalue.StringExact(opts.bucket.Name.ValueString())),
+		statecheck.ExpectKnownValue(rs, tfjsonpath.New(schemaKeyBucket), knownvalue.StringExact(opts.bucket.Name.ValueString())),
 		statecheck.ExpectKnownValue(rs, tfjsonpath.New("audit_logging_enabled"), knownvalue.Bool(opts.settings.AuditLoggingEnabled.ValueBool())),
 	}
 
@@ -116,7 +116,7 @@ func TestBucketSettingsResource(t *testing.T) {
 			ResourceName:                         fmt.Sprintf("coreweave_object_storage_bucket_settings.%s", resourceName),
 			ImportState:                          true,
 			ImportStateId:                        bucket.Name.ValueString(),
-			ImportStateVerifyIdentifierAttribute: "bucket",
+			ImportStateVerifyIdentifierAttribute: schemaKeyBucket,
 			ImportStateVerify:                    true,
 		},
 	}

--- a/coreweave/object_storage/resource_bucket_test.go
+++ b/coreweave/object_storage/resource_bucket_test.go
@@ -50,10 +50,11 @@ func createBucketTestStep(ctx context.Context, t *testing.T, opts bucketTestStep
 
 	fullResourceName := fmt.Sprintf("coreweave_object_storage_bucket.%s", opts.ResourceName)
 
-	statechecks := []statecheck.StateCheck{
-		statecheck.ExpectKnownValue(fullResourceName, tfjsonpath.New("name"), knownvalue.StringExact(opts.Bucket.Name.ValueString())),
+	statechecks := make([]statecheck.StateCheck, 0, 3)
+	statechecks = append(statechecks,
+		statecheck.ExpectKnownValue(fullResourceName, tfjsonpath.New(schemaKeyName), knownvalue.StringExact(opts.Bucket.Name.ValueString())),
 		statecheck.ExpectKnownValue(fullResourceName, tfjsonpath.New("zone"), knownvalue.StringExact(opts.Bucket.Zone.ValueString())),
-	}
+	)
 
 	tagCheck := statecheck.ExpectKnownValue(fullResourceName, tfjsonpath.New("tags"), knownvalue.Null())
 
@@ -91,20 +92,20 @@ func TestBucketResource(t *testing.T) {
 		Steps: []resource.TestStep{
 			createBucketTestStep(ctx, t, bucketTestStep{
 				TestName:     "initial bucket no tags",
-				ResourceName: "test_acc_bucket",
+				ResourceName: testBucketResourceName,
 				Bucket: objectstorage.BucketResourceModel{
 					Name: types.StringValue(bucketName),
 					Zone: types.StringValue(zone),
 				},
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectResourceAction(fmt.Sprintf("coreweave_object_storage_bucket.%s", "test_acc_bucket"), plancheck.ResourceActionCreate),
+						plancheck.ExpectResourceAction(fmt.Sprintf("coreweave_object_storage_bucket.%s", testBucketResourceName), plancheck.ResourceActionCreate),
 					},
 				},
 			}),
 			createBucketTestStep(ctx, t, bucketTestStep{
 				TestName:     "update with tags",
-				ResourceName: "test_acc_bucket",
+				ResourceName: testBucketResourceName,
 				Bucket: objectstorage.BucketResourceModel{
 					Name: types.StringValue(bucketName),
 					Zone: types.StringValue(zone),
@@ -115,13 +116,13 @@ func TestBucketResource(t *testing.T) {
 				},
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectResourceAction(fmt.Sprintf("coreweave_object_storage_bucket.%s", "test_acc_bucket"), plancheck.ResourceActionUpdate),
+						plancheck.ExpectResourceAction(fmt.Sprintf("coreweave_object_storage_bucket.%s", testBucketResourceName), plancheck.ResourceActionUpdate),
 					},
 				},
 			}),
 			createBucketTestStep(ctx, t, bucketTestStep{
 				TestName:     "remove tags",
-				ResourceName: "test_acc_bucket",
+				ResourceName: testBucketResourceName,
 				Bucket: objectstorage.BucketResourceModel{
 					Name: types.StringValue(bucketName),
 					Zone: types.StringValue(zone),
@@ -129,33 +130,33 @@ func TestBucketResource(t *testing.T) {
 				},
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectResourceAction(fmt.Sprintf("coreweave_object_storage_bucket.%s", "test_acc_bucket"), plancheck.ResourceActionUpdate),
+						plancheck.ExpectResourceAction(fmt.Sprintf("coreweave_object_storage_bucket.%s", testBucketResourceName), plancheck.ResourceActionUpdate),
 					},
 				},
 			}),
 			createBucketTestStep(ctx, t, bucketTestStep{
 				TestName:     "requires replace zone",
-				ResourceName: "test_acc_bucket",
+				ResourceName: testBucketResourceName,
 				Bucket: objectstorage.BucketResourceModel{
 					Name: types.StringValue(bucketName),
 					Zone: types.StringValue("US-EAST-02A"),
 				},
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectResourceAction(fmt.Sprintf("coreweave_object_storage_bucket.%s", "test_acc_bucket"), plancheck.ResourceActionDestroyBeforeCreate),
+						plancheck.ExpectResourceAction(fmt.Sprintf("coreweave_object_storage_bucket.%s", testBucketResourceName), plancheck.ResourceActionDestroyBeforeCreate),
 					},
 				},
 			}),
 			createBucketTestStep(ctx, t, bucketTestStep{
 				TestName:     "requires replace name",
-				ResourceName: "test_acc_bucket",
+				ResourceName: testBucketResourceName,
 				Bucket: objectstorage.BucketResourceModel{
 					Name: types.StringValue(fmt.Sprintf("%srequires-replace-%d", AcceptanceTestPrefix, randomInt)),
 					Zone: types.StringValue("US-EAST-02A"),
 				},
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectResourceAction(fmt.Sprintf("coreweave_object_storage_bucket.%s", "test_acc_bucket"), plancheck.ResourceActionDestroyBeforeCreate),
+						plancheck.ExpectResourceAction(fmt.Sprintf("coreweave_object_storage_bucket.%s", testBucketResourceName), plancheck.ResourceActionDestroyBeforeCreate),
 					},
 				},
 			}),
@@ -163,9 +164,9 @@ func TestBucketResource(t *testing.T) {
 				PreConfig: func() {
 					t.Log("Beginning coreweave_object_storage_bucket import test")
 				},
-				ResourceName:                         fmt.Sprintf("coreweave_object_storage_bucket.%s", "test_acc_bucket"),
+				ResourceName:                         fmt.Sprintf("coreweave_object_storage_bucket.%s", testBucketResourceName),
 				ImportState:                          true,
-				ImportStateVerifyIdentifierAttribute: "name",
+				ImportStateVerifyIdentifierAttribute: schemaKeyName,
 				ImportStateId:                        fmt.Sprintf("%srequires-replace-%d", AcceptanceTestPrefix, randomInt),
 			},
 		},

--- a/coreweave/object_storage/resource_bucket_versioning.go
+++ b/coreweave/object_storage/resource_bucket_versioning.go
@@ -51,7 +51,7 @@ func (b *BucketVersioningResource) Schema(ctx context.Context, req resource.Sche
 	resp.Schema = schema.Schema{
 		MarkdownDescription: "Versioning protects your data by preserving all versions of objects and preventing permanent deletion. When objects are deleted, they are \"soft deleted\" with delete markers, allowing you to restore previous versions and recover data. After creating a versioned bucket with Terraform, [use `rclone` to manage versioned objects and delete markers](https://docs.coreweave.com/products/storage/object-storage/buckets/rclone-versioned-buckets).",
 		Attributes: map[string]schema.Attribute{
-			"bucket": schema.StringAttribute{
+			schemaKeyBucket: schema.StringAttribute{
 				Required:            true,
 				MarkdownDescription: "The bucket on which to enable or suspend versioning.",
 			},
@@ -296,7 +296,7 @@ func MustRenderBucketVersioningResource(_ context.Context, name string, bvc *Buc
 	resourceBody := resource.Body()
 
 	// bucket attribute
-	resourceBody.SetAttributeRaw("bucket", hclwrite.Tokens{{Type: hclsyntax.TokenIdent, Bytes: []byte(bvc.Bucket.ValueString())}})
+	resourceBody.SetAttributeRaw(schemaKeyBucket, hclwrite.Tokens{{Type: hclsyntax.TokenIdent, Bytes: []byte(bvc.Bucket.ValueString())}})
 
 	v := resourceBody.AppendNewBlock("versioning_configuration", nil).Body()
 	v.SetAttributeValue("status", cty.StringVal(bvc.VersioningConfiguration.Status.ValueString()))

--- a/coreweave/object_storage/resource_bucket_versioning_test.go
+++ b/coreweave/object_storage/resource_bucket_versioning_test.go
@@ -39,7 +39,7 @@ func createBucketVersioningTestStep(ctx context.Context, t *testing.T, opts buck
 
 	rs := fmt.Sprintf("coreweave_object_storage_bucket_versioning.%s", opts.resourceName)
 	checks := []statecheck.StateCheck{
-		statecheck.ExpectKnownValue(rs, tfjsonpath.New("bucket"), knownvalue.StringExact(opts.bucket.Name.ValueString())),
+		statecheck.ExpectKnownValue(rs, tfjsonpath.New(schemaKeyBucket), knownvalue.StringExact(opts.bucket.Name.ValueString())),
 		statecheck.ExpectKnownValue(rs, tfjsonpath.New("versioning_configuration").AtMapKey("status"), knownvalue.StringExact(opts.bucketVersioning.Status.ValueString())),
 	}
 
@@ -95,7 +95,7 @@ func TestBucketVersioningResource(t *testing.T) {
 			},
 			ResourceName:                         fmt.Sprintf("coreweave_object_storage_bucket_versioning.%s", resourceName),
 			ImportState:                          true,
-			ImportStateVerifyIdentifierAttribute: "name",
+			ImportStateVerifyIdentifierAttribute: schemaKeyName,
 			ImportStateId:                        bucket.Name.ValueString(),
 		},
 	}

--- a/coreweave/object_storage/resource_organization_access_policy.go
+++ b/coreweave/object_storage/resource_organization_access_policy.go
@@ -163,7 +163,7 @@ func (o *OrganizationAccessPolicyResource) Schema(ctx context.Context, req resou
 	resp.Schema = schema.Schema{
 		MarkdownDescription: "[Organization access policies](https://docs.coreweave.com/products/storage/object-storage/auth-access/organization-policies/about) enforce permissions for AI Object Storage across your entire CoreWeave organization, automatically covering every resource, bucket, and user in your account. At least one organization access policy must be in place before you can create a bucket.",
 		Attributes: map[string]schema.Attribute{
-			"name": schema.StringAttribute{
+			schemaKeyName: schema.StringAttribute{
 				Required:            true,
 				MarkdownDescription: "The name of the organization access policy, must be unique.",
 				PlanModifiers: []planmodifier.String{
@@ -178,11 +178,11 @@ func (o *OrganizationAccessPolicyResource) Schema(ctx context.Context, req resou
 				},
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
-						"name": schema.StringAttribute{
+						schemaKeyName: schema.StringAttribute{
 							Required:            true,
 							MarkdownDescription: "A short, human-readable identifier for this specific policy statement, similar to Sid in bucket access policies.",
 						},
-						"effect": schema.StringAttribute{
+						schemaKeyEffect: schema.StringAttribute{
 							Required:            true,
 							MarkdownDescription: "Must be either Allow or Deny (case-sensitive). Determines whether the statement grants or denies the specified actions on the listed resources for the designated principals. By default, all access is denied.",
 							Validators: []validator.String{
@@ -392,38 +392,38 @@ func MustRenderOrganizationAccessPolicy(ctx context.Context, resourceName string
 	resource := body.AppendNewBlock("resource", []string{"coreweave_object_storage_organization_access_policy", resourceName})
 	resourceBody := resource.Body()
 
-	resourceBody.SetAttributeValue("name", cty.StringVal(policy.Name.ValueString()))
+	resourceBody.SetAttributeValue(schemaKeyName, cty.StringVal(policy.Name.ValueString()))
 
-	statements := []cty.Value{}
-	for _, s := range policy.Statements {
+	statements := make([]cty.Value, len(policy.Statements))
+	for i, s := range policy.Statements {
 		actionsSlice := []string{}
 		s.Actions.ElementsAs(ctx, &actionsSlice, false)
-		actions := []cty.Value{}
-		for _, a := range actionsSlice {
-			actions = append(actions, cty.StringVal(a))
+		actions := make([]cty.Value, len(actionsSlice))
+		for i, a := range actionsSlice {
+			actions[i] = cty.StringVal(a)
 		}
 
 		resourcesSlice := []string{}
 		s.Resources.ElementsAs(ctx, &resourcesSlice, false)
-		resources := []cty.Value{}
-		for _, a := range resourcesSlice {
-			resources = append(resources, cty.StringVal(a))
+		resources := make([]cty.Value, len(resourcesSlice))
+		for i, a := range resourcesSlice {
+			resources[i] = cty.StringVal(a)
 		}
 
 		principalsSlice := []string{}
 		s.Principals.ElementsAs(ctx, &principalsSlice, false)
-		principals := []cty.Value{}
-		for _, a := range principalsSlice {
-			principals = append(principals, cty.StringVal(a))
+		principals := make([]cty.Value, len(principalsSlice))
+		for i, a := range principalsSlice {
+			principals[i] = cty.StringVal(a)
 		}
 
-		statements = append(statements, cty.ObjectVal(map[string]cty.Value{
-			"name":       cty.StringVal(s.Name.ValueString()),
-			"effect":     cty.StringVal(s.Effect.ValueString()),
-			"actions":    cty.SetVal(actions),
-			"resources":  cty.SetVal(resources),
-			"principals": cty.SetVal(principals),
-		}))
+		statements[i] = cty.ObjectVal(map[string]cty.Value{
+			schemaKeyName:   cty.StringVal(s.Name.ValueString()),
+			schemaKeyEffect: cty.StringVal(s.Effect.ValueString()),
+			"actions":       cty.SetVal(actions),
+			"resources":     cty.SetVal(resources),
+			"principals":    cty.SetVal(principals),
+		})
 	}
 
 	resourceBody.SetAttributeValue("statements", cty.ListVal(statements))

--- a/coreweave/object_storage/resource_organization_access_policy_test.go
+++ b/coreweave/object_storage/resource_organization_access_policy_test.go
@@ -49,40 +49,41 @@ func createOrgAccessPolicyTestStep(ctx context.Context, t *testing.T, opts orgAc
 	t.Helper()
 
 	fullResourceName := fmt.Sprintf("coreweave_object_storage_organization_access_policy.%s", opts.ResourceName)
-	statechecks := []statecheck.StateCheck{
-		statecheck.ExpectKnownValue(fullResourceName, tfjsonpath.New("name"), knownvalue.StringExact(opts.Policy.Name.ValueString())),
-	}
+	statechecks := make([]statecheck.StateCheck, 0, 2)
+	statechecks = append(statechecks,
+		statecheck.ExpectKnownValue(fullResourceName, tfjsonpath.New(schemaKeyName), knownvalue.StringExact(opts.Policy.Name.ValueString())),
+	)
 
-	statements := []knownvalue.Check{}
-	for _, s := range opts.Policy.Statements {
+	statements := make([]knownvalue.Check, len(opts.Policy.Statements))
+	for i, s := range opts.Policy.Statements {
 		actions := []string{}
 		s.Actions.ElementsAs(ctx, &actions, false)
-		actionValues := []knownvalue.Check{}
-		for _, a := range actions {
-			actionValues = append(actionValues, knownvalue.StringExact(a))
+		actionValues := make([]knownvalue.Check, len(actions))
+		for i, a := range actions {
+			actionValues[i] = knownvalue.StringExact(a)
 		}
 
 		principals := []string{}
 		s.Principals.ElementsAs(ctx, &principals, false)
-		principalValues := []knownvalue.Check{}
-		for _, p := range principals {
-			principalValues = append(principalValues, knownvalue.StringExact(p))
+		principalValues := make([]knownvalue.Check, len(principals))
+		for i, p := range principals {
+			principalValues[i] = knownvalue.StringExact(p)
 		}
 
 		resources := []string{}
 		s.Resources.ElementsAs(ctx, &resources, false)
-		resourceValues := []knownvalue.Check{}
-		for _, r := range resources {
-			resourceValues = append(resourceValues, knownvalue.StringExact(r))
+		resourceValues := make([]knownvalue.Check, len(resources))
+		for i, r := range resources {
+			resourceValues[i] = knownvalue.StringExact(r)
 		}
 
-		statements = append(statements, knownvalue.ObjectExact(map[string]knownvalue.Check{
-			"name":       knownvalue.StringExact(s.Name.ValueString()),
-			"effect":     knownvalue.StringExact(s.Effect.ValueString()),
-			"actions":    knownvalue.SetExact(actionValues),
-			"principals": knownvalue.SetExact(principalValues),
-			"resources":  knownvalue.SetExact(resourceValues),
-		}))
+		statements[i] = knownvalue.ObjectExact(map[string]knownvalue.Check{
+			schemaKeyName:   knownvalue.StringExact(s.Name.ValueString()),
+			schemaKeyEffect: knownvalue.StringExact(s.Effect.ValueString()),
+			"actions":       knownvalue.SetExact(actionValues),
+			"principals":    knownvalue.SetExact(principalValues),
+			"resources":     knownvalue.SetExact(resourceValues),
+		})
 	}
 
 	statechecks = append(statechecks, statecheck.ExpectKnownValue(fullResourceName, tfjsonpath.New("statements"), knownvalue.SetExact(statements)))
@@ -107,10 +108,10 @@ func TestOrganizationAccessPolicyResource(t *testing.T) {
 		Steps: []resource.TestStep{
 			createOrgAccessPolicyTestStep(ctx, t, orgAccessPolicyTestStep{
 				TestName:     "create initial policy",
-				ResourceName: "policy",
+				ResourceName: testPolicyResourceName,
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectResourceAction(fmt.Sprintf("coreweave_object_storage_organization_access_policy.%s", "policy"), plancheck.ResourceActionCreate),
+						plancheck.ExpectResourceAction(fmt.Sprintf("coreweave_object_storage_organization_access_policy.%s", testPolicyResourceName), plancheck.ResourceActionCreate),
 					},
 				},
 				Policy: objectstorage.OrganizationAccessPolicyResourceModel{
@@ -134,10 +135,10 @@ func TestOrganizationAccessPolicyResource(t *testing.T) {
 			}),
 			createOrgAccessPolicyTestStep(ctx, t, orgAccessPolicyTestStep{
 				TestName:     "add statement",
-				ResourceName: "policy",
+				ResourceName: testPolicyResourceName,
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectResourceAction(fmt.Sprintf("coreweave_object_storage_organization_access_policy.%s", "policy"), plancheck.ResourceActionUpdate),
+						plancheck.ExpectResourceAction(fmt.Sprintf("coreweave_object_storage_organization_access_policy.%s", testPolicyResourceName), plancheck.ResourceActionUpdate),
 					},
 				},
 				Policy: objectstorage.OrganizationAccessPolicyResourceModel{
@@ -174,10 +175,10 @@ func TestOrganizationAccessPolicyResource(t *testing.T) {
 			}),
 			createOrgAccessPolicyTestStep(ctx, t, orgAccessPolicyTestStep{
 				TestName:     "remove statement",
-				ResourceName: "policy",
+				ResourceName: testPolicyResourceName,
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectResourceAction(fmt.Sprintf("coreweave_object_storage_organization_access_policy.%s", "policy"), plancheck.ResourceActionUpdate),
+						plancheck.ExpectResourceAction(fmt.Sprintf("coreweave_object_storage_organization_access_policy.%s", testPolicyResourceName), plancheck.ResourceActionUpdate),
 					},
 				},
 				Policy: objectstorage.OrganizationAccessPolicyResourceModel{
@@ -201,10 +202,10 @@ func TestOrganizationAccessPolicyResource(t *testing.T) {
 			}),
 			createOrgAccessPolicyTestStep(ctx, t, orgAccessPolicyTestStep{
 				TestName:     "change statement",
-				ResourceName: "policy",
+				ResourceName: testPolicyResourceName,
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectResourceAction(fmt.Sprintf("coreweave_object_storage_organization_access_policy.%s", "policy"), plancheck.ResourceActionUpdate),
+						plancheck.ExpectResourceAction(fmt.Sprintf("coreweave_object_storage_organization_access_policy.%s", testPolicyResourceName), plancheck.ResourceActionUpdate),
 					},
 				},
 				Policy: objectstorage.OrganizationAccessPolicyResourceModel{
@@ -228,10 +229,10 @@ func TestOrganizationAccessPolicyResource(t *testing.T) {
 			}),
 			createOrgAccessPolicyTestStep(ctx, t, orgAccessPolicyTestStep{
 				TestName:     "require replace",
-				ResourceName: "policy",
+				ResourceName: testPolicyResourceName,
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectResourceAction(fmt.Sprintf("coreweave_object_storage_organization_access_policy.%s", "policy"), plancheck.ResourceActionDestroyBeforeCreate),
+						plancheck.ExpectResourceAction(fmt.Sprintf("coreweave_object_storage_organization_access_policy.%s", testPolicyResourceName), plancheck.ResourceActionDestroyBeforeCreate),
 					},
 				},
 				Policy: objectstorage.OrganizationAccessPolicyResourceModel{
@@ -257,9 +258,9 @@ func TestOrganizationAccessPolicyResource(t *testing.T) {
 				PreConfig: func() {
 					t.Log("Beginning coreweave_object_storage_organization_access_policy import test")
 				},
-				ResourceName:                         fmt.Sprintf("coreweave_object_storage_organization_access_policy.%s", "policy"),
+				ResourceName:                         fmt.Sprintf("coreweave_object_storage_organization_access_policy.%s", testPolicyResourceName),
 				ImportState:                          true,
-				ImportStateVerifyIdentifierAttribute: "name",
+				ImportStateVerifyIdentifierAttribute: schemaKeyName,
 				ImportStateId:                        fmt.Sprintf("%s-require-replace", policyName),
 			},
 		},

--- a/coreweave/object_storage/schema_constants.go
+++ b/coreweave/object_storage/schema_constants.go
@@ -1,13 +1,10 @@
-package objectstorage_test
+package objectstorage
 
 const (
-	AcceptanceTestPrefix                   = "tf-acc-objs-"
 	schemaKeyName                          = "name"
 	schemaKeyBucket                        = "bucket"
 	schemaKeyPrefix                        = "prefix"
 	schemaKeyEffect                        = "effect"
 	inventoryOptionalFieldSize             = "Size"
 	inventoryOptionalFieldLastAccessedDate = "LastAccessedDate"
-	testBucketResourceName                 = "test_acc_bucket"
-	testPolicyResourceName                 = "policy"
 )


### PR DESCRIPTION
This removes all currently reproducible `golangci-lint` findings without changing provider behavior, schemas, exported types, or lint configuration. It fixes 144 findings in total: 129 `goconst` and 15 `prealloc`.

## Changes

- Reuse package-local unexported constants for repeated schema keys, log keys, condition descriptions, and test fixture values.
- Preallocate append-built slices when the final capacity is known, using indexed assignment only where output cardinality exactly matches input.

## Validation

- `golangci-lint run` with v2.12.2: 0 issues
- Repository-pinned `golangci-lint` v2.5.0: 0 issues
- `go test ./coreweave/cks ./coreweave/inference ./coreweave/networking ./coreweave/object_storage`
- `make generate` with no generated changes
- `gopls check` on every edited Go file
- `git diff --check`
