### PR TITLE
fix(inference): Drop support for customer capacity claim type

### DIFF
--- a/coreweave/inference/resource_inference_capacity_claim.go
+++ b/coreweave/inference/resource_inference_capacity_claim.go
@@ -35,6 +35,8 @@ var (
 	errCapacityClaimFailed = errors.New("inference capacity claim entered a failed state")
 )
 
+const capacityTypeManaged = "CAPACITY_TYPE_MANAGED"
+
 func NewInferenceCapacityClaimResource() resource.Resource {
 	return &InferenceCapacityClaimResource{}
 }
@@ -166,10 +168,10 @@ func (r *InferenceCapacityClaimResource) Schema(_ context.Context, _ resource.Sc
 					},
 					"capacity_type": schema.StringAttribute{
 						Required:            true,
-						MarkdownDescription: fmt.Sprintf("The [capacity type](https://docs.coreweave.com/products/inference/scaling#capacity-claims) for the capacity claim. Must be one of: %s.", coreweave.EnumMarkdownValuesExcludingDeprecated(inferencev1.CapacityType_CAPACITY_TYPE_MANAGED.Descriptor())),
+						MarkdownDescription: fmt.Sprintf("The [capacity type](https://docs.coreweave.com/products/inference/scaling#capacity-claims) for the capacity claim. Must be `%s`.", capacityTypeManaged),
 						PlanModifiers:       []planmodifier.String{stringplanmodifier.RequiresReplace()},
 						Validators: []validator.String{
-							stringvalidator.OneOf(coreweave.EnumValues(inferencev1.CapacityType_name, true)...),
+							stringvalidator.OneOf(capacityTypeManaged),
 						},
 					},
 					"zones": schema.SetAttribute{
@@ -471,9 +473,8 @@ func buildCapacityClaimFields(ctx context.Context, m *InferenceCapacityClaimReso
 	}
 
 	capacityTypeStr := m.Resources.CapacityType.ValueString()
-	capacityTypeVal, ok := inferencev1.CapacityType_value[capacityTypeStr]
-	if !ok {
-		diagnostics.AddError("Invalid capacity_type", fmt.Sprintf("Invalid capacity_type: %s. Must be one of: %s.", capacityTypeStr, coreweave.EnumMarkdownValues(inferencev1.CapacityType_name, true)))
+	if capacityTypeStr != capacityTypeManaged {
+		diagnostics.AddError("Invalid capacity_type", fmt.Sprintf("Invalid capacity_type: %s. Must be %s.", capacityTypeStr, capacityTypeManaged))
 		return capacityClaimFields{}, diagnostics
 	}
 
@@ -482,7 +483,7 @@ func buildCapacityClaimFields(ctx context.Context, m *InferenceCapacityClaimReso
 		Resources: &inferencev1.CapacityClaimResources{
 			InstanceId:    m.Resources.InstanceType.ValueString(),
 			InstanceCount: uint32(m.Resources.InstanceCount.ValueInt64()), //nolint:gosec
-			CapacityType:  inferencev1.CapacityType(capacityTypeVal),
+			CapacityType:  inferencev1.CapacityType_CAPACITY_TYPE_MANAGED,
 			Zones:         zones,
 		},
 	}

--- a/coreweave/inference/resource_inference_capacity_claim_test.go
+++ b/coreweave/inference/resource_inference_capacity_claim_test.go
@@ -275,6 +275,30 @@ func TestToCreateCapacityClaimRequest_Fields(t *testing.T) {
 	}
 }
 
+func TestToCreateCapacityClaimRequest_RejectsCustomerCapacityType(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	zones := types.SetValueMust(types.StringType, []attr.Value{
+		types.StringValue("US-WEST-04A"),
+	})
+
+	m := &inference.InferenceCapacityClaimResourceModel{
+		Name: types.StringValue("my-claim"),
+		Resources: &inference.CapacityClaimResourcesModel{
+			InstanceType:  types.StringValue(testInstanceType),
+			InstanceCount: types.Int64Value(5),
+			CapacityType:  types.StringValue("CAPACITY_TYPE_CUSTOMER"),
+			Zones:         zones,
+		},
+	}
+
+	_, diags := inference.ToCreateCapacityClaimRequest(ctx, m)
+	if !diags.HasError() {
+		t.Fatalf("ToCreateCapacityClaimRequest should error for %s", "CAPACITY_TYPE_CUSTOMER")
+	}
+}
+
 func TestToUpdateCapacityClaimRequest_Fields(t *testing.T) {
 	t.Parallel()
 
@@ -316,6 +340,31 @@ func TestToUpdateCapacityClaimRequest_Fields(t *testing.T) {
 	// The proto field is Id + Resources only.
 	if req.GetResources().GetInstanceId() != testInstanceType {
 		t.Errorf("InstanceType: got %q, want %q", req.GetResources().GetInstanceId(), testInstanceType)
+	}
+}
+
+func TestToUpdateCapacityClaimRequest_RejectsCustomerCapacityType(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	zones := types.SetValueMust(types.StringType, []attr.Value{
+		types.StringValue("US-WEST-04A"),
+	})
+
+	m := &inference.InferenceCapacityClaimResourceModel{
+		ID:   types.StringValue("cc-789"),
+		Name: types.StringValue("my-claim"),
+		Resources: &inference.CapacityClaimResourcesModel{
+			InstanceType:  types.StringValue(testInstanceType),
+			InstanceCount: types.Int64Value(10),
+			CapacityType:  types.StringValue("CAPACITY_TYPE_CUSTOMER"),
+			Zones:         zones,
+		},
+	}
+
+	_, diags := inference.ToUpdateCapacityClaimRequest(ctx, m)
+	if !diags.HasError() {
+		t.Fatalf("ToUpdateCapacityClaimRequest should error for %s", "CAPACITY_TYPE_CUSTOMER")
 	}
 }
 

--- a/coreweave/inference/resource_inference_integration_test.go
+++ b/coreweave/inference/resource_inference_integration_test.go
@@ -43,7 +43,7 @@ resource "coreweave_inference_capacity_claim" "test" {
   resources = {
     instance_type  = local.instance
     instance_count = 1
-    capacity_type  = "CAPACITY_TYPE_CUSTOMER"
+    capacity_type  = "CAPACITY_TYPE_MANAGED"
     zones          = [local.zone]
   }
 
@@ -148,7 +148,7 @@ func TestInferenceReservedCapacity(t *testing.T) {
 						statecheck.ExpectKnownValue(ccResource, tfjsonpath.New("id"), knownvalue.NotNull()),
 						statecheck.ExpectKnownValue(ccResource, tfjsonpath.New("status"), knownvalue.NotNull()),
 						statecheck.ExpectKnownValue(ccResource, tfjsonpath.New("allocated_instances"), knownvalue.NotNull()),
-						statecheck.ExpectKnownValue(ccResource, tfjsonpath.New("resources").AtMapKey("capacity_type"), knownvalue.StringExact("CAPACITY_TYPE_CUSTOMER")),
+						statecheck.ExpectKnownValue(ccResource, tfjsonpath.New("resources").AtMapKey("capacity_type"), knownvalue.StringExact("CAPACITY_TYPE_MANAGED")),
 						statecheck.ExpectKnownValue(gwResource, tfjsonpath.New("id"), knownvalue.NotNull()),
 						statecheck.ExpectKnownValue(depResource, tfjsonpath.New("status"), knownvalue.StringExact("STATUS_READY")),
 						statecheck.ExpectKnownValue(depResource, tfjsonpath.New("autoscaling").AtMapKey("capacity_classes"), knownvalue.ListExact([]knownvalue.Check{knownvalue.StringExact("CAPACITY_CLASS_RESERVED")})),

--- a/docs/resources/inference_capacity_claim.md
+++ b/docs/resources/inference_capacity_claim.md
@@ -49,7 +49,7 @@ resource "coreweave_inference_capacity_claim" "example" {
 
 Required:
 
-- `capacity_type` (String) The [capacity type](https://docs.coreweave.com/products/inference/scaling#capacity-claims) for the capacity claim. Must be one of: `CAPACITY_TYPE_CUSTOMER`, `CAPACITY_TYPE_MANAGED`.
+- `capacity_type` (String) The [capacity type](https://docs.coreweave.com/products/inference/scaling#capacity-claims) for the capacity claim. Must be `CAPACITY_TYPE_MANAGED`.
 - `instance_count` (Number) The number of instances to reserve. Must be at least 1.
 - `instance_type` (String) The instance type to reserve (e.g. `gb200-4x`).
 - `zones` (Set of String) The availability zones where the capacity claim may use resources from (e.g. `US-WEST-04A`). At least one is required.

--- a/internal/validators/deprecated_enum_test.go
+++ b/internal/validators/deprecated_enum_test.go
@@ -14,7 +14,6 @@ import (
 const (
 	capacityTypeServerless = "CAPACITY_TYPE_SERVERLESS"
 	capacityTypeManaged    = "CAPACITY_TYPE_MANAGED"
-	capacityTypeCustomer   = "CAPACITY_TYPE_CUSTOMER"
 	deprecationGuidance    = "Use CAPACITY_TYPE_MANAGED instead."
 )
 
@@ -35,7 +34,6 @@ func TestDeprecatedEnumValue_CurrentCapacityTypeDescriptor(t *testing.T) {
 	}{
 		{"removed serverless value does not warn", types.StringValue(capacityTypeServerless), false},
 		{"replacement value does not warn", types.StringValue(capacityTypeManaged), false},
-		{"other valid value does not warn", types.StringValue(capacityTypeCustomer), false},
 		{"unrecognized value does not warn", types.StringValue("NOT_A_REAL_VALUE"), false},
 		{"null does not warn", types.StringNull(), false},
 		{"unknown does not warn", types.StringUnknown(), false},
@@ -67,7 +65,6 @@ func TestRejectDeprecatedEnumValue_CurrentCapacityTypeDescriptor(t *testing.T) {
 	}{
 		{"removed serverless value does not error", types.StringValue(capacityTypeServerless), false},
 		{"replacement value does not error", types.StringValue(capacityTypeManaged), false},
-		{"other valid value does not error", types.StringValue(capacityTypeCustomer), false},
 		{"unrecognized value does not error", types.StringValue("NOT_A_REAL_VALUE"), false},
 		{"null does not error", types.StringNull(), false},
 		{"unknown does not error", types.StringUnknown(), false},


### PR DESCRIPTION
Align inference capacity claim behavior with infr-api 1.30.0 by allowing only managed capacity types, and trim stale customer-capacity references in tests and docs.