### PR TITLE
test(examples): Add credential-free documentation example harness

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,6 +40,15 @@ jobs:
           git diff --compact-summary --exit-code || \
             (echo; echo "Unexpected difference in directories after code generation. Run 'make generate' command and commit."; exit 1)
 
+  test-examples:
+    runs-on: ubuntu-latest
+    needs: build
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: ./.github/actions/setup
+      - run: make -f GNUmakefile test-examples
+
   snapshot-build:
     uses: ./.github/workflows/build.yml
     with:

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -65,4 +65,7 @@ testacc:
 		TF_ACC=1 go test -v -cover -timeout=45m ./coreweave/$$suite; \
 	done
 
-.PHONY: debug fmt lint test testacc testacc-sweep build install generate clean
+test-examples:
+	@./tools/test-examples.sh
+
+.PHONY: debug fmt lint test test-examples testacc testacc-sweep build install generate clean

--- a/docs/data-sources/object_storage_bucket_policy_document.md
+++ b/docs/data-sources/object_storage_bucket_policy_document.md
@@ -13,15 +13,33 @@ description: |-
 ## Example Usage
 
 ```terraform
+variable "bucket_name" {
+  type        = string
+  description = "Name of the bucket to allow access to."
+}
+
+variable "org_id" {
+  type        = string
+  description = "CoreWeave organization ID to match in the bucket policy condition."
+}
+
 data "coreweave_object_storage_bucket_policy_document" "default" {
   version = "2012-10-17"
   statement {
-    sid      = "allow-all"
-    effect   = "Allow"
-    action   = ["s3:*"]
-    resource = ["arn:aws:s3:::*"]
+    sid    = "AllowAllInOrg"
+    effect = "Allow"
+    action = ["s3:*"]
+    resource = [
+      "arn:aws:s3:::${var.bucket_name}",
+      "arn:aws:s3:::${var.bucket_name}/*",
+    ]
     principal = {
       "CW" : ["*"]
+    }
+    condition = {
+      "StringEquals" : {
+        "cw:PrincipalOrgID" : var.org_id
+      }
     }
   }
 }

--- a/docs/data-sources/object_storage_bucket_policy_document.md
+++ b/docs/data-sources/object_storage_bucket_policy_document.md
@@ -13,6 +13,14 @@ description: |-
 ## Example Usage
 
 ```terraform
+terraform {
+  required_providers {
+    coreweave = {
+      source = "coreweave/coreweave"
+    }
+  }
+}
+
 variable "bucket_name" {
   type        = string
   description = "Name of the bucket to allow access to."

--- a/docs/data-sources/object_storage_bucket_policy_document.md
+++ b/docs/data-sources/object_storage_bucket_policy_document.md
@@ -34,7 +34,7 @@ variable "org_id" {
 data "coreweave_object_storage_bucket_policy_document" "default" {
   version = "2012-10-17"
   statement {
-    sid    = "AllowAllInOrg"
+    sid    = "AllowUserAndGroup"
     effect = "Allow"
     action = ["s3:*"]
     resource = [
@@ -42,7 +42,8 @@ data "coreweave_object_storage_bucket_policy_document" "default" {
       "arn:aws:s3:::${var.bucket_name}/*",
     ]
     principal = {
-      "CW" : ["*"]
+      "CW"  = ["arn:aws:iam::[ORG-ID]:coreweave/[USER-ID]"]
+      "AWS" = ["arn:aws:iam::[ORG-ID]:saml/[SAML-GROUP-ID]"]
     }
     condition = {
       "StringEquals" : {

--- a/docs/resources/object_storage_bucket_policy.md
+++ b/docs/resources/object_storage_bucket_policy.md
@@ -15,18 +15,31 @@ description: |-
 ```terraform
 ## Example using jsonencode to pass a raw JSON string to the policy attribute
 
+variable "org_id" {
+  type        = string
+  description = "CoreWeave organization ID to match in the bucket policy condition."
+}
+
 locals {
   bucket_policy = {
     Version = "2012-10-17"
     Statement = [
       {
-        Sid    = "allow-all"
+        Sid    = "AllowAllInOrg"
         Effect = "Allow"
         Principal = {
-          "CW" : "*"
+          "CW" : ["*"]
         }
-        Action   = ["s3:*"]
-        Resource = ["arn:aws:s3:::${coreweave_object_storage_bucket.raw.name}"]
+        Action = ["s3:*"]
+        Resource = [
+          "arn:aws:s3:::${coreweave_object_storage_bucket.raw.name}",
+          "arn:aws:s3:::${coreweave_object_storage_bucket.raw.name}/*",
+        ]
+        Condition = {
+          "StringEquals" = {
+            "cw:PrincipalOrgID" = [var.org_id]
+          }
+        }
       },
     ]
   }
@@ -52,17 +65,25 @@ resource "coreweave_object_storage_bucket" "doc" {
 data "coreweave_object_storage_bucket_policy_document" "doc" {
   version = "2012-10-17"
   statement {
-    sid      = "allow-all"
-    effect   = "Allow"
-    action   = ["s3:*"]
-    resource = ["arn:aws:s3:::${coreweave_object_storage_bucket.doc.name}"]
+    sid    = "AllowAllInOrg"
+    effect = "Allow"
+    action = ["s3:*"]
+    resource = [
+      "arn:aws:s3:::${coreweave_object_storage_bucket.doc.name}",
+      "arn:aws:s3:::${coreweave_object_storage_bucket.doc.name}/*",
+    ]
     principal = {
       "CW" : ["*"]
+    }
+    condition = {
+      "StringEquals" : {
+        "cw:PrincipalOrgID" : var.org_id
+      }
     }
   }
 
   statement {
-    sid      = "DenyIfPrefixEquals"
+    sid      = "DenyIfPrefixNotEquals"
     effect   = "Deny"
     action   = ["s3:ListBucket"]
     resource = ["arn:aws:s3:::${coreweave_object_storage_bucket.doc.name}"]
@@ -72,6 +93,9 @@ data "coreweave_object_storage_bucket_policy_document" "doc" {
     condition = {
       "StringNotEquals" : {
         "s3:prefix" : "projects"
+      }
+      "StringEquals" : {
+        "cw:PrincipalOrgID" : var.org_id
       }
     }
   }

--- a/docs/resources/object_storage_bucket_policy.md
+++ b/docs/resources/object_storage_bucket_policy.md
@@ -15,6 +15,14 @@ description: |-
 ```terraform
 ## Example using jsonencode to pass a raw JSON string to the policy attribute
 
+terraform {
+  required_providers {
+    coreweave = {
+      source = "coreweave/coreweave"
+    }
+  }
+}
+
 variable "org_id" {
   type        = string
   description = "CoreWeave organization ID to match in the bucket policy condition."

--- a/docs/resources/object_storage_bucket_policy.md
+++ b/docs/resources/object_storage_bucket_policy.md
@@ -33,10 +33,11 @@ locals {
     Version = "2012-10-17"
     Statement = [
       {
-        Sid    = "AllowAllInOrg"
+        Sid    = "AllowUserAndGroup"
         Effect = "Allow"
         Principal = {
-          "CW" : ["*"]
+          "CW"  = ["arn:aws:iam::[ORG-ID]:coreweave/[USER-ID]"]
+          "AWS" = ["arn:aws:iam::[ORG-ID]:saml/[SAML-GROUP-ID]"]
         }
         Action = ["s3:*"]
         Resource = [
@@ -73,7 +74,7 @@ resource "coreweave_object_storage_bucket" "doc" {
 data "coreweave_object_storage_bucket_policy_document" "doc" {
   version = "2012-10-17"
   statement {
-    sid    = "AllowAllInOrg"
+    sid    = "AllowUserAndGroup"
     effect = "Allow"
     action = ["s3:*"]
     resource = [
@@ -81,7 +82,8 @@ data "coreweave_object_storage_bucket_policy_document" "doc" {
       "arn:aws:s3:::${coreweave_object_storage_bucket.doc.name}/*",
     ]
     principal = {
-      "CW" : ["*"]
+      "CW"  = ["arn:aws:iam::[ORG-ID]:coreweave/[USER-ID]"]
+      "AWS" = ["arn:aws:iam::[ORG-ID]:saml/[SAML-GROUP-ID]"]
     }
     condition = {
       "StringEquals" : {
@@ -96,7 +98,8 @@ data "coreweave_object_storage_bucket_policy_document" "doc" {
     action   = ["s3:ListBucket"]
     resource = ["arn:aws:s3:::${coreweave_object_storage_bucket.doc.name}"]
     principal = {
-      "CW" : ["*"]
+      "CW"  = ["arn:aws:iam::[ORG-ID]:coreweave/[USER-ID]"]
+      "AWS" = ["arn:aws:iam::[ORG-ID]:saml/[SAML-GROUP-ID]"]
     }
     condition = {
       "StringNotEquals" : {

--- a/examples/README.md
+++ b/examples/README.md
@@ -7,3 +7,17 @@ The document generation tool looks for files in the following locations by defau
 * **provider/provider.tf** example file for the provider index page
 * **data-sources/`full data source name`/data-source.tf** example file for the named data source page
 * **resources/`full resource name`/resource.tf** example file for the named data source page
+
+## Validating documentation examples
+
+Independently copyable examples should declare `coreweave/coreweave` in a `terraform.required_providers` block so Terraform resolves the correct provider when a user copies the example into a new root module.
+
+Run the credential-free validation harness from the repository root:
+
+```bash
+make -f GNUmakefile test-examples
+```
+
+The harness copies each registered example into a temporary directory, then runs `terraform fmt -check`, `terraform init -backend=false`, and `terraform validate`. It does not run `terraform plan` or `apply`, and it does not require CoreWeave API credentials.
+
+To register a new example, add its directory path to the `example_dirs` list in [tools/test-examples.sh](../tools/test-examples.sh).

--- a/examples/data-sources/coreweave_object_storage_bucket_policy_document/data-source.tf
+++ b/examples/data-sources/coreweave_object_storage_bucket_policy_document/data-source.tf
@@ -1,12 +1,30 @@
+variable "bucket_name" {
+  type        = string
+  description = "Name of the bucket to allow access to."
+}
+
+variable "org_id" {
+  type        = string
+  description = "CoreWeave organization ID to match in the bucket policy condition."
+}
+
 data "coreweave_object_storage_bucket_policy_document" "default" {
   version = "2012-10-17"
   statement {
-    sid      = "allow-all"
-    effect   = "Allow"
-    action   = ["s3:*"]
-    resource = ["arn:aws:s3:::*"]
+    sid    = "AllowAllInOrg"
+    effect = "Allow"
+    action = ["s3:*"]
+    resource = [
+      "arn:aws:s3:::${var.bucket_name}",
+      "arn:aws:s3:::${var.bucket_name}/*",
+    ]
     principal = {
       "CW" : ["*"]
+    }
+    condition = {
+      "StringEquals" : {
+        "cw:PrincipalOrgID" : var.org_id
+      }
     }
   }
 }

--- a/examples/data-sources/coreweave_object_storage_bucket_policy_document/data-source.tf
+++ b/examples/data-sources/coreweave_object_storage_bucket_policy_document/data-source.tf
@@ -1,3 +1,11 @@
+terraform {
+  required_providers {
+    coreweave = {
+      source = "coreweave/coreweave"
+    }
+  }
+}
+
 variable "bucket_name" {
   type        = string
   description = "Name of the bucket to allow access to."

--- a/examples/data-sources/coreweave_object_storage_bucket_policy_document/data-source.tf
+++ b/examples/data-sources/coreweave_object_storage_bucket_policy_document/data-source.tf
@@ -19,7 +19,7 @@ variable "org_id" {
 data "coreweave_object_storage_bucket_policy_document" "default" {
   version = "2012-10-17"
   statement {
-    sid    = "AllowAllInOrg"
+    sid    = "AllowUserAndGroup"
     effect = "Allow"
     action = ["s3:*"]
     resource = [
@@ -27,7 +27,8 @@ data "coreweave_object_storage_bucket_policy_document" "default" {
       "arn:aws:s3:::${var.bucket_name}/*",
     ]
     principal = {
-      "CW" : ["*"]
+      "CW"  = ["arn:aws:iam::[ORG-ID]:coreweave/[USER-ID]"]
+      "AWS" = ["arn:aws:iam::[ORG-ID]:saml/[SAML-GROUP-ID]"]
     }
     condition = {
       "StringEquals" : {

--- a/examples/resources/coreweave_object_storage_bucket_policy/resource.tf
+++ b/examples/resources/coreweave_object_storage_bucket_policy/resource.tf
@@ -1,17 +1,30 @@
 ## Example using jsonencode to pass a raw JSON string to the policy attribute
 
+variable "org_id" {
+  type        = string
+  description = "CoreWeave organization ID to match in the bucket policy condition."
+}
+
 locals {
   bucket_policy = {
     Version = "2012-10-17"
     Statement = [
       {
-        Sid    = "allow-all"
+        Sid    = "AllowAllInOrg"
         Effect = "Allow"
         Principal = {
-          "CW" : "*"
+          "CW" : ["*"]
         }
-        Action   = ["s3:*"]
-        Resource = ["arn:aws:s3:::${coreweave_object_storage_bucket.raw.name}"]
+        Action = ["s3:*"]
+        Resource = [
+          "arn:aws:s3:::${coreweave_object_storage_bucket.raw.name}",
+          "arn:aws:s3:::${coreweave_object_storage_bucket.raw.name}/*",
+        ]
+        Condition = {
+          "StringEquals" = {
+            "cw:PrincipalOrgID" = [var.org_id]
+          }
+        }
       },
     ]
   }
@@ -37,17 +50,25 @@ resource "coreweave_object_storage_bucket" "doc" {
 data "coreweave_object_storage_bucket_policy_document" "doc" {
   version = "2012-10-17"
   statement {
-    sid      = "allow-all"
-    effect   = "Allow"
-    action   = ["s3:*"]
-    resource = ["arn:aws:s3:::${coreweave_object_storage_bucket.doc.name}"]
+    sid    = "AllowAllInOrg"
+    effect = "Allow"
+    action = ["s3:*"]
+    resource = [
+      "arn:aws:s3:::${coreweave_object_storage_bucket.doc.name}",
+      "arn:aws:s3:::${coreweave_object_storage_bucket.doc.name}/*",
+    ]
     principal = {
       "CW" : ["*"]
+    }
+    condition = {
+      "StringEquals" : {
+        "cw:PrincipalOrgID" : var.org_id
+      }
     }
   }
 
   statement {
-    sid      = "DenyIfPrefixEquals"
+    sid      = "DenyIfPrefixNotEquals"
     effect   = "Deny"
     action   = ["s3:ListBucket"]
     resource = ["arn:aws:s3:::${coreweave_object_storage_bucket.doc.name}"]
@@ -57,6 +78,9 @@ data "coreweave_object_storage_bucket_policy_document" "doc" {
     condition = {
       "StringNotEquals" : {
         "s3:prefix" : "projects"
+      }
+      "StringEquals" : {
+        "cw:PrincipalOrgID" : var.org_id
       }
     }
   }

--- a/examples/resources/coreweave_object_storage_bucket_policy/resource.tf
+++ b/examples/resources/coreweave_object_storage_bucket_policy/resource.tf
@@ -1,5 +1,13 @@
 ## Example using jsonencode to pass a raw JSON string to the policy attribute
 
+terraform {
+  required_providers {
+    coreweave = {
+      source = "coreweave/coreweave"
+    }
+  }
+}
+
 variable "org_id" {
   type        = string
   description = "CoreWeave organization ID to match in the bucket policy condition."

--- a/examples/resources/coreweave_object_storage_bucket_policy/resource.tf
+++ b/examples/resources/coreweave_object_storage_bucket_policy/resource.tf
@@ -18,10 +18,11 @@ locals {
     Version = "2012-10-17"
     Statement = [
       {
-        Sid    = "AllowAllInOrg"
+        Sid    = "AllowUserAndGroup"
         Effect = "Allow"
         Principal = {
-          "CW" : ["*"]
+          "CW"  = ["arn:aws:iam::[ORG-ID]:coreweave/[USER-ID]"]
+          "AWS" = ["arn:aws:iam::[ORG-ID]:saml/[SAML-GROUP-ID]"]
         }
         Action = ["s3:*"]
         Resource = [
@@ -58,7 +59,7 @@ resource "coreweave_object_storage_bucket" "doc" {
 data "coreweave_object_storage_bucket_policy_document" "doc" {
   version = "2012-10-17"
   statement {
-    sid    = "AllowAllInOrg"
+    sid    = "AllowUserAndGroup"
     effect = "Allow"
     action = ["s3:*"]
     resource = [
@@ -66,7 +67,8 @@ data "coreweave_object_storage_bucket_policy_document" "doc" {
       "arn:aws:s3:::${coreweave_object_storage_bucket.doc.name}/*",
     ]
     principal = {
-      "CW" : ["*"]
+      "CW"  = ["arn:aws:iam::[ORG-ID]:coreweave/[USER-ID]"]
+      "AWS" = ["arn:aws:iam::[ORG-ID]:saml/[SAML-GROUP-ID]"]
     }
     condition = {
       "StringEquals" : {
@@ -81,7 +83,8 @@ data "coreweave_object_storage_bucket_policy_document" "doc" {
     action   = ["s3:ListBucket"]
     resource = ["arn:aws:s3:::${coreweave_object_storage_bucket.doc.name}"]
     principal = {
-      "CW" : ["*"]
+      "CW"  = ["arn:aws:iam::[ORG-ID]:coreweave/[USER-ID]"]
+      "AWS" = ["arn:aws:iam::[ORG-ID]:saml/[SAML-GROUP-ID]"]
     }
     condition = {
       "StringNotEquals" : {

--- a/tools/test-examples.sh
+++ b/tools/test-examples.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+log() {
+  echo "[test-examples] $*" >&2
+}
+
+fail() {
+  log "ERROR: $*"
+  exit 1
+}
+
+if ! command -v terraform >/dev/null 2>&1; then
+  fail "terraform is required but was not found in PATH"
+fi
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(git -C "$script_dir" rev-parse --show-toplevel)"
+
+# Explicit registry of independently copyable documentation examples.
+example_dirs=(
+  "examples/resources/coreweave_object_storage_bucket_policy"
+  "examples/data-sources/coreweave_object_storage_bucket_policy_document"
+)
+
+export TF_IN_AUTOMATION=1
+
+validate_example() {
+  local example_rel="$1"
+  local example_dir="$repo_root/$example_rel"
+  local tmpdir
+  local tf_files
+
+  if [[ ! -d "$example_dir" ]]; then
+    log "FAIL $example_rel: directory does not exist"
+    return 1
+  fi
+
+  tf_files=("$example_dir"/*.tf)
+  if [[ ! -e "${tf_files[0]}" ]]; then
+    log "FAIL $example_rel: no .tf files found"
+    return 1
+  fi
+
+  tmpdir="$(mktemp -d)"
+  trap 'rm -rf "$tmpdir"' RETURN
+
+  log "Validating $example_rel"
+
+  cp "$example_dir"/*.tf "$tmpdir/"
+
+  terraform -chdir="$tmpdir" fmt -check -diff
+  terraform -chdir="$tmpdir" init -backend=false -input=false
+  terraform -chdir="$tmpdir" validate
+
+  log "PASS $example_rel"
+}
+
+failed=0
+
+for example_rel in "${example_dirs[@]}"; do
+  if ! validate_example "$example_rel"; then
+    log "FAIL $example_rel"
+    failed=1
+  fi
+done
+
+if [[ "$failed" -ne 0 ]]; then
+  fail "one or more documentation examples failed validation"
+fi
+
+log "all documentation examples passed validation"


### PR DESCRIPTION
## Summary
- Adds a credential-free harness that validates registered Terraform documentation examples with `terraform fmt -check`, `terraform init -backend=false`, and `terraform validate`.
- Exposes the command as `make -f GNUmakefile test-examples` and runs it in CI.
- Documents the command and registration workflow in `examples/README.md`.

## Dependency
**Draft until [coreweave/terraform-provider-coreweave#304](https://github.com/coreweave/terraform-provider-coreweave/pull/304) merges.**

This branch is rebased on PR #304 so the harness validates the updated bucket policy examples, including `required_providers` and named principal ARNs. After #304 lands, rebase this branch onto `main` and mark ready for review.

Related: [DOCS-3002](https://coreweave.atlassian.net/browse/DOCS-3002)

## Test plan
- [x] Run `make -f GNUmakefile test-examples`
- [x] Run `go test ./coreweave/object_storage`
- [x] Confirm no `.terraform/` or lockfiles are left under `examples/`
- [ ] CI `test-examples` job passes after rebase onto `main` post-#304

## Design notes
- Default harness is credential-free and stops at `validate` (no `plan` or `apply`).
- Examples are copied to temporary directories before validation so source trees stay clean.
- Register additional examples by adding paths to `tools/test-examples.sh`.

Made with [Cursor](https://cursor.com)

[DOCS-3002]: https://coreweave.atlassian.net/browse/DOCS-3002?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ