### PR TITLE
refactor: scope goconst away from Terraform schemas

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -115,6 +115,8 @@ linters:
 
   exclusions:
     rules:
+      # Terraform schema and path strings are intentional inline vocabulary;
+      # extracting them into constants would make their definitions harder to read.
       - path: ^coreweave/[^/]+/(data_source|resource)_[^/]+\.go$
         linters:
           - goconst

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -115,6 +115,12 @@ linters:
 
   exclusions:
     rules:
+      - path: ^coreweave/[^/]+/(data_source|resource)_[^/]+\.go$
+        linters:
+          - goconst
+      - path: ^coreweave/cks/update_mask_test\.go$
+        linters:
+          - goconst
       # Exclude some linters from running on tests files.
       - path: _test\.go
         linters:

--- a/coreweave/inference/sweeper_test.go
+++ b/coreweave/inference/sweeper_test.go
@@ -20,9 +20,10 @@ import (
 const AcceptanceTestPrefix = "test-acc-inf-"
 
 const (
-	defaultInferenceModelName   = "meta-llama/Llama-3.1-8B-Instruct"
-	defaultInferenceModelBucket = "infr-cwc38d"
-	defaultInferenceModelPath   = "raw/OpenPipe/Llama-3.1-8B-Instruct/a33eb8ed541ad2695fe492718662a3577c929888"
+	defaultInferenceModelName       = "meta-llama/Llama-3.1-8B-Instruct"
+	defaultInferenceModelBucket     = "infr-cwc38d"
+	defaultInferenceModelPath       = "raw/OpenPipe/Llama-3.1-8B-Instruct/a33eb8ed541ad2695fe492718662a3577c929888"
+	inferenceDeploymentResourceType = "coreweave_inference_deployment"
 )
 
 func TestMain(m *testing.M) {
@@ -72,8 +73,8 @@ func inferenceModelPath() string {
 }
 
 func init() {
-	resource.AddTestSweepers("coreweave_inference_deployment", &resource.Sweeper{
-		Name:         "coreweave_inference_deployment",
+	resource.AddTestSweepers(inferenceDeploymentResourceType, &resource.Sweeper{
+		Name:         inferenceDeploymentResourceType,
 		Dependencies: []string{},
 		F: func(r string) error {
 			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
@@ -126,7 +127,7 @@ func init() {
 
 	resource.AddTestSweepers("coreweave_inference_capacity_claim", &resource.Sweeper{
 		Name:         "coreweave_inference_capacity_claim",
-		Dependencies: []string{"coreweave_inference_deployment"},
+		Dependencies: []string{inferenceDeploymentResourceType},
 		F: func(r string) error {
 			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
 			defer cancel()
@@ -178,7 +179,7 @@ func init() {
 
 	resource.AddTestSweepers("coreweave_inference_gateway", &resource.Sweeper{
 		Name:         "coreweave_inference_gateway",
-		Dependencies: []string{"coreweave_inference_deployment"},
+		Dependencies: []string{inferenceDeploymentResourceType},
 		F: func(r string) error {
 			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
 			defer cancel()


### PR DESCRIPTION
Keeps `goconst` enabled while excluding Terraform resource and data-source files where repeated schema vocabulary is intentional. It also names the repeated inference deployment sweeper identifier so genuine non-schema repetition remains covered.

## Design

The exclusions follow Terraform implementation file boundaries instead of disabling `goconst` globally or maintaining brittle string allowlists. This preserves useful checks in clients and helpers while avoiding constants that obscure inline schema definitions.

The explicit `update_mask_test.go` exclusion covers its inline schema-path fixture without broadening the rule to unrelated test helpers.
