### PR TITLE
fix(inference): Stop advertising and accepting deprecated CAPACITY_TYPE_CUSTOMER

### DIFF
--- a/coreweave/inference/resource_inference_capacity_claim.go
+++ b/coreweave/inference/resource_inference_capacity_claim.go
@@ -169,7 +169,7 @@ func (r *InferenceCapacityClaimResource) Schema(_ context.Context, _ resource.Sc
 						MarkdownDescription: fmt.Sprintf("The [capacity type](https://docs.coreweave.com/products/inference/scaling#capacity-claims) for the capacity claim. Must be one of: %s.", coreweave.EnumMarkdownValuesExcludingDeprecated(inferencev1.CapacityType_CAPACITY_TYPE_MANAGED.Descriptor())),
 						PlanModifiers:       []planmodifier.String{stringplanmodifier.RequiresReplace()},
 						Validators: []validator.String{
-							stringvalidator.OneOf(coreweave.EnumValues(inferencev1.CapacityType_name, true)...),
+							stringvalidator.OneOf(coreweave.EnumValuesExcludingDeprecated(inferencev1.CapacityType_CAPACITY_TYPE_MANAGED.Descriptor())...),
 						},
 					},
 					"zones": schema.SetAttribute{
@@ -473,7 +473,7 @@ func buildCapacityClaimFields(ctx context.Context, m *InferenceCapacityClaimReso
 	capacityTypeStr := m.Resources.CapacityType.ValueString()
 	capacityTypeVal, ok := inferencev1.CapacityType_value[capacityTypeStr]
 	if !ok {
-		diagnostics.AddError("Invalid capacity_type", fmt.Sprintf("Invalid capacity_type: %s. Must be one of: %s.", capacityTypeStr, coreweave.EnumMarkdownValues(inferencev1.CapacityType_name, true)))
+		diagnostics.AddError("Invalid capacity_type", fmt.Sprintf("Invalid capacity_type: %s. Must be one of: %s.", capacityTypeStr, coreweave.EnumMarkdownValuesExcludingDeprecated(inferencev1.CapacityType_CAPACITY_TYPE_MANAGED.Descriptor())))
 		return capacityClaimFields{}, diagnostics
 	}
 

--- a/docs/resources/inference_capacity_claim.md
+++ b/docs/resources/inference_capacity_claim.md
@@ -49,7 +49,7 @@ resource "coreweave_inference_capacity_claim" "example" {
 
 Required:
 
-- `capacity_type` (String) The [capacity type](https://docs.coreweave.com/products/inference/scaling#capacity-claims) for the capacity claim. Must be one of: `CAPACITY_TYPE_CUSTOMER`, `CAPACITY_TYPE_MANAGED`.
+- `capacity_type` (String) The [capacity type](https://docs.coreweave.com/products/inference/scaling#capacity-claims) for the capacity claim. Must be one of: `CAPACITY_TYPE_MANAGED`.
 - `instance_count` (Number) The number of instances to reserve. Must be at least 1.
 - `instance_type` (String) The instance type to reserve (e.g. `gb200-4x`).
 - `zones` (Set of String) The availability zones where the capacity claim may use resources from (e.g. `US-WEST-04A`). At least one is required.

--- a/go.mod
+++ b/go.mod
@@ -7,8 +7,8 @@ require (
 	buf.build/gen/go/coreweave/cks/protocolbuffers/go v1.36.11-20260326215135-be22b90e1aa6.1
 	buf.build/gen/go/coreweave/cwobject/connectrpc/go v1.19.1-20250604181649-b97f17b05d5b.2
 	buf.build/gen/go/coreweave/cwobject/protocolbuffers/go v1.36.10-20250604181649-b97f17b05d5b.1
-	buf.build/gen/go/coreweave/inference/connectrpc/go v1.20.0-20260629172746-aab7cbdc0c7d.1
-	buf.build/gen/go/coreweave/inference/protocolbuffers/go v1.36.11-20260629172746-aab7cbdc0c7d.1
+	buf.build/gen/go/coreweave/inference/connectrpc/go v1.20.0-20260810160348-e8b5b5e28f21.1
+	buf.build/gen/go/coreweave/inference/protocolbuffers/go v1.36.11-20260810160348-e8b5b5e28f21.1
 	buf.build/gen/go/coreweave/networking/connectrpc/go v1.19.1-20260121155637-a637e7777165.2
 	buf.build/gen/go/coreweave/networking/protocolbuffers/go v1.36.11-20260121155637-a637e7777165.1
 	connectrpc.com/connect v1.20.0

--- a/go.sum
+++ b/go.sum
@@ -8,10 +8,10 @@ buf.build/gen/go/coreweave/cwobject/connectrpc/go v1.19.1-20250604181649-b97f17b
 buf.build/gen/go/coreweave/cwobject/connectrpc/go v1.19.1-20250604181649-b97f17b05d5b.2/go.mod h1:psL+HRMYCDFcWXSom8U7bD6hienITQq/yHCJNlNXuU4=
 buf.build/gen/go/coreweave/cwobject/protocolbuffers/go v1.36.10-20250604181649-b97f17b05d5b.1 h1:MVGYLA7uYissV+3Q3XzT+y0i7clq/A734X8IDN1Ax9c=
 buf.build/gen/go/coreweave/cwobject/protocolbuffers/go v1.36.10-20250604181649-b97f17b05d5b.1/go.mod h1:GVgzP9nXZj2+Hm3L+N3dRTm9zEURuxAcrkdPLPryg3U=
-buf.build/gen/go/coreweave/inference/connectrpc/go v1.20.0-20260629172746-aab7cbdc0c7d.1 h1:VMykBNN1Pf9AqaU+isYebTEz+odUEmkK8Y9EJ51o3AY=
-buf.build/gen/go/coreweave/inference/connectrpc/go v1.20.0-20260629172746-aab7cbdc0c7d.1/go.mod h1:AbIMJQsn9NhIlum6zqtYl8VdkYVmlZdtKa+FelQuoyE=
-buf.build/gen/go/coreweave/inference/protocolbuffers/go v1.36.11-20260629172746-aab7cbdc0c7d.1 h1:dcqCkrIoz7WXkcKcP4FWgmsiUAi/GUeGgCU5x+RPiIE=
-buf.build/gen/go/coreweave/inference/protocolbuffers/go v1.36.11-20260629172746-aab7cbdc0c7d.1/go.mod h1:hTrh8mWkz7c4WFsceMlVfBHnYUjz8CZ6ROAOHPpsIS4=
+buf.build/gen/go/coreweave/inference/connectrpc/go v1.20.0-20260810160348-e8b5b5e28f21.1 h1:ZUWc1RfuPqlFEo7Slr1cH6aA4QnyF72iwFNanvmgJXo=
+buf.build/gen/go/coreweave/inference/connectrpc/go v1.20.0-20260810160348-e8b5b5e28f21.1/go.mod h1:AwIk3mI46qvKunEBquKOQ03Lcq3oxkJIgtYhsvOs4o0=
+buf.build/gen/go/coreweave/inference/protocolbuffers/go v1.36.11-20260810160348-e8b5b5e28f21.1 h1:uOssloHJMwgnj1Dp/jOZ0k5cjRcVfaro+5Jv/j58qwQ=
+buf.build/gen/go/coreweave/inference/protocolbuffers/go v1.36.11-20260810160348-e8b5b5e28f21.1/go.mod h1:hTrh8mWkz7c4WFsceMlVfBHnYUjz8CZ6ROAOHPpsIS4=
 buf.build/gen/go/coreweave/networking/connectrpc/go v1.19.1-20260121155637-a637e7777165.2 h1:7/T8Tbyq8JVWu5ZXznB84IdZ6zN/oXeDcebMaTc+eyc=
 buf.build/gen/go/coreweave/networking/connectrpc/go v1.19.1-20260121155637-a637e7777165.2/go.mod h1:Ri2fOqnsxnYU4CdWVP0GNqzSYq7L+Zw1AV/ebdbNITs=
 buf.build/gen/go/coreweave/networking/protocolbuffers/go v1.36.11-20260121155637-a637e7777165.1 h1:HgaTPkFCzegYtbVOir7vdty10GHoFxMceoscwcH0x7s=


### PR DESCRIPTION
## What and why

`CAPACITY_TYPE_CUSTOMER` is deprecated and the API rejects it. [infr-api #775](https://github.com/coreweave/infr-api/pull/775) (merged 2026-07-21) dropped Customer CapacityClaim support: the value is marked `[deprecated = true]` in `coreweave/inference/v1alpha1/capacity_claim.proto`, with the generated comment *"No longer supported: kept only for wire compatibility; validation rejects it on create/update."* `CAPACITY_TYPE_MANAGED` is the only accepted value.

The provider still advertises and accepts it. Two things were going on:

1. **Stale protos.** `go.mod` pinned the inference modules at the `20260629172746` build — 2026-06-29, three weeks before the deprecation landed. So `EnumMarkdownValuesExcludingDeprecated` had nothing to filter and emitted both values.
2. **Two call sites using the non-deprecation-aware helpers.** The `capacity_type` `MarkdownDescription` already used the excluding variant, but the `OneOf` validator and the invalid-value diagnostic still read from `CapacityType_name`. `EnumValuesExcludingDeprecated`'s own doc comment calls out this exact case:

   > Use it to offer only currently-valid enum values (e.g. in a `stringvalidator.OneOf` list or generated docs) so deprecated values are neither advertised nor accepted.

Net effect today: `terraform plan` accepts `capacity_type = "CAPACITY_TYPE_CUSTOMER"` and the failure only surfaces at apply, when the API rejects it. The generated docs tell users it is valid.

## Changes

- Bump `buf.build/gen/go/coreweave/inference/{protocolbuffers,connectrpc}/go` to the `20260810160348` build, which carries the deprecation.
- `capacity_type` validator: `EnumValues(CapacityType_name, true)` → `EnumValuesExcludingDeprecated(...Descriptor())`, so the value fails at plan time.
- Invalid-value diagnostic: `EnumMarkdownValues` → `EnumMarkdownValuesExcludingDeprecated`, so the error stops listing a value the API rejects.
- Regenerate docs. The only rendered change is `capacity_type`, now `Must be one of: CAPACITY_TYPE_MANAGED.`

`CapacityType` is the only inference enum with a deprecated value today, so the `DeploymentAutoscaling_CapacityClass` and `BodyBasedRouting_APIType` validators are deliberately left alone.

## Testing

- `go build ./...`, `go vet ./coreweave/...` clean
- `go test ./coreweave/inference/...` passes
- `tfplugindocs generate` produces a one-line diff, no unrelated churn

## Related

- Docs side: [coreweave/docs#3416](https://github.com/coreweave/docs/pull/3416) removes `CAPACITY_TYPE_CUSTOMER` from the hand-authored Scaling page and the Inference OpenAPI overlay. `public-docs/platform/terraform/resources/inference_capacity_claim.mdx` is generated from this repo, so it stays wrong until this merges and the docs Terraform sync runs.
- Jira: [DOCS-2905](https://coreweave.atlassian.net/browse/DOCS-2905)


[DOCS-2905]: https://coreweave.atlassian.net/browse/DOCS-2905?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ