### PR TITLE
feat(inference): Validate engine against API-advertised engines instead of a hardcoded list

### DIFF
--- a/coreweave/inference/resource_inference_deployment.go
+++ b/coreweave/inference/resource_inference_deployment.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"sort"
+	"strings"
 	"time"
 
 	inferencev1 "buf.build/gen/go/coreweave/inference/protocolbuffers/go/coreweave/inference/v1alpha1"
@@ -48,6 +50,7 @@ const (
 var (
 	_ resource.Resource                = &InferenceDeploymentResource{}
 	_ resource.ResourceWithImportState = &InferenceDeploymentResource{}
+	_ resource.ResourceWithModifyPlan  = &InferenceDeploymentResource{}
 
 	hostnamePattern = regexp.MustCompile(`^[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?$`)
 	semverPattern   = regexp.MustCompile(
@@ -258,9 +261,6 @@ func (r *InferenceDeploymentResource) Schema(_ context.Context, _ resource.Schem
 					"engine": schema.StringAttribute{
 						Required:            true,
 						MarkdownDescription: "The inference engine to use.",
-						Validators: []validator.String{
-							stringvalidator.OneOf("vllm", "dynamo-vllm"),
-						},
 					},
 					"version": schema.StringAttribute{
 						Optional:            true,
@@ -408,6 +408,77 @@ func (r *InferenceDeploymentResource) Configure(_ context.Context, req resource.
 	}
 
 	r.client = client.Inference
+}
+
+// ModifyPlan validates runtime.engine against the engines the API server
+// currently advertises, instead of a hardcoded list that can drift from the
+// platform's runtime-engines source of truth. The available engines are the
+// keys of RuntimeParameters.RuntimeVersions returned by GetDeploymentParameters
+// — the same data the coreweave_inference_deployment_parameters data source
+// exposes. Adding an engine server-side thus makes it usable here with no
+// provider release.
+func (r *InferenceDeploymentResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	// No planned config on destroy — nothing to validate.
+	if req.Plan.Raw.IsNull() {
+		return
+	}
+	// `terraform validate` and other offline phases run before Configure; the
+	// API-backed check is simply skipped when no client is available.
+	if r.client == nil {
+		return
+	}
+
+	var engine types.String
+	resp.Diagnostics.Append(req.Plan.GetAttribute(ctx, path.Root("runtime").AtName("engine"), &engine)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	// Unknown (interpolated) or null values can't be checked here; the API
+	// enforces the final value on apply.
+	if engine.IsUnknown() || engine.IsNull() {
+		return
+	}
+
+	resp.Diagnostics.Append(r.validateEngineAvailable(ctx, engine.ValueString())...)
+}
+
+// validateEngineAvailable checks engine against the engines the API server
+// advertises (the keys of DeploymentRuntimeParameters.RuntimeVersions). It
+// returns no diagnostics when the engine is advertised, or when the server
+// advertises no engines at all — an unexpected empty response bypasses the
+// check and lets the server be the authority on apply. An unadvertised engine
+// yields an attribute error listing the sorted allowed values. Split out from
+// ModifyPlan so it can be unit-tested with a stub GetDeploymentParameters
+// rather than a live API.
+func (r *InferenceDeploymentResource) validateEngineAvailable(ctx context.Context, engine string) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	paramsResp, err := r.client.GetDeploymentParameters(ctx, connect.NewRequest(&inferencev1.GetDeploymentParametersRequest{}))
+	if err != nil {
+		coreweave.HandleAPIError(ctx, err, &diags)
+		return diags
+	}
+
+	runtimeVersions := paramsResp.Msg.GetRuntimeParameters().GetRuntimeVersions()
+	if len(runtimeVersions) == 0 {
+		return diags
+	}
+
+	engines := make([]string, 0, len(runtimeVersions))
+	for e := range runtimeVersions {
+		if e == engine {
+			return diags
+		}
+		engines = append(engines, e)
+	}
+	sort.Strings(engines)
+
+	diags.AddAttributeError(
+		path.Root("runtime").AtName("engine"),
+		"Invalid inference engine",
+		fmt.Sprintf("engine %q is not available; must be one of: %s", engine, strings.Join(engines, ", ")),
+	)
+	return diags
 }
 
 func (r *InferenceDeploymentResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {

--- a/coreweave/inference/resource_inference_deployment_internal_test.go
+++ b/coreweave/inference/resource_inference_deployment_internal_test.go
@@ -1,0 +1,99 @@
+package inference
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"buf.build/gen/go/coreweave/inference/connectrpc/go/coreweave/inference/v1alpha1/inferencev1alpha1connect"
+	inferencev1 "buf.build/gen/go/coreweave/inference/protocolbuffers/go/coreweave/inference/v1alpha1"
+	"connectrpc.com/connect"
+	"github.com/coreweave/terraform-provider-coreweave/coreweave"
+)
+
+// stubDeploymentServiceClient satisfies the Connect DeploymentServiceClient by
+// embedding the interface (all other methods are unused and would panic if
+// called) and overriding only GetDeploymentParameters, so validateEngineAvailable
+// can be exercised without a live API.
+type stubDeploymentServiceClient struct {
+	inferencev1alpha1connect.DeploymentServiceClient
+	resp *inferencev1.GetDeploymentParametersResponse
+	err  error
+}
+
+func (s stubDeploymentServiceClient) GetDeploymentParameters(
+	_ context.Context,
+	_ *connect.Request[inferencev1.GetDeploymentParametersRequest],
+) (*connect.Response[inferencev1.GetDeploymentParametersResponse], error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	return connect.NewResponse(s.resp), nil
+}
+
+func paramsWithEngines(engines ...string) *inferencev1.GetDeploymentParametersResponse {
+	versions := make(map[string]*inferencev1.DeploymentRuntimeParameters_RuntimeVersions, len(engines))
+	for _, e := range engines {
+		versions[e] = &inferencev1.DeploymentRuntimeParameters_RuntimeVersions{}
+	}
+	return &inferencev1.GetDeploymentParametersResponse{
+		RuntimeParameters: &inferencev1.DeploymentRuntimeParameters{RuntimeVersions: versions},
+	}
+}
+
+func TestValidateEngineAvailable(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		engine          string
+		resp            *inferencev1.GetDeploymentParametersResponse
+		wantErr         bool
+		wantDetailMatch string
+	}{
+		// An engine advertised only in the server response (not any hardcoded
+		// list) is accepted — the point of validating against the live API.
+		"engine present only in server response": {
+			engine: "dynamo-sglang",
+			resp:   paramsWithEngines("vllm", "dynamo-vllm", "dynamo-sglang"),
+		},
+		// An unadvertised engine errors, listing the allowed values sorted.
+		"absent engine reports sorted allowed values": {
+			engine:          "sglang",
+			resp:            paramsWithEngines("vllm", "dynamo-vllm", "dynamo-sglang"),
+			wantErr:         true,
+			wantDetailMatch: `engine "sglang" is not available; must be one of: dynamo-sglang, dynamo-vllm, vllm`,
+		},
+		// An empty advertised set bypasses the check (server is the authority).
+		"empty response bypasses validation": {
+			engine: "anything",
+			resp:   paramsWithEngines(),
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			r := &InferenceDeploymentResource{
+				client: &coreweave.InferenceClient{
+					DeploymentServiceClient: stubDeploymentServiceClient{resp: tc.resp},
+				},
+			}
+
+			diags := r.validateEngineAvailable(context.Background(), tc.engine)
+
+			if tc.wantErr {
+				if !diags.HasError() {
+					t.Fatalf("expected an error diagnostic, got none")
+				}
+				if got := diags.Errors()[0].Detail(); !strings.Contains(got, tc.wantDetailMatch) {
+					t.Fatalf("diagnostic detail = %q, want it to contain %q", got, tc.wantDetailMatch)
+				}
+				return
+			}
+			if diags.HasError() {
+				t.Fatalf("unexpected error diagnostic: %v", diags)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

Replaces the hardcoded `runtime.engine` allow-list (`OneOf("vllm", "dynamo-vllm")`) with plan-time validation against the engines the **API server** currently advertises. This unblocks `dynamo-sglang` (already registered server-side) and any future engine with no provider release.

## Why

The static `OneOf` was a second source of truth that drifts from the platform's runtime-engines config: every new engine required a provider change + release before it could be used. The API already exposes the authoritative engine set via `GetDeploymentParameters` → `RuntimeParameters.RuntimeVersions` (the same data the `coreweave_inference_deployment_parameters` data source surfaces), so the provider can validate against that instead.

Note: a Plugin Framework attribute `validator.String` runs offline and cannot call the API, so this is implemented in the resource's `ModifyPlan` hook (post-Configure, plan time) rather than as an attribute validator.

## How

- Add `ModifyPlan` on `InferenceDeploymentResource`: fetch `GetDeploymentParameters`, error if `runtime.engine` isn't among the advertised `RuntimeVersions` keys, with a `must be one of: …` message listing the live set.
- Guards: skip on destroy (null plan), skip when no client (offline `terraform validate`), skip unknown/null engine values, and defer to the server if the API advertises no engines.
- Remove the hardcoded `OneOf` validator; update the `engine` attribute description and regenerate the resource doc.

## Behavior change

Fully-offline `terraform validate` no longer flags an invalid engine — it is caught at `plan` instead (which already contacts the API). Invalid engines still fail before apply, now with the live list of valid engines.

## Note
Either this or https://github.com/coreweave/terraform-provider-coreweave/pull/390 needed to get Dynamo-SGLang in prod
