### PR TITLE
feat: Add Dynamo-SGLang to allowed inference engines

### DIFF
--- a/coreweave/inference/resource_inference_deployment.go
+++ b/coreweave/inference/resource_inference_deployment.go
@@ -259,7 +259,7 @@ func (r *InferenceDeploymentResource) Schema(_ context.Context, _ resource.Schem
 						Required:            true,
 						MarkdownDescription: "The inference engine to use.",
 						Validators: []validator.String{
-							stringvalidator.OneOf("vllm", "dynamo-vllm"),
+							stringvalidator.OneOf("vllm", "dynamo-vllm", "dynamo-sglang"),
 						},
 					},
 					"version": schema.StringAttribute{


### PR DESCRIPTION
Add Dynamo-SGLang to allowed inference engines.

Either this or https://github.com/coreweave/terraform-provider-coreweave/pull/389 needed to get Dynamo-SGLang in prod.