### PR TITLE
ci(renovate): classify test dependencies

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -124,7 +124,6 @@
         "github.com/hashicorp/terraform-plugin-framework-nettypes",
         "github.com/hashicorp/terraform-plugin-go",
         "github.com/hashicorp/terraform-plugin-log",
-        "github.com/hashicorp/terraform-plugin-testing",
         "github.com/hashicorp/terraform-plugin-sdk/v2",
         "github.com/zclconf/go-cty"
       ],
@@ -136,6 +135,15 @@
       "matchPackageNames": ["github.com/aws/smithy-go"],
       "groupName": "aws-sdk-go-v2-monorepo",
       "semanticCommitType": "deps",
+      "semanticCommitScope": null
+    },
+    {
+      "matchManagers": ["gomod"],
+      "matchPackageNames": [
+        "github.com/hashicorp/terraform-plugin-testing",
+        "github.com/stretchr/testify"
+      ],
+      "semanticCommitType": "test",
       "semanticCommitScope": null
     },
     {


### PR DESCRIPTION
Classifies Renovate updates for the provider's test-only Go dependencies as `test` commits.

## Changes

- Apply the `test` semantic commit type to `terraform-plugin-testing` and `testify`.
- Keep `terraform-plugin-testing` out of the runtime Terraform-plugin update group so mixed updates cannot be mislabeled.

## Validation

- Parsed the JSON5 configuration and verified the target packages and rule ordering.
- Renovate PR workflow will run a full dry run against this change.
