### PR TITLE
test(cks): limit acceptance test concurrency

### DIFF
--- a/.github/workflows/acceptance-test.yaml
+++ b/.github/workflows/acceptance-test.yaml
@@ -48,4 +48,4 @@ jobs:
 
       - name: Validate ${{ inputs.suite }} acceptance tests
         run: |
-          make testacc SUITES='${{ inputs.suite }}'
+          make testacc SUITES='${{ inputs.suite }}' ${{ inputs.suite == 'cks' && 'TEST_ACC_PARALLEL=3 TEST_ACC_TIMEOUT=60m' || '' }}

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -14,6 +14,8 @@ BINARY_NAME := terraform-provider-$(PROVIDER_NAME)_v$(VERSION)
 # This is valuable for limiting the sweeps to known-good resources, and for forcing an ordering.
 TEST_ACC_PACKAGES?=./coreweave/cks ./coreweave/networking
 TEST_ACC_SWEEP_ZONE?=US-LAB-01A
+TEST_ACC_PARALLEL?=
+TEST_ACC_TIMEOUT?=45m
 
 export CGO_ENABLED?=0
 
@@ -62,7 +64,7 @@ testacc-sweep:
 
 testacc:
 	@for suite in $(SUITES); do \
-		TF_ACC=1 go test -v -cover -timeout=45m ./coreweave/$$suite; \
+		TF_ACC=1 go test -v -cover -timeout=$(TEST_ACC_TIMEOUT) $(if $(TEST_ACC_PARALLEL),-parallel=$(TEST_ACC_PARALLEL)) ./coreweave/$$suite; \
 	done
 
 .PHONY: debug fmt lint test testacc testacc-sweep build install generate clean


### PR DESCRIPTION
The CKS acceptance package runs nine top-level scenarios concurrently and has intermittently failed under that contention. Recent fully logged successful runs completed in approximately 884–992 seconds, leaving room to reduce concurrency while retaining explicit package-timeout headroom.

## Changes

- Add optional acceptance-test parallelism and package-timeout controls while preserving the existing defaults.
- Limit only the CKS suite to three concurrent tests and a 60-minute package timeout.
- Leave provider polling, retries, diagnostics, and other suites unchanged.

## Validation

- `make -n testacc SUITES=cks TEST_ACC_PARALLEL=3 TEST_ACC_TIMEOUT=60m`
- `make -n testacc SUITES=networking`
- `make test`
- `make lint`
- `git diff --check`
