### PR TITLE
test: add configurable concurrent sweepers

### DIFF
--- a/.github/workflows/acceptance-test.yaml
+++ b/.github/workflows/acceptance-test.yaml
@@ -21,6 +21,7 @@ jobs:
     env:
       COREWEAVE_API_ENDPOINT: ${{ inputs.suite == 'object_storage' && secrets.COREWEAVE_OBJS_API_ENDPOINT || vars.COREWEAVE_API_ENDPOINT }}
       COREWEAVE_API_TOKEN: ${{ inputs.suite == 'object_storage' && secrets.COREWEAVE_OBJS_API_TOKEN || secrets.COREWEAVE_API_TOKEN }}
+      TEST_ACC_SWEEP_TIMEOUT: ${{ inputs.suite == 'inference' && '105m' || '45m' }}
       TEST_ACC_SWEEP_ZONE: ${{ inputs.suite == 'object_storage' && 'US-EAST-04A' || inputs.suite == 'inference' && 'RNO2A' || 'US-LAB-01A' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/acceptance-tests.yaml
+++ b/.github/workflows/acceptance-tests.yaml
@@ -46,7 +46,7 @@ jobs:
           ACTIVE_SUITES=()
 
           # Core files that affect all test suites
-          if echo "$CHANGED_FILES" | grep -qE "^(go\.(mod|sum)|main\.go|coreweave/(client|retry|s3)(_test)?\.go)$"; then
+          if echo "$CHANGED_FILES" | grep -qE "^(go\.(mod|sum)|main\.go|GNUmakefile|internal/testutil/.*|coreweave/(client|retry|s3)(_test)?\.go)$"; then
             ACTIVE_SUITES=($ALL_SUITES)
             echo "Running all suites due to core file changes"
           fi

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -11,9 +11,12 @@ ARCH := $(shell go env GOARCH)
 PLUGIN_DIR := $(HOME)/.terraform.d/plugins/terraform.local/coreweave/$(PROVIDER_NAME)/$(VERSION)/$(OS)_$(ARCH)
 BINARY_NAME := terraform-provider-$(PROVIDER_NAME)_v$(VERSION)
 
-# This is valuable for limiting the sweeps to known-good resources, and for forcing an ordering.
-TEST_ACC_PACKAGES?=./coreweave/cks ./coreweave/networking
 TEST_ACC_SWEEP_ZONE?=US-LAB-01A
+TEST_ACC_SWEEP_RUN?=
+TEST_ACC_SWEEP_ALLOW_FAILURES?=false
+TEST_ACC_SWEEP_PARALLEL?=4
+TEST_ACC_SWEEP_TIMEOUT?=45m
+SWEEP_DRY_RUN?=false
 TEST_ACC_PARALLEL?=
 TEST_ACC_TIMEOUT?=45m
 
@@ -58,12 +61,12 @@ test:
 SUITES?=caller_identity cks networking object_storage inference
 
 testacc-sweep:
-	@for suite in $(SUITES); do \
-		go test -v -timeout 30m ./coreweave/$$suite -sweep='$(TEST_ACC_SWEEP_ZONE)'; \
+	@set -e; for suite in $(SUITES); do \
+		SWEEP_DRY_RUN='$(SWEEP_DRY_RUN)' TEST_ACC_SWEEP_PARALLEL='$(TEST_ACC_SWEEP_PARALLEL)' go test -v -timeout='$(TEST_ACC_SWEEP_TIMEOUT)' ./coreweave/$$suite -sweep='$(TEST_ACC_SWEEP_ZONE)' $(if $(TEST_ACC_SWEEP_RUN),-sweep-run='$(TEST_ACC_SWEEP_RUN)') -sweep-allow-failures='$(TEST_ACC_SWEEP_ALLOW_FAILURES)'; \
 	done
 
 testacc:
-	@for suite in $(SUITES); do \
+	@set -e; for suite in $(SUITES); do \
 		TF_ACC=1 go test -v -cover -timeout=$(TEST_ACC_TIMEOUT) $(if $(TEST_ACC_PARALLEL),-parallel=$(TEST_ACC_PARALLEL)) ./coreweave/$$suite; \
 	done
 

--- a/internal/testutil/sweepers.go
+++ b/internal/testutil/sweepers.go
@@ -1,19 +1,201 @@
 package testutil
 
 import (
+	"context"
+	"errors"
 	"fmt"
+	"log/slog"
 	"os"
+	"sort"
 	"strconv"
+	"sync"
 )
 
+const defaultSweepParallelism = 4
+
+type SweepRuntime struct {
+	DryRun      bool
+	Parallelism int
+}
+
+type SweepConfig[T any] struct {
+	ResourceType string
+	List         func(context.Context) ([]T, error)
+	Name         func(T) string
+	Match        func(T) bool
+	Delete       func(context.Context, T) error
+}
+
+func SweepRuntimeFromEnv() (SweepRuntime, error) {
+	runtime := SweepRuntime{Parallelism: defaultSweepParallelism}
+
+	if value, ok := os.LookupEnv("SWEEP_DRY_RUN"); ok && value != "" {
+		dryRun, err := strconv.ParseBool(value)
+		if err != nil {
+			return SweepRuntime{}, fmt.Errorf("parse SWEEP_DRY_RUN as bool: %w", err)
+		}
+		runtime.DryRun = dryRun
+	}
+
+	if value, ok := os.LookupEnv("TEST_ACC_SWEEP_PARALLEL"); ok && value != "" {
+		parallelism, err := strconv.Atoi(value)
+		if err != nil {
+			return SweepRuntime{}, fmt.Errorf("parse TEST_ACC_SWEEP_PARALLEL as integer: %w", err)
+		}
+		if parallelism <= 0 {
+			return SweepRuntime{}, fmt.Errorf("TEST_ACC_SWEEP_PARALLEL must be greater than zero, got %d", parallelism)
+		}
+		runtime.Parallelism = parallelism
+	}
+
+	return runtime, nil
+}
+
 func SweepDryRun() bool {
-	dryRunStr, ok := os.LookupEnv("SWEEP_DRY_RUN")
-	if !ok {
+	value, ok := os.LookupEnv("SWEEP_DRY_RUN")
+	if !ok || value == "" {
 		return false
 	}
-	dryRun, err := strconv.ParseBool(dryRunStr)
+	dryRun, err := strconv.ParseBool(value)
 	if err != nil {
 		panic(fmt.Errorf("failed to parse SWEEP_DRY_RUN as bool: %w", err))
 	}
 	return dryRun
+}
+
+func Sweep[T any](ctx context.Context, runtime SweepRuntime, config SweepConfig[T]) error {
+	if err := validateSweep(runtime, config); err != nil {
+		return err
+	}
+
+	resources, err := config.List(ctx)
+	if err != nil {
+		return fmt.Errorf("list %s resources: %w", config.ResourceType, err)
+	}
+
+	type namedResource struct {
+		name     string
+		resource T
+	}
+	selected := make([]namedResource, 0, len(resources))
+	for _, resource := range resources {
+		if config.Match(resource) {
+			selected = append(selected, namedResource{name: config.Name(resource), resource: resource})
+		}
+	}
+	sort.SliceStable(selected, func(i, j int) bool {
+		return selected[i].name < selected[j].name
+	})
+
+	if runtime.DryRun {
+		for _, resource := range selected {
+			slog.InfoContext(ctx, "dry-run: would sweep resource", "resource_type", config.ResourceType, "name", resource.name)
+		}
+		return nil
+	}
+
+	type job struct {
+		index    int
+		resource namedResource
+	}
+	jobs := make(chan job)
+	deleteErrors := make([]error, len(selected))
+	workerCount := min(runtime.Parallelism, len(selected))
+
+	var workers sync.WaitGroup
+	for range workerCount {
+		workers.Go(func() {
+			for job := range jobs {
+				slog.InfoContext(ctx, "sweeping resource", "resource_type", config.ResourceType, "name", job.resource.name)
+				if err := config.Delete(ctx, job.resource.resource); err != nil {
+					if ctxErr := ctx.Err(); ctxErr != nil {
+						err = withoutError(err, ctxErr)
+						if err == nil {
+							continue
+						}
+					}
+					deleteErrors[job.index] = fmt.Errorf("delete %s %q: %w", config.ResourceType, job.resource.name, err)
+				}
+			}
+		})
+	}
+	dispatching := true
+	for index, resource := range selected {
+		select {
+		case <-ctx.Done():
+			dispatching = false
+		default:
+		}
+		if !dispatching {
+			break
+		}
+		select {
+		case <-ctx.Done():
+			dispatching = false
+		case jobs <- job{index: index, resource: resource}:
+		}
+		if !dispatching {
+			break
+		}
+	}
+	close(jobs)
+	workers.Wait()
+
+	joined := make([]error, 0, len(deleteErrors))
+	for _, err := range deleteErrors {
+		if err != nil {
+			joined = append(joined, err)
+		}
+	}
+	if err := ctx.Err(); err != nil {
+		joined = append(joined, err)
+	}
+	return errors.Join(joined...)
+}
+
+func withoutError(err, target error) error {
+	if err == nil || target == nil {
+		return err
+	}
+
+	if joined, ok := err.(interface{ Unwrap() []error }); ok {
+		remaining := make([]error, 0, len(joined.Unwrap()))
+		for _, child := range joined.Unwrap() {
+			if filtered := withoutError(child, target); filtered != nil {
+				remaining = append(remaining, filtered)
+			}
+		}
+		return errors.Join(remaining...)
+	}
+
+	if errors.Is(err, target) {
+		if wrapped, ok := err.(interface{ Unwrap() error }); ok {
+			return withoutError(wrapped.Unwrap(), target)
+		}
+		return nil
+	}
+
+	return err
+}
+
+func validateSweep[T any](runtime SweepRuntime, config SweepConfig[T]) error {
+	if config.ResourceType == "" {
+		return errors.New("sweep ResourceType must not be empty")
+	}
+	if runtime.Parallelism <= 0 {
+		return fmt.Errorf("sweep Parallelism must be greater than zero, got %d", runtime.Parallelism)
+	}
+	if config.List == nil {
+		return fmt.Errorf("sweep %s List callback must not be nil", config.ResourceType)
+	}
+	if config.Name == nil {
+		return fmt.Errorf("sweep %s Name callback must not be nil", config.ResourceType)
+	}
+	if config.Match == nil {
+		return fmt.Errorf("sweep %s Match callback must not be nil", config.ResourceType)
+	}
+	if config.Delete == nil {
+		return fmt.Errorf("sweep %s Delete callback must not be nil", config.ResourceType)
+	}
+	return nil
 }

--- a/internal/testutil/sweepers_test.go
+++ b/internal/testutil/sweepers_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"sort"
@@ -436,9 +437,13 @@ func decodeSweepLogs(t *testing.T, logs *bytes.Buffer) []sweepLogRecord {
 	t.Helper()
 	var records []sweepLogRecord
 	decoder := json.NewDecoder(logs)
-	for decoder.More() {
+	for {
 		var record sweepLogRecord
-		require.NoError(t, decoder.Decode(&record))
+		err := decoder.Decode(&record)
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		require.NoError(t, err)
 		records = append(records, record)
 	}
 	return records

--- a/internal/testutil/sweepers_test.go
+++ b/internal/testutil/sweepers_test.go
@@ -1,0 +1,445 @@
+package testutil_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"sort"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/coreweave/terraform-provider-coreweave/internal/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type sweepResource struct {
+	name     string
+	selected bool
+}
+
+const (
+	testResourceType        = "widgets"
+	testIgnoredResourceName = "ignored"
+)
+
+func TestSweepRuntimeFromEnv(t *testing.T) {
+	tests := []struct {
+		name        string
+		dryRun      *string
+		parallelism *string
+		want        testutil.SweepRuntime
+		wantError   string
+	}{
+		{name: "defaults", want: testutil.SweepRuntime{Parallelism: 4}},
+		{name: "empty values use defaults", dryRun: pointer(""), parallelism: pointer(""), want: testutil.SweepRuntime{Parallelism: 4}},
+		{name: "valid overrides", dryRun: pointer("true"), parallelism: pointer("7"), want: testutil.SweepRuntime{DryRun: true, Parallelism: 7}},
+		{name: "malformed bool", dryRun: pointer("sometimes"), wantError: "parse SWEEP_DRY_RUN as bool"},
+		{name: "malformed integer", parallelism: pointer("many"), wantError: "parse TEST_ACC_SWEEP_PARALLEL as integer"},
+		{name: "zero parallelism", parallelism: pointer("0"), wantError: "must be greater than zero"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setOptionalEnv(t, "SWEEP_DRY_RUN", tt.dryRun)
+			setOptionalEnv(t, "TEST_ACC_SWEEP_PARALLEL", tt.parallelism)
+
+			got, err := testutil.SweepRuntimeFromEnv()
+			if tt.wantError != "" {
+				require.ErrorContains(t, err, tt.wantError)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestSweepDryRun(t *testing.T) {
+	for _, tt := range []struct {
+		name      string
+		value     string
+		wantPanic bool
+	}{
+		{name: "empty is false"},
+		{name: "malformed panics", value: "sometimes", wantPanic: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("SWEEP_DRY_RUN", tt.value)
+			if tt.wantPanic {
+				assert.Panics(t, func() { testutil.SweepDryRun() })
+				return
+			}
+			assert.False(t, testutil.SweepDryRun())
+		})
+	}
+}
+
+func TestSweep(t *testing.T) {
+	errFirst := errors.New("first failure")
+	errSecond := errors.New("second failure")
+	tests := []struct {
+		name           string
+		runtime        testutil.SweepRuntime
+		resources      []sweepResource
+		listError      error
+		deleteErrors   map[string]error
+		mutateConfig   func(*testutil.SweepConfig[sweepResource])
+		wantAttempted  []string
+		wantError      []string
+		wantExactError string
+	}{
+		{name: "no matches", runtime: testutil.SweepRuntime{Parallelism: 2}, resources: []sweepResource{{name: testIgnoredResourceName}}},
+		{name: "filter and sort", runtime: testutil.SweepRuntime{Parallelism: 1}, resources: []sweepResource{{name: "c", selected: true}, {name: testIgnoredResourceName}, {name: "a", selected: true}}, wantAttempted: []string{"a", "c"}},
+		{name: "dry run", runtime: testutil.SweepRuntime{DryRun: true, Parallelism: 2}, resources: []sweepResource{{name: "a", selected: true}}},
+		{name: "list failure", runtime: testutil.SweepRuntime{Parallelism: 2}, listError: errors.New("list unavailable"), wantError: []string{"list widgets resources: list unavailable"}},
+		{name: "aggregate errors and attempt all", runtime: testutil.SweepRuntime{Parallelism: 2}, resources: []sweepResource{{name: "z", selected: true}, {name: "a", selected: true}, {name: "m", selected: true}}, deleteErrors: map[string]error{"z": errSecond, "a": errFirst}, wantAttempted: []string{"a", "m", "z"}, wantError: []string{"delete widgets \"a\": first failure", "delete widgets \"z\": second failure"}, wantExactError: "delete widgets \"a\": first failure\ndelete widgets \"z\": second failure"},
+		{name: "missing resource type", runtime: testutil.SweepRuntime{Parallelism: 1}, mutateConfig: func(config *testutil.SweepConfig[sweepResource]) { config.ResourceType = "" }, wantError: []string{"ResourceType must not be empty"}},
+		{name: "invalid runtime", runtime: testutil.SweepRuntime{}, wantError: []string{"Parallelism must be greater than zero"}},
+		{name: "missing list", runtime: testutil.SweepRuntime{Parallelism: 1}, mutateConfig: func(config *testutil.SweepConfig[sweepResource]) { config.List = nil }, wantError: []string{"List callback must not be nil"}},
+		{name: "missing name", runtime: testutil.SweepRuntime{Parallelism: 1}, mutateConfig: func(config *testutil.SweepConfig[sweepResource]) { config.Name = nil }, wantError: []string{"Name callback must not be nil"}},
+		{name: "missing match", runtime: testutil.SweepRuntime{Parallelism: 1}, mutateConfig: func(config *testutil.SweepConfig[sweepResource]) { config.Match = nil }, wantError: []string{"Match callback must not be nil"}},
+		{name: "missing delete", runtime: testutil.SweepRuntime{Parallelism: 1}, mutateConfig: func(config *testutil.SweepConfig[sweepResource]) { config.Delete = nil }, wantError: []string{"Delete callback must not be nil"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var attemptedLock sync.Mutex
+			var attempted []string
+			listCalls := 0
+			config := testutil.SweepConfig[sweepResource]{
+				ResourceType: testResourceType,
+				List: func(context.Context) ([]sweepResource, error) {
+					listCalls++
+					return tt.resources, tt.listError
+				},
+				Name:  func(resource sweepResource) string { return resource.name },
+				Match: func(resource sweepResource) bool { return resource.selected },
+				Delete: func(ctx context.Context, resource sweepResource) error {
+					attemptedLock.Lock()
+					attempted = append(attempted, resource.name)
+					attemptedLock.Unlock()
+					if err := ctx.Err(); err != nil {
+						return err
+					}
+					return tt.deleteErrors[resource.name]
+				},
+			}
+			if tt.mutateConfig != nil {
+				tt.mutateConfig(&config)
+			}
+
+			err := testutil.Sweep(t.Context(), tt.runtime, config)
+			if len(tt.wantError) == 0 {
+				require.NoError(t, err)
+			} else {
+				for _, fragment := range tt.wantError {
+					assert.ErrorContains(t, err, fragment)
+				}
+			}
+			if tt.wantExactError != "" {
+				assert.EqualError(t, err, tt.wantExactError)
+			}
+			if tt.runtime.Parallelism > 1 {
+				sort.Strings(attempted)
+			}
+			assert.Equal(t, tt.wantAttempted, attempted)
+			if tt.mutateConfig != nil || tt.runtime.Parallelism <= 0 {
+				assert.Zero(t, listCalls)
+			} else {
+				assert.Equal(t, 1, listCalls)
+			}
+		})
+	}
+}
+
+func TestSweepLogsSelectedResources(t *testing.T) {
+	tests := []struct {
+		name        string
+		runtime     testutil.SweepRuntime
+		wantMessage string
+		wantDeleted bool
+	}{
+		{name: "dry run", runtime: testutil.SweepRuntime{DryRun: true, Parallelism: 1}, wantMessage: "dry-run: would sweep resource"},
+		{name: "actual delete", runtime: testutil.SweepRuntime{Parallelism: 1}, wantMessage: "sweeping resource", wantDeleted: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logs := captureDefaultLogs(t)
+			deleted := false
+			err := testutil.Sweep(t.Context(), tt.runtime, testutil.SweepConfig[sweepResource]{
+				ResourceType: testResourceType,
+				List: func(context.Context) ([]sweepResource, error) {
+					return []sweepResource{{name: "selected", selected: true}, {name: testIgnoredResourceName}}, nil
+				},
+				Name:  func(resource sweepResource) string { return resource.name },
+				Match: func(resource sweepResource) bool { return resource.selected },
+				Delete: func(context.Context, sweepResource) error {
+					deleted = true
+					return nil
+				},
+			})
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantDeleted, deleted)
+			assert.Equal(t, []sweepLogRecord{{
+				Message:      tt.wantMessage,
+				ResourceType: testResourceType,
+				Name:         "selected",
+			}}, decodeSweepLogs(t, logs))
+		})
+	}
+}
+
+func TestSweepCancellationStopsDispatch(t *testing.T) {
+	deleteFailure := errors.New("delete failed")
+	compositeFailure := errors.New("composite failure")
+	resources := []sweepResource{
+		{name: "d", selected: true},
+		{name: "c", selected: true},
+		{name: "a", selected: true},
+		{name: "b", selected: true},
+	}
+	started := make(chan string, 3)
+	release := make(chan struct{})
+	config := testutil.SweepConfig[sweepResource]{
+		ResourceType: testResourceType,
+		List:         func(context.Context) ([]sweepResource, error) { return resources, nil },
+		Name:         func(resource sweepResource) string { return resource.name },
+		Match:        func(sweepResource) bool { return true },
+		Delete: func(ctx context.Context, resource sweepResource) error {
+			started <- resource.name
+			<-ctx.Done()
+			<-release
+			if resource.name == "a" {
+				return deleteFailure
+			}
+			if resource.name == "b" {
+				return errors.Join(compositeFailure, ctx.Err())
+			}
+			return ctx.Err()
+		},
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	var releaseOnce sync.Once
+	releaseWorkers := func() {
+		releaseOnce.Do(func() { close(release) })
+	}
+	defer releaseWorkers()
+	done := make(chan error, 1)
+	go func() {
+		done <- testutil.Sweep(ctx, testutil.SweepRuntime{Parallelism: 3}, config)
+	}()
+
+	attempted := []string{waitForStarted(t, started), waitForStarted(t, started), waitForStarted(t, started)}
+	cancel()
+	releaseWorkers()
+	var err error
+	select {
+	case err = <-done:
+	case <-time.After(time.Second):
+		t.Fatal("sweep did not stop after cancellation")
+	}
+
+	sort.Strings(attempted)
+	assert.Equal(t, []string{"a", "b", "c"}, attempted)
+	assert.EqualError(t, err, "delete widgets \"a\": delete failed\ndelete widgets \"b\": composite failure\ncontext canceled")
+}
+
+func TestSweepPreCanceledContextDoesNotDispatch(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	deleteCalls := 0
+
+	err := testutil.Sweep(ctx, testutil.SweepRuntime{Parallelism: 1}, testutil.SweepConfig[sweepResource]{
+		ResourceType: testResourceType,
+		List: func(context.Context) ([]sweepResource, error) {
+			return []sweepResource{{name: "not-dispatched", selected: true}}, nil
+		},
+		Name:  func(resource sweepResource) string { return resource.name },
+		Match: func(resource sweepResource) bool { return resource.selected },
+		Delete: func(context.Context, sweepResource) error {
+			deleteCalls++
+			return nil
+		},
+	})
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Zero(t, deleteCalls)
+}
+
+type cancelOnErrContext struct {
+	context.Context
+	cancel context.CancelFunc
+	once   sync.Once
+}
+
+func (ctx *cancelOnErrContext) Err() error {
+	ctx.once.Do(ctx.cancel)
+	return ctx.Context.Err()
+}
+
+func TestSweepDeletesHandedOffJobWhenCancellationBecomesObservable(t *testing.T) {
+	baseCtx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	ctx := &cancelOnErrContext{Context: baseCtx, cancel: cancel}
+	attempted := make(chan string, 1)
+
+	err := testutil.Sweep(ctx, testutil.SweepRuntime{Parallelism: 1}, testutil.SweepConfig[sweepResource]{
+		ResourceType: testResourceType,
+		List: func(context.Context) ([]sweepResource, error) {
+			return []sweepResource{{name: "handed-off", selected: true}}, nil
+		},
+		Name:  func(resource sweepResource) string { return resource.name },
+		Match: func(resource sweepResource) bool { return resource.selected },
+		Delete: func(ctx context.Context, resource sweepResource) error {
+			attempted <- resource.name
+			return ctx.Err()
+		},
+	})
+
+	assert.ErrorIs(t, err, context.Canceled)
+	require.Len(t, attempted, 1)
+	assert.Equal(t, "handed-off", <-attempted)
+}
+
+func TestSweepBoundsConcurrency(t *testing.T) {
+	const parallelism = 3
+	resources := make([]sweepResource, 12)
+	for index := range resources {
+		resources[index] = sweepResource{name: fmt.Sprintf("resource-%02d", index), selected: true}
+	}
+
+	var active atomic.Int32
+	var maximum atomic.Int32
+	release := make(chan struct{})
+	started := make(chan struct{}, len(resources))
+	config := testutil.SweepConfig[sweepResource]{
+		ResourceType: testResourceType,
+		List:         func(context.Context) ([]sweepResource, error) { return resources, nil },
+		Name:         func(resource sweepResource) string { return resource.name },
+		Match:        func(sweepResource) bool { return true },
+		Delete: func(context.Context, sweepResource) error {
+			current := active.Add(1)
+			old := maximum.Load()
+			for current > old && !maximum.CompareAndSwap(old, current) {
+				old = maximum.Load()
+			}
+			started <- struct{}{}
+			<-release
+			active.Add(-1)
+			return nil
+		},
+	}
+
+	done := make(chan error, 1)
+	ctx := t.Context()
+	go func() {
+		done <- testutil.Sweep(ctx, testutil.SweepRuntime{Parallelism: parallelism}, config)
+	}()
+	for range parallelism {
+		select {
+		case <-started:
+		case <-time.After(time.Second):
+			t.Fatal("workers did not reach configured concurrency")
+		}
+	}
+	exceeded := false
+	select {
+	case <-started:
+		exceeded = true
+	case <-time.After(100 * time.Millisecond):
+	}
+	assert.Equal(t, int32(parallelism), maximum.Load())
+	close(release)
+	require.NoError(t, <-done)
+	assert.False(t, exceeded, "a fourth callback started while three were blocked")
+	assert.LessOrEqual(t, maximum.Load(), int32(parallelism))
+}
+
+func ExampleSweep() {
+	resources := []string{"second", "first"}
+	err := testutil.Sweep(context.Background(), testutil.SweepRuntime{Parallelism: 1}, testutil.SweepConfig[string]{
+		ResourceType: "examples",
+		List:         func(context.Context) ([]string, error) { return resources, nil },
+		Name:         func(name string) string { return name },
+		Match:        func(string) bool { return true },
+		Delete: func(_ context.Context, name string) error {
+			fmt.Println(name)
+			return nil
+		},
+	})
+	if err != nil {
+		fmt.Println(err)
+	}
+	// Output:
+	// first
+	// second
+}
+
+func pointer(value string) *string { return &value }
+
+func waitForStarted(t *testing.T, started <-chan string) string {
+	t.Helper()
+	select {
+	case name := <-started:
+		return name
+	case <-time.After(time.Second):
+		t.Fatal("delete did not start")
+		return ""
+	}
+}
+
+func setOptionalEnv(t *testing.T, name string, value *string) {
+	t.Helper()
+	if value != nil {
+		t.Setenv(name, *value)
+		return
+	}
+	previous, found := os.LookupEnv(name)
+	require.NoError(t, os.Unsetenv(name))
+	t.Cleanup(func() {
+		if found {
+			require.NoError(t, os.Setenv(name, previous))
+		} else {
+			require.NoError(t, os.Unsetenv(name))
+		}
+	})
+}
+
+type sweepLogRecord struct {
+	Message      string `json:"msg"`
+	ResourceType string `json:"resource_type"`
+	Name         string `json:"name"`
+}
+
+func captureDefaultLogs(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var logs bytes.Buffer
+	previous := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&logs, nil)))
+	t.Cleanup(func() {
+		slog.SetDefault(previous)
+	})
+	return &logs
+}
+
+func decodeSweepLogs(t *testing.T, logs *bytes.Buffer) []sweepLogRecord {
+	t.Helper()
+	var records []sweepLogRecord
+	decoder := json.NewDecoder(logs)
+	for decoder.More() {
+		var record sweepLogRecord
+		require.NoError(t, decoder.Decode(&record))
+		records = append(records, record)
+	}
+	return records
+}

--- a/internal/testutil/vpcsweeper/vpc.go
+++ b/internal/testutil/vpcsweeper/vpc.go
@@ -1,0 +1,68 @@
+package vpcsweeper
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"connectrpc.com/connect"
+
+	networkingv1beta1 "buf.build/gen/go/coreweave/networking/protocolbuffers/go/coreweave/networking/v1beta1"
+	"github.com/coreweave/terraform-provider-coreweave/internal/testutil"
+)
+
+const resourceType = "coreweave_networking_vpc"
+
+type Client interface {
+	ListVPCs(context.Context, *connect.Request[networkingv1beta1.ListVPCsRequest]) (*connect.Response[networkingv1beta1.ListVPCsResponse], error)
+	GetVPC(context.Context, *connect.Request[networkingv1beta1.GetVPCRequest]) (*connect.Response[networkingv1beta1.GetVPCResponse], error)
+	DeleteVPC(context.Context, *connect.Request[networkingv1beta1.DeleteVPCRequest]) (*connect.Response[networkingv1beta1.DeleteVPCResponse], error)
+}
+
+type Config struct {
+	Prefix string
+	Zone   string
+}
+
+func New(client Client, config Config) (testutil.SweepConfig[*networkingv1beta1.VPC], error) {
+	config.Prefix = strings.TrimSpace(config.Prefix)
+	if config.Prefix == "" {
+		return testutil.SweepConfig[*networkingv1beta1.VPC]{}, fmt.Errorf("VPC sweep prefix must not be empty")
+	}
+	config.Zone = strings.TrimSpace(config.Zone)
+	if config.Zone == "" {
+		return testutil.SweepConfig[*networkingv1beta1.VPC]{}, fmt.Errorf("VPC sweep zone must not be empty")
+	}
+
+	return testutil.SweepConfig[*networkingv1beta1.VPC]{
+		ResourceType: resourceType,
+		List: func(ctx context.Context) ([]*networkingv1beta1.VPC, error) {
+			response, err := client.ListVPCs(ctx, connect.NewRequest(&networkingv1beta1.ListVPCsRequest{}))
+			if err != nil {
+				return nil, fmt.Errorf("list VPCs: %w", err)
+			}
+			return response.Msg.Items, nil
+		},
+		Name: func(vpc *networkingv1beta1.VPC) string {
+			return vpc.GetName()
+		},
+		Match: func(vpc *networkingv1beta1.VPC) bool {
+			return strings.HasPrefix(vpc.GetName(), config.Prefix) && vpc.GetZone() == config.Zone
+		},
+		Delete: func(ctx context.Context, vpc *networkingv1beta1.VPC) error {
+			_, err := client.DeleteVPC(ctx, connect.NewRequest(&networkingv1beta1.DeleteVPCRequest{Id: vpc.GetId()}))
+			if connect.CodeOf(err) == connect.CodeNotFound {
+				return nil
+			}
+			if err != nil {
+				return fmt.Errorf("delete VPC: %w", err)
+			}
+
+			if err := testutil.WaitForDelete(ctx, 5*time.Minute, 15*time.Second, client.GetVPC, &networkingv1beta1.GetVPCRequest{Id: vpc.GetId()}); err != nil {
+				return fmt.Errorf("wait for VPC deletion: %w", err)
+			}
+			return nil
+		},
+	}, nil
+}

--- a/internal/testutil/vpcsweeper/vpc_test.go
+++ b/internal/testutil/vpcsweeper/vpc_test.go
@@ -1,0 +1,131 @@
+package vpcsweeper_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"connectrpc.com/connect"
+
+	networkingv1beta1 "buf.build/gen/go/coreweave/networking/protocolbuffers/go/coreweave/networking/v1beta1"
+	"github.com/coreweave/terraform-provider-coreweave/internal/testutil/vpcsweeper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeClient struct {
+	listError      error
+	deleteError    error
+	getError       error
+	deletedIDs     []string
+	requestedGetID string
+}
+
+const (
+	listedID   = "listed-id"
+	testPrefix = "test-"
+	testVPC    = "test-one"
+	testZone   = "zone-a"
+)
+
+func (client *fakeClient) ListVPCs(context.Context, *connect.Request[networkingv1beta1.ListVPCsRequest]) (*connect.Response[networkingv1beta1.ListVPCsResponse], error) {
+	if client.listError != nil {
+		return nil, client.listError
+	}
+	return connect.NewResponse(&networkingv1beta1.ListVPCsResponse{}), nil
+}
+
+func (client *fakeClient) DeleteVPC(_ context.Context, request *connect.Request[networkingv1beta1.DeleteVPCRequest]) (*connect.Response[networkingv1beta1.DeleteVPCResponse], error) {
+	client.deletedIDs = append(client.deletedIDs, request.Msg.GetId())
+	if client.deleteError != nil {
+		return nil, client.deleteError
+	}
+	return connect.NewResponse(&networkingv1beta1.DeleteVPCResponse{}), nil
+}
+
+func (client *fakeClient) GetVPC(_ context.Context, request *connect.Request[networkingv1beta1.GetVPCRequest]) (*connect.Response[networkingv1beta1.GetVPCResponse], error) {
+	client.requestedGetID = request.Msg.GetId()
+	if client.getError != nil {
+		return nil, client.getError
+	}
+	return connect.NewResponse(&networkingv1beta1.GetVPCResponse{}), nil
+}
+
+func TestNewValidatesSelectors(t *testing.T) {
+	tests := []struct {
+		name      string
+		config    vpcsweeper.Config
+		wantError string
+	}{
+		{name: "empty prefix", config: vpcsweeper.Config{Zone: testZone}, wantError: "prefix must not be empty"},
+		{name: "whitespace prefix", config: vpcsweeper.Config{Prefix: " \t\n", Zone: testZone}, wantError: "prefix must not be empty"},
+		{name: "empty zone", config: vpcsweeper.Config{Prefix: testPrefix}, wantError: "zone must not be empty"},
+		{name: "whitespace zone", config: vpcsweeper.Config{Prefix: testPrefix, Zone: " \t\n"}, wantError: "zone must not be empty"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := vpcsweeper.New(&fakeClient{}, tt.config)
+			require.ErrorContains(t, err, tt.wantError)
+		})
+	}
+}
+
+func TestConfigMatchesPrefixAndZone(t *testing.T) {
+	tests := []struct {
+		name string
+		vpc  *networkingv1beta1.VPC
+		want bool
+	}{
+		{name: "both match", vpc: &networkingv1beta1.VPC{Name: testVPC, Zone: testZone}, want: true},
+		{name: "prefix mismatch", vpc: &networkingv1beta1.VPC{Name: "prod-one", Zone: testZone}},
+		{name: "zone mismatch", vpc: &networkingv1beta1.VPC{Name: testVPC, Zone: "zone-b"}},
+		{name: "both mismatch", vpc: &networkingv1beta1.VPC{Name: "prod-one", Zone: "zone-b"}},
+	}
+	config, err := vpcsweeper.New(&fakeClient{}, vpcsweeper.Config{Prefix: "  " + testPrefix + "\n", Zone: "\t" + testZone + "  "})
+	require.NoError(t, err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, config.Match(tt.vpc))
+		})
+	}
+}
+
+func TestConfigListError(t *testing.T) {
+	config, err := vpcsweeper.New(&fakeClient{listError: errors.New("unavailable")}, vpcsweeper.Config{Prefix: testPrefix, Zone: testZone})
+	require.NoError(t, err)
+	_, err = config.List(t.Context())
+	require.EqualError(t, err, "list VPCs: unavailable")
+}
+
+func TestConfigDeletesListedID(t *testing.T) {
+	tests := []struct {
+		name      string
+		client    *fakeClient
+		wantError string
+		wantGet   bool
+	}{
+		{name: "delete not found succeeds", client: &fakeClient{deleteError: connect.NewError(connect.CodeNotFound, errors.New("gone"))}},
+		{name: "delete failure", client: &fakeClient{deleteError: errors.New("unavailable")}, wantError: "delete VPC: unavailable"},
+		{name: "post-delete polling succeeds", client: &fakeClient{getError: connect.NewError(connect.CodeNotFound, errors.New("gone"))}, wantGet: true},
+		{name: "post-delete polling fails", client: &fakeClient{getError: connect.NewError(connect.CodeUnavailable, errors.New("API unavailable"))}, wantError: "wait for VPC deletion", wantGet: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config, err := vpcsweeper.New(tt.client, vpcsweeper.Config{Prefix: testPrefix, Zone: testZone})
+			require.NoError(t, err)
+			err = config.Delete(t.Context(), &networkingv1beta1.VPC{Id: listedID, Name: testVPC, Zone: testZone})
+			if tt.wantError == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, tt.wantError)
+			}
+			assert.Equal(t, []string{listedID}, tt.client.deletedIDs)
+			if tt.wantGet {
+				assert.Equal(t, listedID, tt.client.requestedGetID)
+			} else {
+				assert.Empty(t, tt.client.requestedGetID)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adds the shared acceptance-sweeper runtime and reusable adapters used by the module-specific layers above it.

## Changes

- Add deterministic, bounded concurrent sweeping with environment-configurable dry-run and parallelism.
- Validate runtime and callbacks before listing, stop dispatch after cancellation, attempt all already-dispatched deletions, aggregate deterministic resource-named errors, and log dry-run candidates and deletion attempts.
- Add the reusable VPC adapter with normalized ownership selectors and existing deletion polling/idempotency behavior.
- Expose native sweeper selection, failure handling, parallelism, timeout, zone, and dry-run controls across suites.
- Stop multi-suite Make loops on the first failed package and detect changes to shared acceptance helpers across suites.

The Networking, CKS, Object Storage, and Inference adoption layers are split into independent stacked PRs above this foundation.

## Validation

- `go test -race ./internal/testutil/...`
- `git diff --check`