### PR TITLE
test(cks): sweep acceptance-test VPCs

### DIFF
--- a/coreweave/cks/resource_cluster_test.go
+++ b/coreweave/cks/resource_cluster_test.go
@@ -3,17 +3,11 @@ package cks_test
 import (
 	"context"
 	"fmt"
-	"log"
 	"math/rand/v2"
 	"regexp"
 	"strings"
 	"testing"
-	"time"
 
-	cksv1beta1 "buf.build/gen/go/coreweave/cks/protocolbuffers/go/coreweave/cks/v1beta1"
-
-	"connectrpc.com/connect"
-	"github.com/coreweave/terraform-provider-coreweave/coreweave"
 	"github.com/coreweave/terraform-provider-coreweave/coreweave/cks"
 	"github.com/coreweave/terraform-provider-coreweave/coreweave/networking"
 	"github.com/coreweave/terraform-provider-coreweave/internal/provider"
@@ -32,110 +26,12 @@ import (
 )
 
 const (
-	AuditPolicyB64       = "ewogICJhcGlWZXJzaW9uIjogImF1ZGl0Lms4cy5pby92MSIsCiAgImtpbmQiOiAiUG9saWN5IiwKICAib21pdFN0YWdlcyI6IFsKICAgICJSZXF1ZXN0UmVjZWl2ZWQiCiAgXSwKICAicnVsZXMiOiBbCiAgICB7CiAgICAgICJsZXZlbCI6ICJSZXF1ZXN0UmVzcG9uc2UiLAogICAgICAicmVzb3VyY2VzIjogWwogICAgICAgIHsKICAgICAgICAgICJncm91cCI6ICIiLAogICAgICAgICAgInJlc291cmNlcyI6IFsKICAgICAgICAgICAgInBvZHMiCiAgICAgICAgICBdCiAgICAgICAgfQogICAgICBdCiAgICB9LAogICAgewogICAgICAibGV2ZWwiOiAiTWV0YWRhdGEiLAogICAgICAicmVzb3VyY2VzIjogWwogICAgICAgIHsKICAgICAgICAgICJncm91cCI6ICIiLAogICAgICAgICAgInJlc291cmNlcyI6IFsKICAgICAgICAgICAgInBvZHMvbG9nIiwKICAgICAgICAgICAgInBvZHMvc3RhdHVzIgogICAgICAgICAgXQogICAgICAgIH0KICAgICAgXQogICAgfSwKICAgIHsKICAgICAgImxldmVsIjogIk5vbmUiLAogICAgICAicmVzb3VyY2VzIjogWwogICAgICAgIHsKICAgICAgICAgICJncm91cCI6ICIiLAogICAgICAgICAgInJlc291cmNlcyI6IFsKICAgICAgICAgICAgImNvbmZpZ21hcHMiCiAgICAgICAgICBdLAogICAgICAgICAgInJlc291cmNlTmFtZXMiOiBbCiAgICAgICAgICAgICJjb250cm9sbGVyLWxlYWRlciIKICAgICAgICAgIF0KICAgICAgICB9CiAgICAgIF0KICAgIH0sCiAgICB7CiAgICAgICJsZXZlbCI6ICJOb25lIiwKICAgICAgInVzZXJzIjogWwogICAgICAgICJzeXN0ZW06a3ViZS1wcm94eSIKICAgICAgXSwKICAgICAgInZlcmJzIjogWwogICAgICAgICJ3YXRjaCIKICAgICAgXSwKICAgICAgInJlc291cmNlcyI6IFsKICAgICAgICB7CiAgICAgICAgICAiZ3JvdXAiOiAiIiwKICAgICAgICAgICJyZXNvdXJjZXMiOiBbCiAgICAgICAgICAgICJlbmRwb2ludHMiLAogICAgICAgICAgICAic2VydmljZXMiCiAgICAgICAgICBdCiAgICAgICAgfQogICAgICBdCiAgICB9LAogICAgewogICAgICAibGV2ZWwiOiAiTm9uZSIsCiAgICAgICJ1c2VyR3JvdXBzIjogWwogICAgICAgICJzeXN0ZW06YXV0aGVudGljYXRlZCIKICAgICAgXSwKICAgICAgIm5vblJlc291cmNlVVJMcyI6IFsKICAgICAgICAiL2FwaSoiLAogICAgICAgICIvdmVyc2lvbiIKICAgICAgXQogICAgfSwKICAgIHsKICAgICAgImxldmVsIjogIlJlcXVlc3QiLAogICAgICAicmVzb3VyY2VzIjogWwogICAgICAgIHsKICAgICAgICAgICJncm91cCI6ICIiLAogICAgICAgICAgInJlc291cmNlcyI6IFsKICAgICAgICAgICAgImNvbmZpZ21hcHMiCiAgICAgICAgICBdCiAgICAgICAgfQogICAgICBdLAogICAgICAibmFtZXNwYWNlcyI6IFsKICAgICAgICAia3ViZS1zeXN0ZW0iCiAgICAgIF0KICAgIH0sCiAgICB7CiAgICAgICJsZXZlbCI6ICJNZXRhZGF0YSIsCiAgICAgICJyZXNvdXJjZXMiOiBbCiAgICAgICAgewogICAgICAgICAgImdyb3VwIjogIiIsCiAgICAgICAgICAicmVzb3VyY2VzIjogWwogICAgICAgICAgICAic2VjcmV0cyIsCiAgICAgICAgICAgICJjb25maWdtYXBzIgogICAgICAgICAgXQogICAgICAgIH0KICAgICAgXQogICAgfSwKICAgIHsKICAgICAgImxldmVsIjogIlJlcXVlc3QiLAogICAgICAicmVzb3VyY2VzIjogWwogICAgICAgIHsKICAgICAgICAgICJncm91cCI6ICIiCiAgICAgICAgfSwKICAgICAgICB7CiAgICAgICAgICAiZ3JvdXAiOiAiZXh0ZW5zaW9ucyIKICAgICAgICB9CiAgICAgIF0KICAgIH0sCiAgICB7CiAgICAgICJsZXZlbCI6ICJNZXRhZGF0YSIsCiAgICAgICJvbWl0U3RhZ2VzIjogWwogICAgICAgICJSZXF1ZXN0UmVjZWl2ZWQiCiAgICAgIF0KICAgIH0KICBdCn0K"
-	ExampleCAB64         = "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURnekNDQW11Z0F3SUJBZ0lRVGhhQitUNmdtdVVYN3dXZi9XUitmekFOQmdrcWhraUc5dzBCQVFzRkFEQUEKTUI0WERUSTBNRFl5TlRJeE1UY3pNVm9YRFRJME1Ea3lNekl4TVRjek1Wb3dBRENDQVNJd0RRWUpLb1pJaHZjTgpBUUVCQlFBRGdnRVBBRENDQVFvQ2dnRUJBT240VkVpRWJoL29GRkoxcG1QZXZxb1pBbWtVUjRqeWd5Y0MvRFhCCmVEWjYxd1NzV1FPU21peFg1bDZDd1FXNzdkV3NRVGhsU0RqN003RytxYjZCWHBSUWcrMndJOFVsVHp6Y0NpM0UKN1pib2M2LzI1YXd3NVpLOW1GVWVGWlBWemI4ZHNuVUFkbmFNa2V2ckFGQXNoL0NmSEh0cThzSUZnOVF2SWJnUApNRFJJcnZnSmlGY1NLS1E5clgxOWkzcFY3ZE9UaGxaYW11UWRGUjhGSVgyQ3BVQithajdSWkdMTFFra3AzMzhUCjFTRk5hK3V1THk3Mlh6MldIdEdqOTE5OFVENFFTRzByd2JUYXEvQVdxNjcvblhRS2FOQ2xHYzlGajNRSjU2NEUKK3cvWXBvK1krc053OXY0M1NVSVdyQXRMNGRicHNadlBEK0FKS1RDRXArUExZWlVDQXdFQUFhT0IrRENCOVRBTwpCZ05WSFE4QkFmOEVCQU1DQmFBd0RBWURWUjBUQVFIL0JBSXdBRENCMUFZRFZSMFJBUUgvQklISk1JSEdnaVJsCmVHVmpkWFJ2Y2kxcllYUmhiRzluTFdWNFpXTjFkRzl5TFhKbFkyOXVZMmxzWlhLQ0xHVjRaV04xZEc5eUxXdGgKZEdGc2IyY3RaWGhsWTNWMGIzSXRjbVZqYjI1amFXeGxjaTVyWVhSaGJHOW5nakJsZUdWamRYUnZjaTFyWVhSaApiRzluTFdWNFpXTjFkRzl5TFhKbFkyOXVZMmxzWlhJdWEyRjBZV3h2Wnk1emRtT0NQbVY0WldOMWRHOXlMV3RoCmRHRnNiMmN0WlhobFkzVjBiM0l0Y21WamIyNWphV3hsY2k1cllYUmhiRzluTG5OMll5NWpiSFZ6ZEdWeUxteHYKWTJGc01BMEdDU3FHU0liM0RRRUJDd1VBQTRJQkFRQlEvQ2JBdEFCQkZORUE5d1hYaE9vYUNrRFY1dTc3VFlzMQpFV2FJcFJFNjV5QmVtTDc2eXpYeEtoc2RmR3RJSmJ0THBWS1lUYlpBVTQrem9IS1NVTWs4REY4bXN0dGhOMWQ5CnR6a1d4ZXZ3UGViL2NtMVZVWlBzWkxvNnFRblJRUFJCUXc0dFpWdkhTWmtsSjBVb2lvVk5zOWJJY3ZQZ2Z4UW0KNkhDU3NEWU9sWnlPRHlrY045U21nbFZtVWFNeVkxMGcrL3BWRzg4WkRyLy9zdUI1ZERPaktUcDNGbjRPSGR0VwpnRmpuY3RVOEV4Zk5YNTR1Yndja2ZTMGdiOXRtejcyaHN3OU5KaTV2QXlMS2ZIcmxNNTJTeWhwUVZKbkpPYzF6ClhqQVlLTHE1M1E1TGt3RXBZMXpkL21XdVhkRWswWldZcHlXemk3WWN4UXQreUJkWVNJQzEKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo="
-	AcceptanceTestPrefix = "test-acc-"
+	AuditPolicyB64                  = "ewogICJhcGlWZXJzaW9uIjogImF1ZGl0Lms4cy5pby92MSIsCiAgImtpbmQiOiAiUG9saWN5IiwKICAib21pdFN0YWdlcyI6IFsKICAgICJSZXF1ZXN0UmVjZWl2ZWQiCiAgXSwKICAicnVsZXMiOiBbCiAgICB7CiAgICAgICJsZXZlbCI6ICJSZXF1ZXN0UmVzcG9uc2UiLAogICAgICAicmVzb3VyY2VzIjogWwogICAgICAgIHsKICAgICAgICAgICJncm91cCI6ICIiLAogICAgICAgICAgInJlc291cmNlcyI6IFsKICAgICAgICAgICAgInBvZHMiCiAgICAgICAgICBdCiAgICAgICAgfQogICAgICBdCiAgICB9LAogICAgewogICAgICAibGV2ZWwiOiAiTWV0YWRhdGEiLAogICAgICAicmVzb3VyY2VzIjogWwogICAgICAgIHsKICAgICAgICAgICJncm91cCI6ICIiLAogICAgICAgICAgInJlc291cmNlcyI6IFsKICAgICAgICAgICAgInBvZHMvbG9nIiwKICAgICAgICAgICAgInBvZHMvc3RhdHVzIgogICAgICAgICAgXQogICAgICAgIH0KICAgICAgXQogICAgfSwKICAgIHsKICAgICAgImxldmVsIjogIk5vbmUiLAogICAgICAicmVzb3VyY2VzIjogWwogICAgICAgIHsKICAgICAgICAgICJncm91cCI6ICIiLAogICAgICAgICAgInJlc291cmNlcyI6IFsKICAgICAgICAgICAgImNvbmZpZ21hcHMiCiAgICAgICAgICBdLAogICAgICAgICAgInJlc291cmNlTmFtZXMiOiBbCiAgICAgICAgICAgICJjb250cm9sbGVyLWxlYWRlciIKICAgICAgICAgIF0KICAgICAgICB9CiAgICAgIF0KICAgIH0sCiAgICB7CiAgICAgICJsZXZlbCI6ICJOb25lIiwKICAgICAgInVzZXJzIjogWwogICAgICAgICJzeXN0ZW06a3ViZS1wcm94eSIKICAgICAgXSwKICAgICAgInZlcmJzIjogWwogICAgICAgICJ3YXRjaCIKICAgICAgXSwKICAgICAgInJlc291cmNlcyI6IFsKICAgICAgICB7CiAgICAgICAgICAiZ3JvdXAiOiAiIiwKICAgICAgICAgICJyZXNvdXJjZXMiOiBbCiAgICAgICAgICAgICJlbmRwb2ludHMiLAogICAgICAgICAgICAic2VydmljZXMiCiAgICAgICAgICBdCiAgICAgICAgfQogICAgICBdCiAgICB9LAogICAgewogICAgICAibGV2ZWwiOiAiTm9uZSIsCiAgICAgICJ1c2VyR3JvdXBzIjogWwogICAgICAgICJzeXN0ZW06YXV0aGVudGljYXRlZCIKICAgICAgXSwKICAgICAgIm5vblJlc291cmNlVVJMcyI6IFsKICAgICAgICAiL2FwaSoiLAogICAgICAgICIvdmVyc2lvbiIKICAgICAgXQogICAgfSwKICAgIHsKICAgICAgImxldmVsIjogIlJlcXVlc3QiLAogICAgICAicmVzb3VyY2VzIjogWwogICAgICAgIHsKICAgICAgICAgICJncm91cCI6ICIiLAogICAgICAgICAgInJlc291cmNlcyI6IFsKICAgICAgICAgICAgImNvbmZpZ21hcHMiCiAgICAgICAgICBdCiAgICAgICAgfQogICAgICBdLAogICAgICAibmFtZXNwYWNlcyI6IFsKICAgICAgICAia3ViZS1zeXN0ZW0iCiAgICAgIF0KICAgIH0sCiAgICB7CiAgICAgICJsZXZlbCI6ICJNZXRhZGF0YSIsCiAgICAgICJyZXNvdXJjZXMiOiBbCiAgICAgICAgewogICAgICAgICAgImdyb3VwIjogIiIsCiAgICAgICAgICAicmVzb3VyY2VzIjogWwogICAgICAgICAgICAic2VjcmV0cyIsCiAgICAgICAgICAgICJjb25maWdtYXBzIgogICAgICAgICAgXQogICAgICAgIH0KICAgICAgXQogICAgfSwKICAgIHsKICAgICAgImxldmVsIjogIlJlcXVlc3QiLAogICAgICAicmVzb3VyY2VzIjogWwogICAgICAgIHsKICAgICAgICAgICJncm91cCI6ICIiCiAgICAgICAgfSwKICAgICAgICB7CiAgICAgICAgICAiZ3JvdXAiOiAiZXh0ZW5zaW9ucyIKICAgICAgICB9CiAgICAgIF0KICAgIH0sCiAgICB7CiAgICAgICJsZXZlbCI6ICJNZXRhZGF0YSIsCiAgICAgICJvbWl0U3RhZ2VzIjogWwogICAgICAgICJSZXF1ZXN0UmVjZWl2ZWQiCiAgICAgIF0KICAgIH0KICBdCn0K"
+	ExampleCAB64                    = "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURnekNDQW11Z0F3SUJBZ0lRVGhhQitUNmdtdVVYN3dXZi9XUitmekFOQmdrcWhraUc5dzBCQVFzRkFEQUEKTUI0WERUSTBNRFl5TlRJeE1UY3pNVm9YRFRJME1Ea3lNekl4TVRjek1Wb3dBRENDQVNJd0RRWUpLb1pJaHZjTgpBUUVCQlFBRGdnRVBBRENDQVFvQ2dnRUJBT240VkVpRWJoL29GRkoxcG1QZXZxb1pBbWtVUjRqeWd5Y0MvRFhCCmVEWjYxd1NzV1FPU21peFg1bDZDd1FXNzdkV3NRVGhsU0RqN003RytxYjZCWHBSUWcrMndJOFVsVHp6Y0NpM0UKN1pib2M2LzI1YXd3NVpLOW1GVWVGWlBWemI4ZHNuVUFkbmFNa2V2ckFGQXNoL0NmSEh0cThzSUZnOVF2SWJnUApNRFJJcnZnSmlGY1NLS1E5clgxOWkzcFY3ZE9UaGxaYW11UWRGUjhGSVgyQ3BVQithajdSWkdMTFFra3AzMzhUCjFTRk5hK3V1THk3Mlh6MldIdEdqOTE5OFVENFFTRzByd2JUYXEvQVdxNjcvblhRS2FOQ2xHYzlGajNRSjU2NEUKK3cvWXBvK1krc053OXY0M1NVSVdyQXRMNGRicHNadlBEK0FKS1RDRXArUExZWlVDQXdFQUFhT0IrRENCOVRBTwpCZ05WSFE4QkFmOEVCQU1DQmFBd0RBWURWUjBUQVFIL0JBSXdBRENCMUFZRFZSMFJBUUgvQklISk1JSEdnaVJsCmVHVmpkWFJ2Y2kxcllYUmhiRzluTFdWNFpXTjFkRzl5TFhKbFkyOXVZMmxzWlhLQ0xHVjRaV04xZEc5eUxXdGgKZEdGc2IyY3RaWGhsWTNWMGIzSXRjbVZqYjI1amFXeGxjaTVyWVhSaGJHOW5nakJsZUdWamRYUnZjaTFyWVhSaApiRzluTFdWNFpXTjFkRzl5TFhKbFkyOXVZMmxzWlhJdWEyRjBZV3h2Wnk1emRtT0NQbVY0WldOMWRHOXlMV3RoCmRHRnNiMmN0WlhobFkzVjBiM0l0Y21WamIyNWphV3hsY2k1cllYUmhiRzluTG5OMll5NWpiSFZ6ZEdWeUxteHYKWTJGc01BMEdDU3FHU0liM0RRRUJDd1VBQTRJQkFRQlEvQ2JBdEFCQkZORUE5d1hYaE9vYUNrRFY1dTc3VFlzMQpFV2FJcFJFNjV5QmVtTDc2eXpYeEtoc2RmR3RJSmJ0THBWS1lUYlpBVTQrem9IS1NVTWs4REY4bXN0dGhOMWQ5CnR6a1d4ZXZ3UGViL2NtMVZVWlBzWkxvNnFRblJRUFJCUXc0dFpWdkhTWmtsSjBVb2lvVk5zOWJJY3ZQZ2Z4UW0KNkhDU3NEWU9sWnlPRHlrY045U21nbFZtVWFNeVkxMGcrL3BWRzg4WkRyLy9zdUI1ZERPaktUcDNGbjRPSGR0VwpnRmpuY3RVOEV4Zk5YNTR1Yndja2ZTMGdiOXRtejcyaHN3OU5KaTV2QXlMS2ZIcmxNNTJTeWhwUVZKbkpPYzF6ClhqQVlLTHE1M1E1TGt3RXBZMXpkL21XdVhkRWswWldZcHlXemk3WWN4UXQreUJkWVNJQzEKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo="
+	AcceptanceTestPrefix            = "test-acc-"
+	cksVPCNamePrefix                = "test-acc-cks-vpc-"
+	maxAcceptanceResourceNameLength = 30
 )
-
-func deleteCluster(ctx context.Context, client *coreweave.Client, cluster *cksv1beta1.Cluster) error {
-	retryDelay := 30 * time.Second
-	for {
-		if cluster.Status == cksv1beta1.Cluster_STATUS_CREATING || cluster.Status == cksv1beta1.Cluster_STATUS_UPDATING || cluster.Status == cksv1beta1.Cluster_STATUS_DELETING {
-			log.Printf("cluster %s is in creating or updating state, waiting before deletion", cluster.Name)
-			select {
-			case <-ctx.Done():
-				return fmt.Errorf("timed out waiting for cluster %s to reach stable state: %w", cluster.Name, ctx.Err())
-			case <-time.After(retryDelay):
-			}
-			clusterResp, err := client.GetCluster(ctx, connect.NewRequest(&cksv1beta1.GetClusterRequest{
-				Id: cluster.Id,
-			}))
-			if connect.CodeOf(err) == connect.CodeNotFound {
-				log.Printf("cluster %s has already been deleted", cluster.Name)
-				return nil
-			} else if err != nil {
-				return fmt.Errorf("failed to get cluster %s: %w", cluster.Name, err)
-			}
-
-			cluster = clusterResp.Msg.Cluster
-		} else {
-			_, err := client.DeleteCluster(ctx, connect.NewRequest(&cksv1beta1.DeleteClusterRequest{
-				Id: cluster.Id,
-			}))
-			if err == nil {
-				return nil
-			} else if connect.CodeOf(err) == connect.CodeNotFound {
-				log.Printf("cluster %s has already been deleted", cluster.Name)
-				return nil
-			} else {
-				return fmt.Errorf("failed to delete cluster %s: %w", cluster.Name, err)
-			}
-		}
-
-		select {
-		case <-ctx.Done():
-			return fmt.Errorf("timed out waiting to delete cluster %s: %w", cluster.Name, ctx.Err())
-		case <-time.After(retryDelay):
-			continue
-		}
-	}
-}
-
-func init() {
-	resource.AddTestSweepers("coreweave_cks_cluster", &resource.Sweeper{
-		Name:         "coreweave_cks_cluster",
-		Dependencies: []string{}, // left as a placeholder; more types are likely to be added that would need to be torn down first.
-		F: func(r string) error {
-			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
-			defer cancel()
-
-			testutil.SetEnvDefaults()
-			client, err := provider.BuildClient(ctx, provider.CoreweaveProviderModel{}, "", "")
-			if err != nil {
-				return fmt.Errorf("failed to build client: %w", err)
-			}
-
-			listResp, err := client.ListClusters(ctx, &connect.Request[cksv1beta1.ListClustersRequest]{})
-			if err != nil {
-				return fmt.Errorf("failed to list clusters: %w", err)
-			}
-			for _, cluster := range listResp.Msg.Items {
-				if !strings.HasPrefix(cluster.Name, AcceptanceTestPrefix) {
-					log.Printf("skipping cluster %s because it does not have prefix %s", cluster.Name, AcceptanceTestPrefix)
-					continue
-				}
-
-				if cluster.GetZone() != r {
-					log.Printf("skipping cluster %s in zone %s because it does not match sweep zone %s", cluster.Name, cluster.Zone, r)
-					continue
-				}
-
-				log.Printf("sweeping cluster %s", cluster.Name)
-				if testutil.SweepDryRun() {
-					log.Printf("skipping Cluster %s because of dry-run mode", cluster.Name)
-					continue
-				}
-
-				deleteCtx, deleteCancel := context.WithTimeout(ctx, 30*time.Minute)
-				defer deleteCancel()
-
-				if err := deleteCluster(deleteCtx, client, cluster); err != nil {
-					return fmt.Errorf("failed to delete cluster %s: %w", cluster.Name, err)
-				}
-
-				waitCtx, waitCancel := context.WithTimeout(ctx, 10*time.Minute)
-				defer waitCancel()
-				if err := testutil.WaitForDelete(waitCtx, 5*time.Minute, 15*time.Second, client.GetCluster, &cksv1beta1.GetClusterRequest{
-					Id: cluster.Id,
-				}); err != nil {
-					return fmt.Errorf("failed to wait for cluster %s to be deleted: %w", cluster.Name, err)
-				}
-			}
-
-			return nil
-		},
-	})
-}
 
 func TestClusterSchema(t *testing.T) {
 	ctx := context.Background()
@@ -157,7 +53,7 @@ func TestClusterSchema(t *testing.T) {
 }
 
 func defaultVpc(name, zone string) *networking.VpcResourceModel { //nolint:unparam
-	if len(name) > 30 {
+	if len(name) > maxAcceptanceResourceNameLength {
 		// Bail on the tests as early as possible; this is a test definition failure.
 		panic("Vpc name must be 30 characters or less")
 	}
@@ -193,6 +89,7 @@ func defaultVpc(name, zone string) *networking.VpcResourceModel { //nolint:unpar
 
 type resourceNames struct {
 	ClusterName        string
+	VPCName            string
 	ResourceName       string
 	FullResourceName   string
 	FullDataSourceName string
@@ -203,16 +100,23 @@ func with[T any](obj T, fn func(*T)) T {
 	return obj
 }
 
-func generateResourceNames(clusterNamePrefix string) resourceNames {
-	randomInt := rand.IntN(100)
+func generateResourceNames(t *testing.T, clusterNamePrefix string) resourceNames {
+	t.Helper()
 
-	clusterName := fmt.Sprintf("%s%s-%x", AcceptanceTestPrefix, clusterNamePrefix, randomInt)
-	resourceName := fmt.Sprintf("test_acc_cks_cluster_%s_%x", clusterNamePrefix, randomInt)
+	suffix := fmt.Sprintf("%05x", rand.IntN(1<<20))
+
+	clusterName := fmt.Sprintf("%s%s-%s", AcceptanceTestPrefix, clusterNamePrefix, suffix)
+	vpcName := cksVPCNamePrefix + suffix
+	if len(clusterName) > maxAcceptanceResourceNameLength || len(vpcName) > maxAcceptanceResourceNameLength {
+		panic("acceptance-test cluster and VPC names must be 30 characters or less")
+	}
+	resourceName := fmt.Sprintf("test_acc_cks_cluster_%s_%s", clusterNamePrefix, suffix)
 	fullResourceName := fmt.Sprintf("coreweave_cks_cluster.%s", resourceName)
 	fullDataSourceName := fmt.Sprintf("data.coreweave_cks_cluster.%s", resourceName)
 
 	return resourceNames{
 		ClusterName:        clusterName,
+		VPCName:            vpcName,
 		ResourceName:       resourceName,
 		FullResourceName:   fullResourceName,
 		FullDataSourceName: fullDataSourceName,
@@ -409,11 +313,11 @@ func createClusterTestStep(ctx context.Context, t *testing.T, config testStepCon
 }
 
 func TestClusterResource(t *testing.T) {
-	config := generateResourceNames("cks-cluster")
+	config := generateResourceNames(t, "cks-cluster")
 	zone := testutil.AcceptanceTestZone
 	kubeVersion := testutil.AcceptanceTestKubeVersion
 
-	vpc := defaultVpc(config.ClusterName, zone)
+	vpc := defaultVpc(config.VPCName, zone)
 	npTypes := map[string]attr.Type{
 		"start": types.Int32Type,
 		"end":   types.Int32Type,
@@ -634,11 +538,11 @@ func TestClusterResource(t *testing.T) {
 }
 
 func TestClusterResource_V6FieldsCreateOnly(t *testing.T) {
-	config := generateResourceNames("cks-cluster-v6")
+	config := generateResourceNames(t, "cks-cluster-v6")
 	zone := testutil.AcceptanceTestZone
 	kubeVersion := testutil.AcceptanceTestKubeVersion
 
-	vpc := defaultVpc(config.ClusterName, zone)
+	vpc := defaultVpc(config.VPCName, zone)
 	vpc.VpcPrefixes = append(vpc.VpcPrefixes,
 		networking.VpcPrefixResourceModel{
 			Name:  types.StringValue("pod-cidr-v6"),
@@ -752,11 +656,11 @@ func TestClusterResource_V6FieldsCreateOnly(t *testing.T) {
 }
 
 func TestClusterResource_Tailscale(t *testing.T) {
-	config := generateResourceNames("cks-tailscale")
+	config := generateResourceNames(t, "cks-tailscale")
 	zone := testutil.AcceptanceTestZone
 	kubeVersion := testutil.AcceptanceTestKubeVersion
 
-	vpc := defaultVpc(config.ClusterName, zone)
+	vpc := defaultVpc(config.VPCName, zone)
 
 	base := &cks.ClusterResourceModel{
 		VpcId:               types.StringValue(fmt.Sprintf("coreweave_networking_vpc.%s.id", config.ResourceName)),
@@ -847,11 +751,11 @@ func TestClusterResource_Tailscale(t *testing.T) {
 }
 
 func TestClusterResource_Kubelet(t *testing.T) {
-	config := generateResourceNames("cks-kubelet")
+	config := generateResourceNames(t, "cks-kubelet")
 	zone := testutil.AcceptanceTestZone
 	kubeVersion := testutil.AcceptanceTestKubeVersion
 
-	vpc := defaultVpc(config.ClusterName, zone)
+	vpc := defaultVpc(config.VPCName, zone)
 
 	base := &cks.ClusterResourceModel{
 		VpcId:               types.StringValue(fmt.Sprintf("coreweave_networking_vpc.%s.id", config.ResourceName)),
@@ -940,11 +844,11 @@ func TestClusterResource_Kubelet(t *testing.T) {
 }
 
 func TestPartialOidcConfig(t *testing.T) {
-	config := generateResourceNames("partial-oidc")
+	config := generateResourceNames(t, "partial-oidc")
 	zone := testutil.AcceptanceTestZone
 	kubeVersion := testutil.AcceptanceTestKubeVersion
 
-	vpc := defaultVpc(config.ClusterName, zone)
+	vpc := defaultVpc(config.VPCName, zone)
 
 	initial := &cks.ClusterResourceModel{
 		VpcId:               types.StringValue(fmt.Sprintf("coreweave_networking_vpc.%s.id", config.ResourceName)),
@@ -1075,11 +979,11 @@ func TestPartialOidcConfig(t *testing.T) {
 }
 
 func TestPartialWebhookConfig(t *testing.T) {
-	config := generateResourceNames("partial-webhook")
+	config := generateResourceNames(t, "partial-webhook")
 	zone := testutil.AcceptanceTestZone
 	kubeVersion := testutil.AcceptanceTestKubeVersion
 
-	vpc := defaultVpc(config.ClusterName, zone)
+	vpc := defaultVpc(config.VPCName, zone)
 
 	initial := &cks.ClusterResourceModel{
 		VpcId:               types.StringValue(fmt.Sprintf("coreweave_networking_vpc.%s.id", config.ResourceName)),
@@ -1181,11 +1085,11 @@ func TestPartialWebhookConfig(t *testing.T) {
 }
 
 func TestEmptyAuditPolicy(t *testing.T) {
-	config := generateResourceNames("audit-policy")
+	config := generateResourceNames(t, "audit-policy")
 	zone := testutil.AcceptanceTestZone
 	kubeVersion := testutil.AcceptanceTestKubeVersion
 
-	vpc := defaultVpc(config.ClusterName, zone)
+	vpc := defaultVpc(config.VPCName, zone)
 	cluster := &cks.ClusterResourceModel{
 		VpcId:               types.StringValue(fmt.Sprintf("coreweave_networking_vpc.%s.id", config.ResourceName)),
 		Name:                types.StringValue(config.ClusterName),
@@ -1220,8 +1124,8 @@ func TestSharedStorage(t *testing.T) {
 	kubeVersion := testutil.AcceptanceTestKubeVersion
 	ctx := t.Context()
 	// Create base (original/source) cluster that is sharing it's storage
-	baseConfig1 := generateResourceNames("shared")
-	baseVpc1 := defaultVpc(baseConfig1.ClusterName, zone)
+	baseConfig1 := generateResourceNames(t, "shared")
+	baseVpc1 := defaultVpc(baseConfig1.VPCName, zone)
 	baseCluster1 := &cks.ClusterResourceModel{
 		VpcId:               types.StringValue(fmt.Sprintf("coreweave_networking_vpc.%s.id", baseConfig1.ResourceName)),
 		Name:                types.StringValue(baseConfig1.ClusterName),
@@ -1234,8 +1138,8 @@ func TestSharedStorage(t *testing.T) {
 	}
 
 	// Create migrated cluster which is taking over it's storage
-	dependentConfig := generateResourceNames("migrated")
-	dependentVpc := defaultVpc(dependentConfig.ClusterName, zone)
+	dependentConfig := generateResourceNames(t, "migrated")
+	dependentVpc := defaultVpc(dependentConfig.VPCName, zone)
 
 	dependentClusterInitial := &cks.ClusterResourceModel{
 		VpcId:                  types.StringValue(fmt.Sprintf("coreweave_networking_vpc.%s.id", dependentConfig.ResourceName)),
@@ -1295,11 +1199,11 @@ func TestSharedStorage(t *testing.T) {
 }
 
 func TestClusterResource_AdditionalServerSANs(t *testing.T) {
-	config := generateResourceNames("cks-sans")
+	config := generateResourceNames(t, "cks-sans")
 	zone := testutil.AcceptanceTestZone
 	kubeVersion := testutil.AcceptanceTestKubeVersion
 
-	vpc := defaultVpc(config.ClusterName, zone)
+	vpc := defaultVpc(config.VPCName, zone)
 	ctx := t.Context()
 
 	base := cks.ClusterResourceModel{

--- a/coreweave/cks/resource_names_test.go
+++ b/coreweave/cks/resource_names_test.go
@@ -1,0 +1,47 @@
+package cks_test
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenerateResourceNames(t *testing.T) {
+	scenarios := []string{
+		"cks-cluster",
+		"cks-cluster-v6",
+		"cks-tailscale",
+		"cks-kubelet",
+		"partial-oidc",
+		"partial-webhook",
+		"audit-policy",
+		"shared",
+		"migrated",
+		"cks-sans",
+	}
+	fiveLowercaseHexDigits := regexp.MustCompile(`^[0-9a-f]{5}$`)
+
+	for _, scenario := range scenarios {
+		t.Run(scenario, func(t *testing.T) {
+			names := generateResourceNames(t, scenario)
+			clusterPrefix := AcceptanceTestPrefix + scenario + "-"
+
+			require.True(t, strings.HasPrefix(names.ClusterName, clusterPrefix))
+			suffix := strings.TrimPrefix(names.ClusterName, clusterPrefix)
+			assert.Regexp(t, fiveLowercaseHexDigits, suffix)
+			assert.Equal(t, cksVPCNamePrefix+suffix, names.VPCName)
+			assert.True(t, strings.HasSuffix(names.ResourceName, "_"+suffix))
+			assert.LessOrEqual(t, len(names.ClusterName), maxAcceptanceResourceNameLength)
+			assert.LessOrEqual(t, len(names.VPCName), maxAcceptanceResourceNameLength)
+		})
+	}
+}
+
+func TestGenerateResourceNamesRejectsLongClusterName(t *testing.T) {
+	assert.Panics(t, func() {
+		generateResourceNames(t, "scenario-name-that-is-too-long")
+	})
+}

--- a/coreweave/cks/sweeper_test.go
+++ b/coreweave/cks/sweeper_test.go
@@ -1,10 +1,430 @@
 package cks_test
 
 import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
 	"testing"
+	"time"
 
+	cksv1beta1 "buf.build/gen/go/coreweave/cks/protocolbuffers/go/coreweave/cks/v1beta1"
+	networkingv1beta1 "buf.build/gen/go/coreweave/networking/protocolbuffers/go/coreweave/networking/v1beta1"
+	"connectrpc.com/connect"
+	"github.com/coreweave/terraform-provider-coreweave/coreweave"
+	"github.com/coreweave/terraform-provider-coreweave/internal/provider"
+	"github.com/coreweave/terraform-provider-coreweave/internal/testutil"
+	"github.com/coreweave/terraform-provider-coreweave/internal/testutil/vpcsweeper"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+const (
+	cksClusterSweeperName       = "coreweave_cks_cluster"
+	cksVPCSweeperName           = "coreweave_cks_vpc"
+	cksClusterSweeperTimeout    = 30 * time.Minute
+	cksVPCSweeperTimeout        = 10 * time.Minute
+	testAccSweepTimeout         = 45 * time.Minute
+	sweepTimeoutHeadroom        = 5 * time.Minute
+	clusterDeleteTimeout        = 30 * time.Minute
+	clusterTransitionRetryDelay = 30 * time.Second
+	clusterDeleteWaitTimeout    = 10 * time.Minute
+	clusterDeletePollTimeout    = 5 * time.Minute
+	clusterDeletePollInterval   = 15 * time.Second
+	testSweepZone               = "zone-a"
+	testSweepClusterName        = "test-acc-cluster-12345"
+)
+
+type clusterSweepClient interface {
+	ListClusters(context.Context, *connect.Request[cksv1beta1.ListClustersRequest]) (*connect.Response[cksv1beta1.ListClustersResponse], error)
+	GetCluster(context.Context, *connect.Request[cksv1beta1.GetClusterRequest]) (*connect.Response[cksv1beta1.GetClusterResponse], error)
+	DeleteCluster(context.Context, *connect.Request[cksv1beta1.DeleteClusterRequest]) (*connect.Response[cksv1beta1.DeleteClusterResponse], error)
+}
+
+type clusterSweepOptions struct {
+	transitionRetryDelay time.Duration
+	deleteTimeout        time.Duration
+	waitTimeout          time.Duration
+	waitForDelete        func(context.Context, clusterSweepClient, string) error
+}
+
+func defaultClusterSweepOptions() clusterSweepOptions {
+	return clusterSweepOptions{
+		transitionRetryDelay: clusterTransitionRetryDelay,
+		deleteTimeout:        clusterDeleteTimeout,
+		waitTimeout:          clusterDeleteWaitTimeout,
+		waitForDelete: func(ctx context.Context, client clusterSweepClient, id string) error {
+			return testutil.WaitForDelete(ctx, clusterDeletePollTimeout, clusterDeletePollInterval, client.GetCluster, &cksv1beta1.GetClusterRequest{Id: id})
+		},
+	}
+}
+
+func normalizeCKSSweepZone(zone string) (string, error) {
+	zone = strings.TrimSpace(zone)
+	if zone == "" {
+		return "", fmt.Errorf("CKS sweep zone must not be empty")
+	}
+	return zone, nil
+}
+
+func newClusterSweepConfig(client clusterSweepClient, zone string, options clusterSweepOptions) (testutil.SweepConfig[*cksv1beta1.Cluster], error) {
+	zone, err := normalizeCKSSweepZone(zone)
+	if err != nil {
+		return testutil.SweepConfig[*cksv1beta1.Cluster]{}, err
+	}
+
+	return testutil.SweepConfig[*cksv1beta1.Cluster]{
+		ResourceType: cksClusterSweeperName,
+		List: func(ctx context.Context) ([]*cksv1beta1.Cluster, error) {
+			response, err := client.ListClusters(ctx, connect.NewRequest(&cksv1beta1.ListClustersRequest{}))
+			if err != nil {
+				return nil, fmt.Errorf("list clusters: %w", err)
+			}
+			return response.Msg.Items, nil
+		},
+		Name: func(cluster *cksv1beta1.Cluster) string {
+			return cluster.GetName()
+		},
+		Match: func(cluster *cksv1beta1.Cluster) bool {
+			return strings.HasPrefix(cluster.GetName(), AcceptanceTestPrefix) && cluster.GetZone() == zone
+		},
+		Delete: func(ctx context.Context, cluster *cksv1beta1.Cluster) error {
+			deleteCtx, deleteCancel := context.WithTimeout(ctx, options.deleteTimeout)
+			err := deleteCluster(deleteCtx, client, cluster, options.transitionRetryDelay)
+			deleteCancel()
+			if err != nil {
+				return err
+			}
+
+			waitCtx, waitCancel := context.WithTimeout(ctx, options.waitTimeout)
+			defer waitCancel()
+			if err := options.waitForDelete(waitCtx, client, cluster.GetId()); err != nil {
+				return fmt.Errorf("wait for cluster deletion: %w", err)
+			}
+			return nil
+		},
+	}, nil
+}
+
+func deleteCluster(ctx context.Context, client clusterSweepClient, listedCluster *cksv1beta1.Cluster, retryDelay time.Duration) error {
+	cluster := listedCluster
+	for isTransitionalClusterStatus(cluster.GetStatus()) {
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("wait for cluster %s to reach stable state: %w", listedCluster.GetName(), ctx.Err())
+		case <-time.After(retryDelay):
+		}
+
+		response, err := client.GetCluster(ctx, connect.NewRequest(&cksv1beta1.GetClusterRequest{Id: listedCluster.GetId()}))
+		if connect.CodeOf(err) == connect.CodeNotFound {
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("get cluster %s: %w", listedCluster.GetName(), err)
+		}
+		cluster = response.Msg.Cluster
+	}
+
+	_, err := client.DeleteCluster(ctx, connect.NewRequest(&cksv1beta1.DeleteClusterRequest{Id: listedCluster.GetId()}))
+	if connect.CodeOf(err) == connect.CodeNotFound {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("delete cluster %s: %w", listedCluster.GetName(), err)
+	}
+	return nil
+}
+
+func isTransitionalClusterStatus(status cksv1beta1.Cluster_Status) bool {
+	return status == cksv1beta1.Cluster_STATUS_CREATING ||
+		status == cksv1beta1.Cluster_STATUS_UPDATING ||
+		status == cksv1beta1.Cluster_STATUS_UPGRADING ||
+		status == cksv1beta1.Cluster_STATUS_DELETING
+}
+
+func newCKSClusterSweeper() *resource.Sweeper {
+	return &resource.Sweeper{
+		Name:         cksClusterSweeperName,
+		Dependencies: []string{},
+		F: func(zone string) error {
+			zone, err := normalizeCKSSweepZone(zone)
+			if err != nil {
+				return err
+			}
+			runtime, err := testutil.SweepRuntimeFromEnv()
+			if err != nil {
+				return err
+			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), cksClusterSweeperTimeout)
+			defer cancel()
+
+			testutil.SetEnvDefaults()
+			client, err := provider.BuildClient(ctx, provider.CoreweaveProviderModel{}, "", "")
+			if err != nil {
+				return fmt.Errorf("build client: %w", err)
+			}
+			config, err := newClusterSweepConfig(client, zone, defaultClusterSweepOptions())
+			if err != nil {
+				return err
+			}
+			return testutil.Sweep(ctx, runtime, config)
+		},
+	}
+}
+
+func newCKSVPCSweeper() *resource.Sweeper {
+	return &resource.Sweeper{
+		Name:         cksVPCSweeperName,
+		Dependencies: []string{cksClusterSweeperName},
+		F: func(zone string) error {
+			zone, err := normalizeCKSSweepZone(zone)
+			if err != nil {
+				return err
+			}
+			runtime, err := testutil.SweepRuntimeFromEnv()
+			if err != nil {
+				return err
+			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), cksVPCSweeperTimeout)
+			defer cancel()
+
+			testutil.SetEnvDefaults()
+			client, err := provider.BuildClient(ctx, provider.CoreweaveProviderModel{}, "", "")
+			if err != nil {
+				return fmt.Errorf("build client: %w", err)
+			}
+			config, err := newCKSVPCSweepConfig(client, zone)
+			if err != nil {
+				return err
+			}
+			return testutil.Sweep(ctx, runtime, config)
+		},
+	}
+}
+
+func newCKSVPCSweepConfig(client vpcsweeper.Client, zone string) (testutil.SweepConfig[*networkingv1beta1.VPC], error) {
+	return vpcsweeper.New(client, vpcsweeper.Config{Prefix: cksVPCNamePrefix, Zone: zone})
+}
+
+func init() {
+	resource.AddTestSweepers(cksClusterSweeperName, newCKSClusterSweeper())
+	resource.AddTestSweepers(cksVPCSweeperName, newCKSVPCSweeper())
+}
+
+type fakeClusterSweepClient struct {
+	getResponses   []*cksv1beta1.Cluster
+	getError       error
+	deleteError    error
+	getIDs         []string
+	deletedIDs     []string
+	getResponseIdx int
+}
+
+func (*fakeClusterSweepClient) ListClusters(context.Context, *connect.Request[cksv1beta1.ListClustersRequest]) (*connect.Response[cksv1beta1.ListClustersResponse], error) {
+	return connect.NewResponse(&cksv1beta1.ListClustersResponse{}), nil
+}
+
+func (client *fakeClusterSweepClient) GetCluster(_ context.Context, request *connect.Request[cksv1beta1.GetClusterRequest]) (*connect.Response[cksv1beta1.GetClusterResponse], error) {
+	client.getIDs = append(client.getIDs, request.Msg.GetId())
+	if client.getError != nil {
+		return nil, client.getError
+	}
+	response := client.getResponses[client.getResponseIdx]
+	client.getResponseIdx++
+	return connect.NewResponse(&cksv1beta1.GetClusterResponse{Cluster: response}), nil
+}
+
+func (client *fakeClusterSweepClient) DeleteCluster(_ context.Context, request *connect.Request[cksv1beta1.DeleteClusterRequest]) (*connect.Response[cksv1beta1.DeleteClusterResponse], error) {
+	client.deletedIDs = append(client.deletedIDs, request.Msg.GetId())
+	if client.deleteError != nil {
+		return nil, client.deleteError
+	}
+	return connect.NewResponse(&cksv1beta1.DeleteClusterResponse{}), nil
+}
+
+func TestCKSSweeperRegistrations(t *testing.T) {
+	clusterSweeper := newCKSClusterSweeper()
+	assert.Equal(t, cksClusterSweeperName, clusterSweeper.Name)
+	assert.Empty(t, clusterSweeper.Dependencies)
+	assert.NotNil(t, clusterSweeper.F)
+
+	vpcSweeper := newCKSVPCSweeper()
+	assert.Equal(t, cksVPCSweeperName, vpcSweeper.Name)
+	assert.Equal(t, []string{cksClusterSweeperName}, vpcSweeper.Dependencies)
+	assert.NotNil(t, vpcSweeper.F)
+}
+
+func TestCKSSweepersValidateZoneBeforeSetup(t *testing.T) {
+	t.Setenv(provider.CoreweaveApiTokenEnvVar, "")
+	unsetCKSEnv(t, provider.CoreweaveApiEndpointEnvVar)
+	t.Setenv("TEST_ACC_SWEEP_PARALLEL", "invalid")
+
+	tests := []struct {
+		name string
+		zone string
+		fn   func(string) error
+	}{
+		{name: "cluster empty", fn: newCKSClusterSweeper().F},
+		{name: "cluster whitespace", zone: " \t\n", fn: newCKSClusterSweeper().F},
+		{name: "VPC empty", fn: newCKSVPCSweeper().F},
+		{name: "VPC whitespace", zone: " \t\n", fn: newCKSVPCSweeper().F},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.EqualError(t, tt.fn(tt.zone), "CKS sweep zone must not be empty")
+			_, found := os.LookupEnv(provider.CoreweaveApiEndpointEnvVar)
+			assert.False(t, found)
+		})
+	}
+}
+
+func TestCKSSweepersValidateRuntimeBeforeSetup(t *testing.T) {
+	t.Setenv(provider.CoreweaveApiTokenEnvVar, "")
+	unsetCKSEnv(t, provider.CoreweaveApiEndpointEnvVar)
+	t.Setenv("TEST_ACC_SWEEP_PARALLEL", "invalid")
+
+	for _, tt := range []struct {
+		name string
+		fn   func(string) error
+	}{
+		{name: "cluster", fn: newCKSClusterSweeper().F},
+		{name: "VPC", fn: newCKSVPCSweeper().F},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			require.ErrorContains(t, tt.fn(testSweepZone), "parse TEST_ACC_SWEEP_PARALLEL as integer")
+			_, endpointWasDefaulted := os.LookupEnv(provider.CoreweaveApiEndpointEnvVar)
+			assert.False(t, endpointWasDefaulted)
+		})
+	}
+}
+
+func unsetCKSEnv(t *testing.T, name string) {
+	t.Helper()
+	t.Setenv(name, "restored by testing")
+	require.NoError(t, os.Unsetenv(name))
+}
+
+func TestCKSSweeperTimeoutBudget(t *testing.T) {
+	chainTimeout := cksClusterSweeperTimeout + cksVPCSweeperTimeout
+	require.LessOrEqual(t, chainTimeout, testAccSweepTimeout-sweepTimeoutHeadroom)
+}
+
+func TestIsTransitionalClusterStatus(t *testing.T) {
+	for _, status := range []cksv1beta1.Cluster_Status{
+		cksv1beta1.Cluster_STATUS_CREATING,
+		cksv1beta1.Cluster_STATUS_UPDATING,
+		cksv1beta1.Cluster_STATUS_UPGRADING,
+		cksv1beta1.Cluster_STATUS_DELETING,
+	} {
+		assert.True(t, isTransitionalClusterStatus(status), status.String())
+	}
+	assert.False(t, isTransitionalClusterStatus(cksv1beta1.Cluster_STATUS_RUNNING))
+}
+
+func TestCKSVPCSweepConfigMatchesOnlyNewPrefixAndZone(t *testing.T) {
+	config, err := newCKSVPCSweepConfig(nil, testSweepZone)
+	require.NoError(t, err)
+	tests := []struct {
+		name string
+		vpc  *networkingv1beta1.VPC
+		want bool
+	}{
+		{name: "new CKS VPC", vpc: &networkingv1beta1.VPC{Name: "test-acc-cks-vpc-12345", Zone: testSweepZone}, want: true},
+		{name: "legacy acceptance VPC", vpc: &networkingv1beta1.VPC{Name: "test-acc-cks-cluster-12", Zone: testSweepZone}},
+		{name: "wrong zone", vpc: &networkingv1beta1.VPC{Name: "test-acc-cks-vpc-12345", Zone: "zone-b"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, config.Match(tt.vpc))
+		})
+	}
+}
+
+func TestClusterSweepConfigMatchesPrefixAndZone(t *testing.T) {
+	config, err := newClusterSweepConfig(&fakeClusterSweepClient{}, "  "+testSweepZone+"\n", testClusterSweepOptions(nil))
+	require.NoError(t, err)
+	tests := []struct {
+		name    string
+		cluster *cksv1beta1.Cluster
+		want    bool
+	}{
+		{name: "both match", cluster: &cksv1beta1.Cluster{Name: testSweepClusterName, Zone: testSweepZone}, want: true},
+		{name: "prefix mismatch", cluster: &cksv1beta1.Cluster{Name: "production", Zone: testSweepZone}},
+		{name: "zone mismatch", cluster: &cksv1beta1.Cluster{Name: testSweepClusterName, Zone: "zone-b"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, config.Match(tt.cluster))
+		})
+	}
+}
+
+func TestClusterSweepDeleteBehavior(t *testing.T) {
+	tests := []struct {
+		name            string
+		status          cksv1beta1.Cluster_Status
+		getResponses    []*cksv1beta1.Cluster
+		getError        error
+		deleteError     error
+		waitError       error
+		wantError       string
+		wantGetCalls    int
+		wantDeleteCalls int
+		wantWaitCalls   int
+	}{
+		{name: "stable delete and post-delete wait", status: cksv1beta1.Cluster_STATUS_RUNNING, wantDeleteCalls: 1, wantWaitCalls: 1},
+		{name: "transitional states retry until stable", status: cksv1beta1.Cluster_STATUS_CREATING, getResponses: []*cksv1beta1.Cluster{{Status: cksv1beta1.Cluster_STATUS_UPGRADING}, {Status: cksv1beta1.Cluster_STATUS_RUNNING}}, wantGetCalls: 2, wantDeleteCalls: 1, wantWaitCalls: 1},
+		{name: "deleting retries until not found", status: cksv1beta1.Cluster_STATUS_DELETING, getError: connect.NewError(connect.CodeNotFound, assert.AnError), wantGetCalls: 1, wantWaitCalls: 1},
+		{name: "refresh API failure", status: cksv1beta1.Cluster_STATUS_CREATING, getError: connect.NewError(connect.CodeUnavailable, assert.AnError), wantError: "get cluster", wantGetCalls: 1},
+		{name: "delete not found succeeds", status: cksv1beta1.Cluster_STATUS_RUNNING, deleteError: connect.NewError(connect.CodeNotFound, assert.AnError), wantDeleteCalls: 1, wantWaitCalls: 1},
+		{name: "delete API failure", status: cksv1beta1.Cluster_STATUS_RUNNING, deleteError: connect.NewError(connect.CodeUnavailable, assert.AnError), wantError: "delete cluster", wantDeleteCalls: 1},
+		{name: "post-delete polling failure", status: cksv1beta1.Cluster_STATUS_RUNNING, waitError: assert.AnError, wantError: "wait for cluster deletion", wantDeleteCalls: 1, wantWaitCalls: 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := &fakeClusterSweepClient{getResponses: tt.getResponses, getError: tt.getError, deleteError: tt.deleteError}
+			waitCalls := 0
+			options := testClusterSweepOptions(func(_ context.Context, _ clusterSweepClient, id string) error {
+				waitCalls++
+				assert.Equal(t, "listed-id", id)
+				return tt.waitError
+			})
+			config, err := newClusterSweepConfig(client, testSweepZone, options)
+			require.NoError(t, err)
+			err = config.Delete(t.Context(), &cksv1beta1.Cluster{Id: "listed-id", Name: testSweepClusterName, Zone: testSweepZone, Status: tt.status})
+			if tt.wantError == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, tt.wantError)
+			}
+			assert.Len(t, client.getIDs, tt.wantGetCalls)
+			assert.Len(t, client.deletedIDs, tt.wantDeleteCalls)
+			assert.Equal(t, tt.wantWaitCalls, waitCalls)
+			for _, id := range append(client.getIDs, client.deletedIDs...) {
+				assert.Equal(t, "listed-id", id)
+			}
+		})
+	}
+}
+
+func testClusterSweepOptions(waitForDelete func(context.Context, clusterSweepClient, string) error) clusterSweepOptions {
+	if waitForDelete == nil {
+		waitForDelete = func(context.Context, clusterSweepClient, string) error { return nil }
+	}
+	return clusterSweepOptions{
+		transitionRetryDelay: 0,
+		deleteTimeout:        time.Second,
+		waitTimeout:          time.Second,
+		waitForDelete:        waitForDelete,
+	}
+}
+
+var _ clusterSweepClient = (*coreweave.Client)(nil)
 
 func TestMain(m *testing.M) {
 	resource.TestMain(m)


### PR DESCRIPTION
Uses the shared sweeper foundation and Networking layer to isolate CKS acceptance VPCs and clean them only after their clusters.

## Changes

- Generate one correlated five-hex suffix per fixture and keep generated cluster and VPC names within the API limit.
- Give future CKS VPCs the exclusive `test-acc-cks-vpc-` prefix while cluster names retain their scenarios.
- Register the CKS VPC sweeper behind the cluster dependency gate and validate cluster and VPC selectors before client setup.
- Migrate cluster cleanup while preserving transitional-state retries, `NotFound` handling, and post-delete polling.
- Leave legacy CKS VPC names untouched.

## Validation

- `go test -race ./coreweave/cks`
- `git diff --check`