### PR TITLE
fix(object_storage): preserve untagged buckets in state

### DIFF
--- a/coreweave/object_storage/resource_bucket.go
+++ b/coreweave/object_storage/resource_bucket.go
@@ -151,9 +151,16 @@ func handleS3Error(
 	)
 }
 
-func isNoSuchTagSetError(err error) bool {
+func isMissingBucketTagSetError(err error) bool {
 	var apiErr smithy.APIError
-	return errors.As(err, &apiErr) && apiErr.ErrorCode() == errNoSuchTagSet
+	if errors.As(err, &apiErr) && apiErr.ErrorCode() == errNoSuchTagSet {
+		return true
+	}
+
+	var httpErr *http.ResponseError
+	return errors.As(err, &httpErr) &&
+		httpErr.Response != nil &&
+		httpErr.Response.StatusCode == 404
 }
 
 // waitForBucket polls HeadBucket every 'interval' until the bucket
@@ -398,18 +405,9 @@ func (b *BucketResource) Read(ctx context.Context, req resource.ReadRequest, res
 		Bucket: aws.String(data.Name.ValueString()),
 	})
 	if err != nil {
-		if isNoSuchTagSetError(err) {
+		if isMissingBucketTagSetError(err) {
 			tagSet = &s3.GetBucketTaggingOutput{}
 		} else {
-			var httpErr *http.ResponseError
-			if errors.As(err, &httpErr) && httpErr.Response != nil {
-				// if we get a 404 back from the client, the bucket does not exist & can be removed from state
-				if httpErr.Response.StatusCode == 404 {
-					resp.State.RemoveResource(ctx)
-					return
-				}
-			}
-
 			handleS3Error(err, &resp.Diagnostics, data.Name.ValueString())
 			return
 		}

--- a/coreweave/object_storage/resource_bucket.go
+++ b/coreweave/object_storage/resource_bucket.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	awsretry "github.com/aws/aws-sdk-go-v2/aws/retry"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/smithy-go"
 	"github.com/aws/smithy-go/transport/http"
@@ -34,8 +35,10 @@ var (
 )
 
 const (
-	ErrNoSuchBucket string = "NoSuchBucket"
-	errNoSuchTagSet string = "NoSuchTagSet"
+	ErrNoSuchBucket       string = "NoSuchBucket"
+	errNotFound           string = "NotFound"
+	errNoSuchTagSet       string = "NoSuchTagSet"
+	bucketReadMaxAttempts        = 8
 )
 
 func NewBucketResource() resource.Resource {
@@ -153,11 +156,7 @@ func handleS3Error(
 
 func isMissingBucketTagSetError(err error) bool {
 	var apiErr smithy.APIError
-	if errors.As(err, &apiErr) {
-		return apiErr.ErrorCode() == errNoSuchTagSet
-	}
-
-	return isHTTPNotFoundError(err)
+	return errors.As(err, &apiErr) && apiErr.ErrorCode() == errNoSuchTagSet
 }
 
 func isHTTPNotFoundError(err error) bool {
@@ -168,20 +167,48 @@ func isHTTPNotFoundError(err error) bool {
 }
 
 func bucketExists(ctx context.Context, client s3.HeadBucketAPIClient, bucket string) (bool, error) {
-	_, err := client.HeadBucket(ctx, &s3.HeadBucketInput{Bucket: aws.String(bucket)})
+	_, err := client.HeadBucket(ctx, &s3.HeadBucketInput{Bucket: aws.String(bucket)}, withBucketReadRetry)
 	if err == nil {
 		return true, nil
 	}
-	if isHTTPNotFoundError(err) {
-		return false, nil
-	}
 
-	var apiErr smithy.APIError
-	if errors.As(err, &apiErr) && apiErr.ErrorCode() == ErrNoSuchBucket {
+	if isBucketNotFoundError(err) {
 		return false, nil
 	}
 
 	return false, err
+}
+
+func isBucketNotFoundError(err error) bool {
+	var apiErr smithy.APIError
+	if errors.As(err, &apiErr) {
+		return apiErr.ErrorCode() == ErrNoSuchBucket || apiErr.ErrorCode() == errNotFound
+	}
+
+	return isHTTPNotFoundError(err)
+}
+
+type bucketReadRetryer struct {
+	aws.Retryer
+}
+
+func (r bucketReadRetryer) IsErrorRetryable(err error) bool {
+	return isBucketNotFoundError(err) || r.Retryer.IsErrorRetryable(err)
+}
+
+func (r bucketReadRetryer) GetAttemptToken(ctx context.Context) (func(error) error, error) {
+	if retryer, ok := r.Retryer.(aws.RetryerV2); ok {
+		return retryer.GetAttemptToken(ctx)
+	}
+
+	return r.GetInitialToken(), nil
+}
+
+func withBucketReadRetry(options *s3.Options) {
+	options.Retryer = awsretry.AddWithMaxAttempts(
+		bucketReadRetryer{Retryer: options.Retryer},
+		bucketReadMaxAttempts,
+	)
 }
 
 // waitForBucket polls HeadBucket every 'interval' until the bucket
@@ -422,23 +449,11 @@ func (b *BucketResource) Read(ctx context.Context, req resource.ReadRequest, res
 		return
 	}
 
-	tagSet, err := s3Client.GetBucketTagging(ctx, &s3.GetBucketTaggingInput{
-		Bucket: aws.String(data.Name.ValueString()),
-	})
-	if err != nil {
-		if isMissingBucketTagSetError(err) {
-			tagSet = &s3.GetBucketTaggingOutput{}
-		} else {
-			handleS3Error(err, &resp.Diagnostics, data.Name.ValueString())
-			return
-		}
-	}
-
 	location, err := s3Client.GetBucketLocation(ctx, &s3.GetBucketLocationInput{
 		Bucket: aws.String(data.Name.ValueString()),
-	})
+	}, withBucketReadRetry)
 	if err != nil {
-		if !isHTTPNotFoundError(err) {
+		if !isBucketNotFoundError(err) {
 			handleS3Error(err, &resp.Diagnostics, data.Name.ValueString())
 			return
 		}
@@ -454,6 +469,30 @@ func (b *BucketResource) Read(ctx context.Context, req resource.ReadRequest, res
 		}
 	} else {
 		data.Zone = types.StringValue(string(location.LocationConstraint))
+	}
+
+	tagSet, err := s3Client.GetBucketTagging(ctx, &s3.GetBucketTaggingInput{
+		Bucket: aws.String(data.Name.ValueString()),
+	}, withBucketReadRetry)
+	if err != nil {
+		if isMissingBucketTagSetError(err) {
+			tagSet = &s3.GetBucketTaggingOutput{}
+		} else {
+			if isBucketNotFoundError(err) {
+				exists, existsErr := bucketExists(ctx, s3Client, data.Name.ValueString())
+				if existsErr != nil {
+					handleS3Error(existsErr, &resp.Diagnostics, data.Name.ValueString())
+					return
+				}
+				if !exists {
+					resp.State.RemoveResource(ctx)
+					return
+				}
+			}
+
+			handleS3Error(err, &resp.Diagnostics, data.Name.ValueString())
+			return
+		}
 	}
 
 	tags := types.MapNull(types.StringType)

--- a/coreweave/object_storage/resource_bucket.go
+++ b/coreweave/object_storage/resource_bucket.go
@@ -157,10 +157,26 @@ func isMissingBucketTagSetError(err error) bool {
 		return true
 	}
 
+	return isHTTPNotFoundError(err)
+}
+
+func isHTTPNotFoundError(err error) bool {
 	var httpErr *http.ResponseError
 	return errors.As(err, &httpErr) &&
 		httpErr.Response != nil &&
 		httpErr.Response.StatusCode == 404
+}
+
+func bucketExists(ctx context.Context, client s3.HeadBucketAPIClient, bucket string) (bool, error) {
+	_, err := client.HeadBucket(ctx, &s3.HeadBucketInput{Bucket: aws.String(bucket)})
+	if err == nil {
+		return true, nil
+	}
+	if isHTTPNotFoundError(err) {
+		return false, nil
+	}
+
+	return false, err
 }
 
 // waitForBucket polls HeadBucket every 'interval' until the bucket
@@ -417,17 +433,22 @@ func (b *BucketResource) Read(ctx context.Context, req resource.ReadRequest, res
 		Bucket: aws.String(data.Name.ValueString()),
 	})
 	if err != nil {
-		var httpErr *http.ResponseError
-		if errors.As(err, &httpErr) && httpErr.Response != nil {
-			// if we get a 404 back from the client, the bucket does not exist & can be removed from state
-			if httpErr.Response.StatusCode == 404 {
-				resp.State.RemoveResource(ctx)
-				return
-			}
+		if !isHTTPNotFoundError(err) {
+			handleS3Error(err, &resp.Diagnostics, data.Name.ValueString())
+			return
 		}
 
-		handleS3Error(err, &resp.Diagnostics, data.Name.ValueString())
-		return
+		exists, err := bucketExists(ctx, s3Client, data.Name.ValueString())
+		if err != nil {
+			handleS3Error(err, &resp.Diagnostics, data.Name.ValueString())
+			return
+		}
+		if !exists {
+			resp.State.RemoveResource(ctx)
+			return
+		}
+	} else {
+		data.Zone = types.StringValue(string(location.LocationConstraint))
 	}
 
 	tags := types.MapNull(types.StringType)
@@ -445,7 +466,6 @@ func (b *BucketResource) Read(ctx context.Context, req resource.ReadRequest, res
 		tags = tagMapValue
 	}
 
-	data.Zone = types.StringValue(string(location.LocationConstraint))
 	data.Tags = tags
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }

--- a/coreweave/object_storage/resource_bucket.go
+++ b/coreweave/object_storage/resource_bucket.go
@@ -35,6 +35,7 @@ var (
 
 const (
 	ErrNoSuchBucket string = "NoSuchBucket"
+	errNoSuchTagSet string = "NoSuchTagSet"
 )
 
 func NewBucketResource() resource.Resource {
@@ -148,6 +149,11 @@ func handleS3Error(
 		fmt.Sprintf("Unexpected error with bucket %q", bucketName),
 		err.Error(),
 	)
+}
+
+func isNoSuchTagSetError(err error) bool {
+	var apiErr smithy.APIError
+	return errors.As(err, &apiErr) && apiErr.ErrorCode() == errNoSuchTagSet
 }
 
 // waitForBucket polls HeadBucket every 'interval' until the bucket
@@ -392,17 +398,21 @@ func (b *BucketResource) Read(ctx context.Context, req resource.ReadRequest, res
 		Bucket: aws.String(data.Name.ValueString()),
 	})
 	if err != nil {
-		var httpErr *http.ResponseError
-		if errors.As(err, &httpErr) && httpErr.Response != nil {
-			// if we get a 404 back from the client, the bucket does not exist & can be removed from state
-			if httpErr.Response.StatusCode == 404 {
-				resp.State.RemoveResource(ctx)
-				return
+		if isNoSuchTagSetError(err) {
+			tagSet = &s3.GetBucketTaggingOutput{}
+		} else {
+			var httpErr *http.ResponseError
+			if errors.As(err, &httpErr) && httpErr.Response != nil {
+				// if we get a 404 back from the client, the bucket does not exist & can be removed from state
+				if httpErr.Response.StatusCode == 404 {
+					resp.State.RemoveResource(ctx)
+					return
+				}
 			}
-		}
 
-		handleS3Error(err, &resp.Diagnostics, data.Name.ValueString())
-		return
+			handleS3Error(err, &resp.Diagnostics, data.Name.ValueString())
+			return
+		}
 	}
 
 	location, err := s3Client.GetBucketLocation(ctx, &s3.GetBucketLocationInput{

--- a/coreweave/object_storage/resource_bucket.go
+++ b/coreweave/object_storage/resource_bucket.go
@@ -153,8 +153,8 @@ func handleS3Error(
 
 func isMissingBucketTagSetError(err error) bool {
 	var apiErr smithy.APIError
-	if errors.As(err, &apiErr) && apiErr.ErrorCode() == errNoSuchTagSet {
-		return true
+	if errors.As(err, &apiErr) {
+		return apiErr.ErrorCode() == errNoSuchTagSet
 	}
 
 	return isHTTPNotFoundError(err)
@@ -173,6 +173,11 @@ func bucketExists(ctx context.Context, client s3.HeadBucketAPIClient, bucket str
 		return true, nil
 	}
 	if isHTTPNotFoundError(err) {
+		return false, nil
+	}
+
+	var apiErr smithy.APIError
+	if errors.As(err, &apiErr) && apiErr.ErrorCode() == ErrNoSuchBucket {
 		return false, nil
 	}
 

--- a/coreweave/object_storage/resource_bucket_unit_test.go
+++ b/coreweave/object_storage/resource_bucket_unit_test.go
@@ -1,0 +1,43 @@
+package objectstorage
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/aws/smithy-go"
+)
+
+func TestIsNoSuchTagSetError(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		err  error
+		want bool
+	}{
+		"matching API error": {
+			err:  &smithy.GenericAPIError{Code: errNoSuchTagSet},
+			want: true,
+		},
+		"wrapped matching API error": {
+			err:  fmt.Errorf("get bucket tagging: %w", &smithy.GenericAPIError{Code: errNoSuchTagSet}),
+			want: true,
+		},
+		"different API error": {
+			err: &smithy.GenericAPIError{Code: ErrNoSuchBucket},
+		},
+		"non-API error": {
+			err: errors.New("request failed"),
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := isNoSuchTagSetError(tt.err); got != tt.want {
+				t.Errorf("isNoSuchTagSetError() = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}

--- a/coreweave/object_storage/resource_bucket_unit_test.go
+++ b/coreweave/object_storage/resource_bucket_unit_test.go
@@ -3,13 +3,23 @@ package objectstorage
 import (
 	"errors"
 	"fmt"
+	standardhttp "net/http"
 	"testing"
 
 	"github.com/aws/smithy-go"
+	smithyhttp "github.com/aws/smithy-go/transport/http"
 )
 
-func TestIsNoSuchTagSetError(t *testing.T) {
+func TestIsMissingBucketTagSetError(t *testing.T) {
 	t.Parallel()
+
+	httpError := func(statusCode int) error {
+		t.Helper()
+		return &smithyhttp.ResponseError{
+			Response: &smithyhttp.Response{Response: &standardhttp.Response{StatusCode: statusCode}},
+			Err:      errors.New("request failed"),
+		}
+	}
 
 	tests := map[string]struct {
 		err  error
@@ -23,8 +33,19 @@ func TestIsNoSuchTagSetError(t *testing.T) {
 			err:  fmt.Errorf("get bucket tagging: %w", &smithy.GenericAPIError{Code: errNoSuchTagSet}),
 			want: true,
 		},
+		"HTTP 404": {
+			err:  httpError(standardhttp.StatusNotFound),
+			want: true,
+		},
+		"wrapped HTTP 404": {
+			err:  fmt.Errorf("get bucket tagging: %w", httpError(standardhttp.StatusNotFound)),
+			want: true,
+		},
 		"different API error": {
 			err: &smithy.GenericAPIError{Code: ErrNoSuchBucket},
+		},
+		"HTTP 500": {
+			err: httpError(standardhttp.StatusInternalServerError),
 		},
 		"non-API error": {
 			err: errors.New("request failed"),
@@ -35,8 +56,8 @@ func TestIsNoSuchTagSetError(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			if got := isNoSuchTagSetError(tt.err); got != tt.want {
-				t.Errorf("isNoSuchTagSetError() = %t, want %t", got, tt.want)
+			if got := isMissingBucketTagSetError(tt.err); got != tt.want {
+				t.Errorf("isMissingBucketTagSetError() = %t, want %t", got, tt.want)
 			}
 		})
 	}

--- a/coreweave/object_storage/resource_bucket_unit_test.go
+++ b/coreweave/object_storage/resource_bucket_unit_test.go
@@ -22,10 +22,15 @@ func (s bucketHeadCheckerStub) HeadBucket(_ context.Context, _ *s3.HeadBucketInp
 
 func responseError(t *testing.T, statusCode int) error {
 	t.Helper()
+	return responseErrorWithCause(t, statusCode, errors.New("request failed"))
+}
+
+func responseErrorWithCause(t *testing.T, statusCode int, err error) error {
+	t.Helper()
 
 	return &smithyhttp.ResponseError{
 		Response: &smithyhttp.Response{Response: &standardhttp.Response{StatusCode: statusCode}},
-		Err:      errors.New("request failed"),
+		Err:      err,
 	}
 }
 
@@ -55,6 +60,9 @@ func TestIsMissingBucketTagSetError(t *testing.T) {
 		"different API error": {
 			err: &smithy.GenericAPIError{Code: ErrNoSuchBucket},
 		},
+		"different API error with HTTP 404": {
+			err: responseErrorWithCause(t, standardhttp.StatusNotFound, &smithy.GenericAPIError{Code: ErrNoSuchBucket}),
+		},
 		"HTTP 500": {
 			err: responseError(t, standardhttp.StatusInternalServerError),
 		},
@@ -78,6 +86,7 @@ func TestBucketExists(t *testing.T) {
 	t.Parallel()
 
 	headNotFound := fmt.Errorf("head bucket: %w", responseError(t, standardhttp.StatusNotFound))
+	headNoSuchBucket := fmt.Errorf("head bucket: %w", &smithy.GenericAPIError{Code: ErrNoSuchBucket})
 	headFailure := responseError(t, standardhttp.StatusInternalServerError)
 
 	tests := []struct {
@@ -88,6 +97,7 @@ func TestBucketExists(t *testing.T) {
 	}{
 		{name: "success confirms existence", wantExists: true},
 		{name: "404 confirms absence", err: headNotFound},
+		{name: "NoSuchBucket confirms absence", err: headNoSuchBucket},
 		{name: "other error is propagated", err: headFailure, wantErr: headFailure},
 	}
 

--- a/coreweave/object_storage/resource_bucket_unit_test.go
+++ b/coreweave/object_storage/resource_bucket_unit_test.go
@@ -7,6 +7,7 @@ import (
 	standardhttp "net/http"
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/smithy-go"
 	smithyhttp "github.com/aws/smithy-go/transport/http"
@@ -50,12 +51,10 @@ func TestIsMissingBucketTagSetError(t *testing.T) {
 			want: true,
 		},
 		"HTTP 404": {
-			err:  responseError(t, standardhttp.StatusNotFound),
-			want: true,
+			err: responseError(t, standardhttp.StatusNotFound),
 		},
 		"wrapped HTTP 404": {
-			err:  fmt.Errorf("get bucket tagging: %w", responseError(t, standardhttp.StatusNotFound)),
-			want: true,
+			err: fmt.Errorf("get bucket tagging: %w", responseError(t, standardhttp.StatusNotFound)),
 		},
 		"different API error": {
 			err: &smithy.GenericAPIError{Code: ErrNoSuchBucket},
@@ -79,6 +78,29 @@ func TestIsMissingBucketTagSetError(t *testing.T) {
 				t.Errorf("isMissingBucketTagSetError() = %t, want %t", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestWithBucketReadRetry(t *testing.T) {
+	t.Parallel()
+
+	options := s3.Options{Retryer: aws.NopRetryer{}}
+	withBucketReadRetry(&options)
+
+	if got := options.Retryer.MaxAttempts(); got != bucketReadMaxAttempts {
+		t.Errorf("MaxAttempts() = %d, want %d", got, bucketReadMaxAttempts)
+	}
+	if !options.Retryer.IsErrorRetryable(&smithy.GenericAPIError{Code: ErrNoSuchBucket}) {
+		t.Error("NoSuchBucket should be retryable")
+	}
+	if !options.Retryer.IsErrorRetryable(&smithy.GenericAPIError{Code: errNotFound}) {
+		t.Error("NotFound should be retryable")
+	}
+	if !options.Retryer.IsErrorRetryable(responseError(t, standardhttp.StatusNotFound)) {
+		t.Error("HTTP 404 should be retryable")
+	}
+	if options.Retryer.IsErrorRetryable(&smithy.GenericAPIError{Code: errNoSuchTagSet}) {
+		t.Error("NoSuchTagSet should not be retryable")
 	}
 }
 

--- a/coreweave/object_storage/resource_bucket_unit_test.go
+++ b/coreweave/object_storage/resource_bucket_unit_test.go
@@ -1,25 +1,36 @@
 package objectstorage
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	standardhttp "net/http"
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/smithy-go"
 	smithyhttp "github.com/aws/smithy-go/transport/http"
 )
 
+type bucketHeadCheckerStub struct {
+	err error
+}
+
+func (s bucketHeadCheckerStub) HeadBucket(_ context.Context, _ *s3.HeadBucketInput, _ ...func(*s3.Options)) (*s3.HeadBucketOutput, error) {
+	return &s3.HeadBucketOutput{}, s.err
+}
+
+func responseError(t *testing.T, statusCode int) error {
+	t.Helper()
+
+	return &smithyhttp.ResponseError{
+		Response: &smithyhttp.Response{Response: &standardhttp.Response{StatusCode: statusCode}},
+		Err:      errors.New("request failed"),
+	}
+}
+
 func TestIsMissingBucketTagSetError(t *testing.T) {
 	t.Parallel()
-
-	httpError := func(statusCode int) error {
-		t.Helper()
-		return &smithyhttp.ResponseError{
-			Response: &smithyhttp.Response{Response: &standardhttp.Response{StatusCode: statusCode}},
-			Err:      errors.New("request failed"),
-		}
-	}
 
 	tests := map[string]struct {
 		err  error
@@ -34,18 +45,18 @@ func TestIsMissingBucketTagSetError(t *testing.T) {
 			want: true,
 		},
 		"HTTP 404": {
-			err:  httpError(standardhttp.StatusNotFound),
+			err:  responseError(t, standardhttp.StatusNotFound),
 			want: true,
 		},
 		"wrapped HTTP 404": {
-			err:  fmt.Errorf("get bucket tagging: %w", httpError(standardhttp.StatusNotFound)),
+			err:  fmt.Errorf("get bucket tagging: %w", responseError(t, standardhttp.StatusNotFound)),
 			want: true,
 		},
 		"different API error": {
 			err: &smithy.GenericAPIError{Code: ErrNoSuchBucket},
 		},
 		"HTTP 500": {
-			err: httpError(standardhttp.StatusInternalServerError),
+			err: responseError(t, standardhttp.StatusInternalServerError),
 		},
 		"non-API error": {
 			err: errors.New("request failed"),
@@ -58,6 +69,38 @@ func TestIsMissingBucketTagSetError(t *testing.T) {
 
 			if got := isMissingBucketTagSetError(tt.err); got != tt.want {
 				t.Errorf("isMissingBucketTagSetError() = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBucketExists(t *testing.T) {
+	t.Parallel()
+
+	headNotFound := fmt.Errorf("head bucket: %w", responseError(t, standardhttp.StatusNotFound))
+	headFailure := responseError(t, standardhttp.StatusInternalServerError)
+
+	tests := []struct {
+		name       string
+		err        error
+		wantExists bool
+		wantErr    error
+	}{
+		{name: "success confirms existence", wantExists: true},
+		{name: "404 confirms absence", err: headNotFound},
+		{name: "other error is propagated", err: headFailure, wantErr: headFailure},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			exists, err := bucketExists(t.Context(), bucketHeadCheckerStub{err: tt.err}, "test-bucket")
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("bucketExists() error = %v, want %v", err, tt.wantErr)
+			}
+			if exists != tt.wantExists {
+				t.Errorf("bucketExists() = %t, want %t", exists, tt.wantExists)
 			}
 		})
 	}


### PR DESCRIPTION
S3 bucket metadata reads can temporarily disagree after a bucket mutation: `GetBucketLocation` or `GetBucketTagging` may report a not-found response while the bucket still exists. An untagged bucket may also return S3's [`NoSuchTagSet`](https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketTagging.html), which means the bucket exists without tags.

## Changes

- Establish bucket location and existence before reading tags.
- Add a context-aware, jittered retry budget for `NoSuchBucket`, `NotFound`, and otherwise uncoded HTTP 404 responses during bucket refresh.
- Treat only `NoSuchTagSet` as an empty tag set.
- Recheck existence after exhausted tagging retries, removing state only when `HeadBucket` confirms absence.
- Preserve existing diagnostics for permission and other API failures.
- Add focused coverage for error classification and the operation-scoped retry policy.

This is defensive provider handling for transient S3 metadata inconsistency; it does not change the global S3 retry policy.

## Testing

- `go test -race ./coreweave/object_storage -count=1`
- `make test`
- `make lint`
- `git diff --check`
