### PR TITLE
fix(object_storage): preserve bucket policy conditions

### DIFF
--- a/coreweave/object_storage/data_source_bucket_policy_document.go
+++ b/coreweave/object_storage/data_source_bucket_policy_document.go
@@ -123,6 +123,8 @@ func (sl StringList) MarshalJSON() ([]byte, error) {
 // Single‐string values get normalized into a slice of length 1.
 type Condition map[string]map[string][]string
 
+type scalarCondition map[string]map[string]string
+
 func (c *Condition) UnmarshalJSON(b []byte) error {
 	// First unmarshal into a generic map[string]json.RawMessage
 	var rawOps map[string]json.RawMessage
@@ -285,10 +287,13 @@ func BuildPolicyDocument(ctx context.Context, bm BucketPolicyDocumentModel) Poli
 		// condition
 		cond := Condition{}
 		if !sm.Condition.IsNull() {
-			var tmp Condition
+			var tmp scalarCondition
 			sm.Condition.ElementsAs(ctx, &tmp, false)
-			for op, raw := range tmp {
-				cond[op] = raw
+			for op, values := range tmp {
+				cond[op] = make(map[string][]string, len(values))
+				for key, value := range values {
+					cond[op][key] = []string{value}
+				}
 			}
 		}
 		// actions

--- a/coreweave/object_storage/data_source_bucket_policy_document_unit_test.go
+++ b/coreweave/object_storage/data_source_bucket_policy_document_unit_test.go
@@ -1,0 +1,32 @@
+package objectstorage_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	objectstorage "github.com/coreweave/terraform-provider-coreweave/coreweave/object_storage"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildPolicyDocumentPreservesCondition(t *testing.T) {
+	t.Parallel()
+
+	model := objectstorage.BucketPolicyDocumentModel{
+		Statement: []objectstorage.StatementModel{
+			{
+				Condition: types.MapValueMust(types.MapType{ElemType: types.StringType}, map[string]attr.Value{
+					"StringEquals": types.MapValueMust(types.StringType, map[string]attr.Value{
+						"cw:PrincipalOrgID": types.StringValue("test-org-id"),
+					}),
+				}),
+			},
+		},
+	}
+
+	document := objectstorage.BuildPolicyDocument(t.Context(), model)
+	conditionJSON, err := json.Marshal(document.Statement[0].Condition)
+	require.NoError(t, err)
+	require.JSONEq(t, `{"StringEquals":{"cw:PrincipalOrgID":["test-org-id"]}}`, string(conditionJSON))
+}


### PR DESCRIPTION
Bucket policy conditions were silently omitted because the Terraform
schema stores scalar strings while BuildPolicyDocument decoded values into
string slices.

Decode the schema-aligned values first, then normalize them for the JSON
policy model. Add a regression test for cw:PrincipalOrgID.
