### PR TITLE
test(networking): migrate acceptance sweeper

### DIFF
--- a/coreweave/networking/resource_vpc_test.go
+++ b/coreweave/networking/resource_vpc_test.go
@@ -1,17 +1,13 @@
 package networking_test
 
 import (
-	"context"
 	"fmt"
-	"log"
 	"math/rand/v2"
 	"regexp"
 	"slices"
 	"strings"
 	"testing"
-	"time"
 
-	"connectrpc.com/connect"
 	"github.com/coreweave/terraform-provider-coreweave/coreweave/networking"
 	"github.com/coreweave/terraform-provider-coreweave/internal/provider"
 	"github.com/coreweave/terraform-provider-coreweave/internal/testutil"
@@ -35,66 +31,6 @@ const (
 
 	defaultPrimaryHostPrefixName = "host primary"
 )
-
-func init() {
-	resource.AddTestSweepers("coreweave_vpc", &resource.Sweeper{
-		Name:         "coreweave_networking_vpc",
-		Dependencies: []string{},
-		F: func(r string) error {
-			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
-			defer cancel()
-
-			testutil.SetEnvDefaults()
-			client, err := provider.BuildClient(ctx, provider.CoreweaveProviderModel{}, "", "")
-			if err != nil {
-				return fmt.Errorf("failed to build client: %w", err)
-			}
-
-			listResp, err := client.ListVPCs(ctx, &connect.Request[networkingv1beta1.ListVPCsRequest]{})
-			if err != nil {
-				return fmt.Errorf("failed to list VPCs: %w", err)
-			}
-			for _, vpc := range listResp.Msg.Items {
-				if !strings.HasPrefix(vpc.Name, AcceptanceTestPrefix) {
-					log.Printf("skipping VPC %s because it does not have prefix %s", vpc.Name, AcceptanceTestPrefix)
-					continue
-				}
-
-				if vpc.GetZone() != r {
-					log.Printf("skipping VPC %s in zone %s because it does not match sweep zone %s", vpc.Name, vpc.Zone, r)
-					continue
-				}
-
-				log.Printf("sweeping VPC %s", vpc.Name)
-				if testutil.SweepDryRun() {
-					log.Printf("skipping VPC %s because of dry-run mode", vpc.Name)
-					continue
-				}
-
-				deleteReq := connect.NewRequest(&networkingv1beta1.DeleteVPCRequest{
-					Id: vpc.Id,
-				})
-
-				deleteResp, err := client.DeleteVPC(ctx, deleteReq)
-				if connect.CodeOf(err) == connect.CodeNotFound {
-					log.Printf("VPC %s already deleted", vpc.Name)
-					continue
-				} else if err != nil {
-					return fmt.Errorf("failed to delete VPC %s: %w", vpc.Name, err)
-				}
-				deletedVpc := deleteResp.Msg.Vpc
-
-				if err := testutil.WaitForDelete(ctx, 5*time.Minute, 15*time.Second, client.GetVPC, &networkingv1beta1.GetVPCRequest{
-					Id: deletedVpc.Id,
-				}); err != nil {
-					return fmt.Errorf("failed to wait for VPC %s to be deleted: %w", deletedVpc.Name, err)
-				}
-			}
-
-			return nil
-		},
-	})
-}
 
 // with is a helper function that creates a shallow copy of the given object, passes it to the given function, and returns the modified object.
 func with[T any](t *testing.T, obj T, fn func(t *testing.T, obj *T)) T {

--- a/coreweave/networking/sweeper_test.go
+++ b/coreweave/networking/sweeper_test.go
@@ -1,10 +1,108 @@
 package networking_test
 
 import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
 	"testing"
+	"time"
 
+	"github.com/coreweave/terraform-provider-coreweave/internal/provider"
+	"github.com/coreweave/terraform-provider-coreweave/internal/testutil"
+	"github.com/coreweave/terraform-provider-coreweave/internal/testutil/vpcsweeper"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+const networkingVPCSweeperName = "coreweave_networking_vpc"
+
+func normalizeNetworkingSweepZone(zone string) (string, error) {
+	zone = strings.TrimSpace(zone)
+	if zone == "" {
+		return "", errors.New("networking VPC sweep zone must not be empty")
+	}
+	return zone, nil
+}
+
+func newNetworkingVPCSweeper() *resource.Sweeper {
+	return &resource.Sweeper{
+		Name:         networkingVPCSweeperName,
+		Dependencies: []string{},
+		F: func(zone string) error {
+			zone, err := normalizeNetworkingSweepZone(zone)
+			if err != nil {
+				return err
+			}
+			runtime, err := testutil.SweepRuntimeFromEnv()
+			if err != nil {
+				return err
+			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
+			defer cancel()
+
+			testutil.SetEnvDefaults()
+			client, err := provider.BuildClient(ctx, provider.CoreweaveProviderModel{}, "", "")
+			if err != nil {
+				return fmt.Errorf("build client: %w", err)
+			}
+			config, err := vpcsweeper.New(client, vpcsweeper.Config{Prefix: AcceptanceTestPrefix, Zone: zone})
+			if err != nil {
+				return err
+			}
+			return testutil.Sweep(ctx, runtime, config)
+		},
+	}
+}
+
+func init() {
+	resource.AddTestSweepers(networkingVPCSweeperName, newNetworkingVPCSweeper())
+}
+
+func TestNetworkingVPCSweeperRegistration(t *testing.T) {
+	sweeper := newNetworkingVPCSweeper()
+	assert.Equal(t, networkingVPCSweeperName, sweeper.Name)
+	assert.Empty(t, sweeper.Dependencies)
+}
+
+func TestNetworkingVPCSweeperRejectsBlankZoneBeforeSetup(t *testing.T) {
+	t.Setenv(provider.CoreweaveApiTokenEnvVar, "")
+	unsetEnv(t, provider.CoreweaveApiEndpointEnvVar)
+	t.Setenv("TEST_ACC_SWEEP_PARALLEL", "invalid")
+
+	for _, tt := range []struct {
+		name string
+		zone string
+	}{
+		{name: "empty"},
+		{name: "whitespace", zone: " \t\n"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			require.EqualError(t, newNetworkingVPCSweeper().F(tt.zone), "networking VPC sweep zone must not be empty")
+			_, endpointWasDefaulted := os.LookupEnv(provider.CoreweaveApiEndpointEnvVar)
+			assert.False(t, endpointWasDefaulted)
+		})
+	}
+}
+
+func TestNetworkingVPCSweeperRejectsMalformedRuntimeBeforeSetup(t *testing.T) {
+	t.Setenv(provider.CoreweaveApiTokenEnvVar, "")
+	unsetEnv(t, provider.CoreweaveApiEndpointEnvVar)
+	t.Setenv("TEST_ACC_SWEEP_PARALLEL", "invalid")
+
+	require.ErrorContains(t, newNetworkingVPCSweeper().F("US-LAB-01A"), "parse TEST_ACC_SWEEP_PARALLEL as integer")
+	_, endpointWasDefaulted := os.LookupEnv(provider.CoreweaveApiEndpointEnvVar)
+	assert.False(t, endpointWasDefaulted)
+}
+
+func unsetEnv(t *testing.T, name string) {
+	t.Helper()
+	t.Setenv(name, "restored by testing")
+	require.NoError(t, os.Unsetenv(name))
+}
 
 func TestMain(m *testing.M) {
 	resource.TestMain(m)


### PR DESCRIPTION
## Summary

Migrate the Networking acceptance sweeper to the shared configurable sweeper runtime and reusable VPC adapter. The change keeps ownership matching, zone filtering, deletion polling, and idempotent deletion behavior explicit for Networking.

## Validation

Focused Networking tests and race-enabled package tests pass.