### PR TITLE
fix(object_storage): propagate policy conversion diagnostics

### DIFF
--- a/coreweave/object_storage/data_source_bucket_policy_document.go
+++ b/coreweave/object_storage/data_source_bucket_policy_document.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/zclconf/go-cty/cty"
 )
@@ -268,7 +269,9 @@ func (d *BucketPolicyDocumentDataSource) Schema(ctx context.Context, req datasou
 	}
 }
 
-func BuildPolicyDocument(ctx context.Context, bm BucketPolicyDocumentModel) PolicyDocument {
+func BuildPolicyDocument(ctx context.Context, bm BucketPolicyDocumentModel) (PolicyDocument, diag.Diagnostics) {
+	var diagnostics diag.Diagnostics
+
 	// Build the reusable PolicyDocument
 	pd := PolicyDocument{
 		Version: bm.Version.ValueString(),
@@ -281,14 +284,20 @@ func BuildPolicyDocument(ctx context.Context, bm BucketPolicyDocumentModel) Poli
 		pr := map[string][]string{}
 		if !sm.Principal.IsNull() {
 			var tmp map[string][]string
-			sm.Principal.ElementsAs(ctx, &tmp, false)
+			diagnostics.Append(sm.Principal.ElementsAs(ctx, &tmp, false)...)
+			if diagnostics.HasError() {
+				return pd, diagnostics
+			}
 			pr = tmp
 		}
 		// condition
 		cond := Condition{}
 		if !sm.Condition.IsNull() {
 			var tmp scalarCondition
-			sm.Condition.ElementsAs(ctx, &tmp, false)
+			diagnostics.Append(sm.Condition.ElementsAs(ctx, &tmp, false)...)
+			if diagnostics.HasError() {
+				return pd, diagnostics
+			}
 			for op, values := range tmp {
 				cond[op] = make(map[string][]string, len(values))
 				for key, value := range values {
@@ -300,14 +309,20 @@ func BuildPolicyDocument(ctx context.Context, bm BucketPolicyDocumentModel) Poli
 		acts := make([]string, 0)
 		if !sm.Action.IsNull() {
 			var tmp []string
-			sm.Action.ElementsAs(ctx, &tmp, false)
+			diagnostics.Append(sm.Action.ElementsAs(ctx, &tmp, false)...)
+			if diagnostics.HasError() {
+				return pd, diagnostics
+			}
 			acts = tmp
 		}
 		// resources
 		res := make([]string, 0)
 		if !sm.Resource.IsNull() {
 			var tmp []string
-			sm.Resource.ElementsAs(ctx, &tmp, false)
+			diagnostics.Append(sm.Resource.ElementsAs(ctx, &tmp, false)...)
+			if diagnostics.HasError() {
+				return pd, diagnostics
+			}
 			res = tmp
 		}
 
@@ -323,7 +338,7 @@ func BuildPolicyDocument(ctx context.Context, bm BucketPolicyDocumentModel) Poli
 		})
 	}
 
-	return pd
+	return pd, diagnostics
 }
 
 func (d *BucketPolicyDocumentDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
@@ -334,7 +349,11 @@ func (d *BucketPolicyDocumentDataSource) Read(ctx context.Context, req datasourc
 	}
 
 	// Translate the Terraform data model to the JSON schema represented by PolicyDocument
-	pd := BuildPolicyDocument(ctx, bm)
+	pd, diags := BuildPolicyDocument(ctx, bm)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 	// Marshal the document
 	bytes, err := json.Marshal(pd)
 	if err != nil {

--- a/coreweave/object_storage/data_source_bucket_policy_document.go
+++ b/coreweave/object_storage/data_source_bucket_policy_document.go
@@ -286,7 +286,7 @@ func BuildPolicyDocument(ctx context.Context, bm BucketPolicyDocumentModel) (Pol
 			var tmp map[string][]string
 			diagnostics.Append(sm.Principal.ElementsAs(ctx, &tmp, false)...)
 			if diagnostics.HasError() {
-				return pd, diagnostics
+				return PolicyDocument{}, diagnostics
 			}
 			pr = tmp
 		}
@@ -296,7 +296,7 @@ func BuildPolicyDocument(ctx context.Context, bm BucketPolicyDocumentModel) (Pol
 			var tmp scalarCondition
 			diagnostics.Append(sm.Condition.ElementsAs(ctx, &tmp, false)...)
 			if diagnostics.HasError() {
-				return pd, diagnostics
+				return PolicyDocument{}, diagnostics
 			}
 			for op, values := range tmp {
 				cond[op] = make(map[string][]string, len(values))
@@ -311,7 +311,7 @@ func BuildPolicyDocument(ctx context.Context, bm BucketPolicyDocumentModel) (Pol
 			var tmp []string
 			diagnostics.Append(sm.Action.ElementsAs(ctx, &tmp, false)...)
 			if diagnostics.HasError() {
-				return pd, diagnostics
+				return PolicyDocument{}, diagnostics
 			}
 			acts = tmp
 		}
@@ -321,7 +321,7 @@ func BuildPolicyDocument(ctx context.Context, bm BucketPolicyDocumentModel) (Pol
 			var tmp []string
 			diagnostics.Append(sm.Resource.ElementsAs(ctx, &tmp, false)...)
 			if diagnostics.HasError() {
-				return pd, diagnostics
+				return PolicyDocument{}, diagnostics
 			}
 			res = tmp
 		}

--- a/coreweave/object_storage/data_source_bucket_policy_document_unit_test.go
+++ b/coreweave/object_storage/data_source_bucket_policy_document_unit_test.go
@@ -36,7 +36,11 @@ func TestBuildPolicyDocumentReturnsConditionDiagnostics(t *testing.T) {
 	t.Parallel()
 
 	model := objectstorage.BucketPolicyDocumentModel{
+		Version: types.StringValue("2012-10-17"),
 		Statement: []objectstorage.StatementModel{
+			{
+				Effect: types.StringValue("Allow"),
+			},
 			{
 				Condition: types.MapValueMust(types.MapType{ElemType: types.StringType}, map[string]attr.Value{
 					"StringEquals": types.MapValueMust(types.StringType, map[string]attr.Value{
@@ -48,8 +52,7 @@ func TestBuildPolicyDocumentReturnsConditionDiagnostics(t *testing.T) {
 	}
 
 	document, diagnostics := objectstorage.BuildPolicyDocument(t.Context(), model)
-	require.Len(t, diagnostics.Errors(), 1)
-	require.Equal(t, "Value Conversion Error", diagnostics.Errors()[0].Summary())
+	require.True(t, diagnostics.HasError())
 	require.Contains(t, diagnostics.Errors()[0].Detail(), "cw:PrincipalOrgID")
-	require.Empty(t, document.Statement)
+	require.Equal(t, objectstorage.PolicyDocument{}, document)
 }

--- a/coreweave/object_storage/data_source_bucket_policy_document_unit_test.go
+++ b/coreweave/object_storage/data_source_bucket_policy_document_unit_test.go
@@ -25,8 +25,31 @@ func TestBuildPolicyDocumentPreservesCondition(t *testing.T) {
 		},
 	}
 
-	document := objectstorage.BuildPolicyDocument(t.Context(), model)
+	document, diagnostics := objectstorage.BuildPolicyDocument(t.Context(), model)
+	require.False(t, diagnostics.HasError(), diagnostics.Errors())
 	conditionJSON, err := json.Marshal(document.Statement[0].Condition)
 	require.NoError(t, err)
 	require.JSONEq(t, `{"StringEquals":{"cw:PrincipalOrgID":["test-org-id"]}}`, string(conditionJSON))
+}
+
+func TestBuildPolicyDocumentReturnsConditionDiagnostics(t *testing.T) {
+	t.Parallel()
+
+	model := objectstorage.BucketPolicyDocumentModel{
+		Statement: []objectstorage.StatementModel{
+			{
+				Condition: types.MapValueMust(types.MapType{ElemType: types.StringType}, map[string]attr.Value{
+					"StringEquals": types.MapValueMust(types.StringType, map[string]attr.Value{
+						"cw:PrincipalOrgID": types.StringNull(),
+					}),
+				}),
+			},
+		},
+	}
+
+	document, diagnostics := objectstorage.BuildPolicyDocument(t.Context(), model)
+	require.Len(t, diagnostics.Errors(), 1)
+	require.Equal(t, "Value Conversion Error", diagnostics.Errors()[0].Summary())
+	require.Contains(t, diagnostics.Errors()[0].Detail(), "cw:PrincipalOrgID")
+	require.Empty(t, document.Statement)
 }

--- a/coreweave/object_storage/resource_bucket_policy_test.go
+++ b/coreweave/object_storage/resource_bucket_policy_test.go
@@ -59,7 +59,10 @@ func createBucketPolicyTestStep(ctx context.Context, t *testing.T, opts bucketPo
 		dataSourceConfig = objectstorage.MustRenderBucketPolicyDocument(ctx, opts.resourceName, opts.policyDoc)
 
 		// generate the JSON that is expected to be stored in state
-		pd := objectstorage.BuildPolicyDocument(ctx, *opts.policyDoc)
+		pd, diags := objectstorage.BuildPolicyDocument(ctx, *opts.policyDoc)
+		if diags.HasError() {
+			panic(fmt.Sprintf("failed to build policy document: %v", diags))
+		}
 		rawJSON, err := json.Marshal(pd)
 		if err != nil {
 			panic(fmt.Sprintf("failed to marshal policy document json: %v", err))


### PR DESCRIPTION
## Summary

- Propagate `ElementsAs` conversion diagnostics from `BuildPolicyDocument` to the data source response.
- Stop rendering when a bucket policy field cannot be converted instead of returning a partial policy document.
- Add a regression test proving that a null condition value produces a diagnostic rather than silently removing the condition.

## Testing

- `make fmt`
- `make generate`
- `make lint`
- `make test`
