### PR TITLE
docs(object_storage): add destination bucket policy to inventory example

### DIFF
--- a/docs/resources/object_storage_bucket_inventory.md
+++ b/docs/resources/object_storage_bucket_inventory.md
@@ -23,6 +23,32 @@ resource "coreweave_object_storage_bucket" "destination" {
   zone = "US-EAST-04A"
 }
 
+# The CoreWeave inventory service writes reports to the destination bucket.
+# Grant it only the actions it needs: s3:PutObject to write reports and
+# s3:AbortMultipartUpload to clean up uploads left by failed report generation.
+resource "coreweave_object_storage_bucket_policy" "destination" {
+  bucket = coreweave_object_storage_bucket.destination.name
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowServiceAccountWriteReportsToDestination"
+        Effect = "Allow"
+        Principal = {
+          CW = "arn:aws:iam::static:role/static/inventory"
+        }
+        Action = [
+          "s3:PutObject",
+          "s3:AbortMultipartUpload",
+        ]
+        Resource = [
+          "arn:aws:s3:::${coreweave_object_storage_bucket.destination.name}/*",
+        ]
+      },
+    ]
+  })
+}
+
 resource "coreweave_object_storage_bucket_inventory" "default" {
   bucket                   = coreweave_object_storage_bucket.source.name
   name                     = "daily-inventory"
@@ -48,6 +74,10 @@ resource "coreweave_object_storage_bucket_inventory" "default" {
       prefix     = "inventory-reports/"
     }
   }
+
+  # The destination bucket policy must exist before the inventory configuration,
+  # or the inventory service cannot write reports to the destination bucket.
+  depends_on = [coreweave_object_storage_bucket_policy.destination]
 }
 ```
 

--- a/docs/resources/object_storage_bucket_inventory.md
+++ b/docs/resources/object_storage_bucket_inventory.md
@@ -26,6 +26,12 @@ resource "coreweave_object_storage_bucket" "destination" {
 # The CoreWeave inventory service writes reports to the destination bucket.
 # Grant it only the actions it needs: s3:PutObject to write reports and
 # s3:AbortMultipartUpload to clean up uploads left by failed report generation.
+#
+# This is not a complete destination policy. Once a bucket policy exists,
+# CAIOS implicitly denies any principal or action the policy does not allow,
+# so this policy blocks everyone except the inventory service. Add owner
+# s3:ListBucket and s3:GetObject statements if you need to read the reports. See
+# https://docs.coreweave.com/products/storage/object-storage/buckets/inventory-reporting/configure#create-destination-bucket-policy
 resource "coreweave_object_storage_bucket_policy" "destination" {
   bucket = coreweave_object_storage_bucket.destination.name
   policy = jsonencode({
@@ -75,8 +81,8 @@ resource "coreweave_object_storage_bucket_inventory" "default" {
     }
   }
 
-  # The destination bucket policy must exist before the inventory configuration,
-  # or the inventory service cannot write reports to the destination bucket.
+  # Create the destination bucket policy first. PutBucketInventoryConfiguration
+  # is rejected if the inventory service cannot PutObject to the destination.
   depends_on = [coreweave_object_storage_bucket_policy.destination]
 }
 ```

--- a/examples/resources/coreweave_object_storage_bucket_inventory/resource.tf
+++ b/examples/resources/coreweave_object_storage_bucket_inventory/resource.tf
@@ -8,6 +8,32 @@ resource "coreweave_object_storage_bucket" "destination" {
   zone = "US-EAST-04A"
 }
 
+# The CoreWeave inventory service writes reports to the destination bucket.
+# Grant it only the actions it needs: s3:PutObject to write reports and
+# s3:AbortMultipartUpload to clean up uploads left by failed report generation.
+resource "coreweave_object_storage_bucket_policy" "destination" {
+  bucket = coreweave_object_storage_bucket.destination.name
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowServiceAccountWriteReportsToDestination"
+        Effect = "Allow"
+        Principal = {
+          CW = "arn:aws:iam::static:role/static/inventory"
+        }
+        Action = [
+          "s3:PutObject",
+          "s3:AbortMultipartUpload",
+        ]
+        Resource = [
+          "arn:aws:s3:::${coreweave_object_storage_bucket.destination.name}/*",
+        ]
+      },
+    ]
+  })
+}
+
 resource "coreweave_object_storage_bucket_inventory" "default" {
   bucket                   = coreweave_object_storage_bucket.source.name
   name                     = "daily-inventory"
@@ -33,4 +59,8 @@ resource "coreweave_object_storage_bucket_inventory" "default" {
       prefix     = "inventory-reports/"
     }
   }
+
+  # The destination bucket policy must exist before the inventory configuration,
+  # or the inventory service cannot write reports to the destination bucket.
+  depends_on = [coreweave_object_storage_bucket_policy.destination]
 }

--- a/examples/resources/coreweave_object_storage_bucket_inventory/resource.tf
+++ b/examples/resources/coreweave_object_storage_bucket_inventory/resource.tf
@@ -60,7 +60,7 @@ resource "coreweave_object_storage_bucket_inventory" "default" {
     }
   }
 
-  # The destination bucket policy must exist before the inventory configuration,
-  # or the inventory service cannot write reports to the destination bucket.
+  # Create the destination bucket policy first. PutBucketInventoryConfiguration
+  # is rejected if the inventory service cannot PutObject to the destination.
   depends_on = [coreweave_object_storage_bucket_policy.destination]
 }

--- a/examples/resources/coreweave_object_storage_bucket_inventory/resource.tf
+++ b/examples/resources/coreweave_object_storage_bucket_inventory/resource.tf
@@ -11,6 +11,12 @@ resource "coreweave_object_storage_bucket" "destination" {
 # The CoreWeave inventory service writes reports to the destination bucket.
 # Grant it only the actions it needs: s3:PutObject to write reports and
 # s3:AbortMultipartUpload to clean up uploads left by failed report generation.
+#
+# This is not a complete destination policy. Once a bucket policy exists,
+# CAIOS implicitly denies any principal or action the policy does not allow,
+# so this policy blocks everyone except the inventory service. Add owner
+# s3:ListBucket and s3:GetObject statements if you need to read the reports. See
+# https://docs.coreweave.com/products/storage/object-storage/buckets/inventory-reporting/configure#create-destination-bucket-policy
 resource "coreweave_object_storage_bucket_policy" "destination" {
   bucket = coreweave_object_storage_bucket.destination.name
   policy = jsonencode({


### PR DESCRIPTION
## Summary

The `coreweave_object_storage_bucket_inventory` example created an inventory configuration without granting the CoreWeave inventory service access to the destination bucket. When the destination bucket has a bucket policy, the example can fail because the inventory service cannot write reports.

- Add a destination bucket policy that grants the inventory service principal `arn:aws:iam::static:role/static/inventory` only `s3:PutObject` and `s3:AbortMultipartUpload`.
- Add `depends_on` so Terraform creates the inventory configuration after the destination bucket policy.
- Regenerate `docs/resources/object_storage_bucket_inventory.md` with `terraform fmt` and `tfplugindocs` via `go generate`.

This is the same destination bucket policy that [Configure inventory reporting](https://docs.coreweave.com/products/storage/object-storage/buckets/inventory-reporting/configure#set-bucket-access-policies) documents, down to the Sid.


## Sources and decision log

<details>
<summary>Click to expand: sources and decision log</summary>
### Factual claims

- The inventory service principal `arn:aws:iam::static:role/static/inventory` and the two actions `s3:PutObject` and `s3:AbortMultipartUpload` come from the published guide, [Configure inventory reporting, "Set bucket access policies"](https://docs.coreweave.com/products/storage/object-storage/buckets/inventory-reporting/configure#set-bucket-access-policies), added in coreweave/docs#3464 under DOCS-2451 and DOCS-2988. DOCS-2451 records that the service also needs `s3:AbortMultipartUpload`, which it uses to clean up multipart uploads left by failed report generation.
- The `depends_on` ordering mirrors the acceptance test in `coreweave/object_storage/resource_bucket_inventory_test.go`, which creates the destination bucket policy before the inventory configuration. I didn't copy the test's broad `s3:*` policy. DOCS-2996 asks for a least-privilege customer example, and the test policy only works because `s3:*` happens to include the two required actions.

### Wording and structure choices

- The Sid `AllowServiceAccountWriteReportsToDestination` reuses the Sid from the destination policy example in the public docs, so both read as the same policy.
- The principal uses the string form, `CW = "arn:..."`, to match the public docs example.
- `Resource` grants only the objects path, `arn:aws:s3:::<destination>/*`, because both granted actions operate on objects. The docs example scopes it the same way.
- The policy is inline `jsonencode` rather than the `coreweave_object_storage_bucket_policy_document` data source. Inline keeps the example single-purpose, and the bucket policy resource example already shows both styles.

### Intentionally omitted

- The second statement from the docs' destination policy example, which grants bucket access to the user who manages and reads reports. DOCS-2996 asks for only the actions the inventory service requires, and the full pattern lives in the configure guide.
- Any conditions. The principal is a specific CoreWeave service account, not a wildcard, so no `cw:PrincipalOrgID` condition applies. The guide also warns against IP conditions on this principal because inventory requests carry no source IP.

### Related

- Jira: DOCS-2996, DOCS-2451, DOCS-2988
- Docs PR: coreweave/docs#3464
- After this merges and ships in a provider release, TFDocsBot syncs `public-docs/platform/terraform/resources/object_storage_bucket_inventory.mdx` in coreweave/docs on its own.
</details>


[DOCS-2996]: https://coreweave.atlassian.net/browse/DOCS-2996?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ