### PR TITLE
ci(release-please): always update release PR

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,6 @@
 {
     "pull-request-title-pattern": "chore: release ${version}",
+    "always-update": true,
     "include-component-in-tag": false,
     "include-v-in-tag": true,
     "initial-version": "v0.1.0",


### PR DESCRIPTION
Configure Release Please to keep the release PR current whenever changes are added, including changes that do not alter the generated release notes.

## Changes

- Set the root-level `always-update` option to `true` in the manifest configuration.

## Validation

- `jq empty` on the release-please configuration.
- `git diff --check`.
- Repository pre-commit hooks where configured.

## Reference

- [Release Please manifest configuration documentation](https://github.com/googleapis/release-please/blob/main/docs/manifest-releaser.md)
