### PR TITLE
feat(inference): Sync inference proto and enforce gateway name length

### DIFF
--- a/coreweave/inference/resource_inference_capacity_claim.go
+++ b/coreweave/inference/resource_inference_capacity_claim.go
@@ -156,7 +156,7 @@ func (r *InferenceCapacityClaimResource) Schema(_ context.Context, _ resource.Sc
 				Attributes: map[string]schema.Attribute{
 					"instance_type": schema.StringAttribute{
 						Required:            true,
-						MarkdownDescription: "The instance type to reserve (e.g. `gb200-4x`).",
+						MarkdownDescription: "The instance type to reserve (e.g. `gb200-4x`). Case-sensitive.",
 						PlanModifiers:       []planmodifier.String{stringplanmodifier.RequiresReplace()},
 					},
 					"instance_count": schema.Int64Attribute{
@@ -177,7 +177,7 @@ func (r *InferenceCapacityClaimResource) Schema(_ context.Context, _ resource.Sc
 					"zones": schema.SetAttribute{
 						ElementType:         types.StringType,
 						Required:            true,
-						MarkdownDescription: "The availability zones where the capacity claim may use resources from (e.g. `US-WEST-04A`). At least one is required.",
+						MarkdownDescription: "The availability zones where the capacity claim may use resources from (e.g. `US-WEST-04A`), case-sensitive. At least one is required.",
 						PlanModifiers:       []planmodifier.Set{setplanmodifier.RequiresReplace()},
 						Validators: []validator.Set{
 							setvalidator.SizeAtLeast(1),

--- a/coreweave/inference/resource_inference_gateway.go
+++ b/coreweave/inference/resource_inference_gateway.go
@@ -267,7 +267,7 @@ func (r *InferenceGatewayResource) Schema(_ context.Context, _ resource.SchemaRe
 					},
 					"edge_proxy_mode": schema.StringAttribute{
 						Optional:            true,
-						MarkdownDescription: fmt.Sprintf("How client traffic reaches the gateway. Must be one of: %s. When unset, the platform default (currently `EDGE_PROXY_MODE_MANAGED`) applies.", coreweave.EnumMarkdownValues(inferencev1.EdgeProxyMode_name, true)),
+						MarkdownDescription: "How client traffic reaches the gateway. Must be one of: `EDGE_PROXY_MODE_MANAGED` (traffic is proxied through CoreWeave's managed edge network: DDoS mitigation and WAF, with TLS terminated at the edge and the origin address kept out of public DNS) or `EDGE_PROXY_MODE_DIRECT` (clients connect straight to the gateway's load balancer, with no edge filtering and the load balancer address published in DNS). When unset, the platform default (currently `EDGE_PROXY_MODE_MANAGED`) applies.",
 						Validators: []validator.String{
 							stringvalidator.OneOf(coreweave.EnumValues(inferencev1.EdgeProxyMode_name, true)...),
 						},
@@ -758,6 +758,17 @@ func toUpdateGatewayRequest(ctx context.Context, m *InferenceGatewayResourceMode
 	return req, diags
 }
 
+// emptyOrNullSet returns the value to store for an optional set attribute when the API returned
+// no elements: an empty set if the prior config/state held one (an explicit `[]`), otherwise
+// null. Preserving this distinction keeps the applied state consistent with the plan for both
+// `= []` and unset configs, avoiding Terraform's "inconsistent result after apply" error.
+func emptyOrNullSet(elemType attr.Type, prior types.Set) types.Set {
+	if !prior.IsNull() && !prior.IsUnknown() {
+		return types.SetValueMust(elemType, []attr.Value{})
+	}
+	return types.SetNull(elemType)
+}
+
 // setFromGateway populates all fields on the model from a proto Gateway response.
 // For Optional (non-Computed) fields, null is preserved when the plan/state was null and the
 // API returns the default (zero/empty) value.
@@ -885,6 +896,16 @@ func setFromGateway(m *InferenceGatewayResourceModel, gw *inferencev1.Gateway, p
 	if m.EndpointConfiguration == nil && !hasDNS && !hasRanges && !hasMode {
 		m.EndpointConfiguration = nil
 	} else {
+		// Capture the prior null/empty state of the optional set attributes: the
+		// API returns an empty list for both an unset (null) config and an
+		// explicit empty set, so we mirror what the config/state held to avoid
+		// drift between plan and applied state.
+		var priorDNS, priorRanges types.Set
+		if m.EndpointConfiguration != nil {
+			priorDNS = m.EndpointConfiguration.AdditionalDNS
+			priorRanges = m.EndpointConfiguration.AllowedSourceIPRanges
+		}
+
 		ecModel := &EndpointConfigurationModel{}
 
 		if hasDNS {
@@ -896,7 +917,7 @@ func setFromGateway(m *InferenceGatewayResourceModel, gw *inferencev1.Gateway, p
 			diagnostics.Append(diags...)
 			ecModel.AdditionalDNS = dnsSet
 		} else {
-			ecModel.AdditionalDNS = types.SetNull(types.StringType)
+			ecModel.AdditionalDNS = emptyOrNullSet(types.StringType, priorDNS)
 		}
 
 		if hasMode {
@@ -914,7 +935,7 @@ func setFromGateway(m *InferenceGatewayResourceModel, gw *inferencev1.Gateway, p
 			diagnostics.Append(diags...)
 			ecModel.AllowedSourceIPRanges = rangeSet
 		} else {
-			ecModel.AllowedSourceIPRanges = types.SetNull(cidrtypes.IPPrefixType{})
+			ecModel.AllowedSourceIPRanges = emptyOrNullSet(cidrtypes.IPPrefixType{}, priorRanges)
 		}
 
 		m.EndpointConfiguration = ecModel

--- a/coreweave/inference/resource_inference_gateway.go
+++ b/coreweave/inference/resource_inference_gateway.go
@@ -9,6 +9,7 @@ import (
 	inferencev1 "buf.build/gen/go/coreweave/inference/protocolbuffers/go/coreweave/inference/v1alpha1"
 	"connectrpc.com/connect"
 	"github.com/coreweave/terraform-provider-coreweave/coreweave"
+	"github.com/hashicorp/terraform-plugin-framework-nettypes/cidrtypes"
 	"github.com/hashicorp/terraform-plugin-framework-validators/resourcevalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -75,7 +76,9 @@ type GatewayRoutingModel struct {
 }
 
 type EndpointConfigurationModel struct {
-	AdditionalDNS types.Set `tfsdk:"additional_dns"`
+	AdditionalDNS         types.Set    `tfsdk:"additional_dns"`
+	EdgeProxyMode         types.String `tfsdk:"edge_proxy_mode"`
+	AllowedSourceIPRanges types.Set    `tfsdk:"allowed_source_ip_ranges"`
 }
 
 // InferenceGatewayResourceModel is the top-level Terraform state model.
@@ -261,6 +264,21 @@ func (r *InferenceGatewayResource) Schema(_ context.Context, _ resource.SchemaRe
 						ElementType:         types.StringType,
 						Optional:            true,
 						MarkdownDescription: "Additional DNS names for the gateway endpoint. These DNS names must be manually configured to point to the gateway endpoint.",
+					},
+					"edge_proxy_mode": schema.StringAttribute{
+						Optional:            true,
+						MarkdownDescription: fmt.Sprintf("How client traffic reaches the gateway. Must be one of: %s. When unset, the platform default (currently `EDGE_PROXY_MODE_MANAGED`) applies.", coreweave.EnumMarkdownValues(inferencev1.EdgeProxyMode_name, true)),
+						Validators: []validator.String{
+							stringvalidator.OneOf(coreweave.EnumValues(inferencev1.EdgeProxyMode_name, true)...),
+						},
+					},
+					"allowed_source_ip_ranges": schema.SetAttribute{
+						ElementType:         cidrtypes.IPPrefixType{},
+						Optional:            true,
+						MarkdownDescription: "Client source IP ranges permitted to reach the gateway, in CIDR notation (IPv4 or IPv6). Up to 50 entries; an empty list applies no source restriction. Use a full-length prefix for a single address (e.g. `203.0.113.5/32`).",
+						Validators: []validator.Set{
+							setvalidator.SizeAtMost(50),
+						},
 					},
 				},
 			},
@@ -567,21 +585,50 @@ func buildGatewayFields(ctx context.Context, m *InferenceGatewayResourceModel) (
 		Zones: zones,
 	}
 
-	// Only build an EndpointConfiguration when additional_dns is explicitly
-	// configured. Sending an empty EndpointConfiguration is non-destructive
-	// (the API merges DNS records rather than replacing them), but it muddies
-	// the wire payload for `endpoint_configuration {}` configs that set no
-	// fields.
-	if m.EndpointConfiguration != nil &&
-		!m.EndpointConfiguration.AdditionalDNS.IsNull() &&
-		!m.EndpointConfiguration.AdditionalDNS.IsUnknown() {
-		dns := []string{}
-		diagnostics.Append(m.EndpointConfiguration.AdditionalDNS.ElementsAs(ctx, &dns, false)...)
-		if diagnostics.HasError() {
-			return gatewayFields{}, diagnostics
+	// Only attach an EndpointConfiguration when at least one of its fields is
+	// explicitly configured. Sending an empty EndpointConfiguration is
+	// non-destructive (the API merges DNS records rather than replacing them),
+	// but it muddies the wire payload for `endpoint_configuration {}` configs
+	// that set no fields.
+	if m.EndpointConfiguration != nil {
+		ec := &inferencev1.EndpointConfiguration{}
+		var populated bool
+
+		if s := m.EndpointConfiguration.AdditionalDNS; !s.IsNull() && !s.IsUnknown() {
+			dns := []string{}
+			diagnostics.Append(s.ElementsAs(ctx, &dns, false)...)
+			if diagnostics.HasError() {
+				return gatewayFields{}, diagnostics
+			}
+			ec.AdditionalDns = dns
+			populated = true
 		}
-		f.EndpointConfiguration = &inferencev1.EndpointConfiguration{
-			AdditionalDns: dns,
+
+		if mode := m.EndpointConfiguration.EdgeProxyMode; !mode.IsNull() && !mode.IsUnknown() {
+			val, ok := inferencev1.EdgeProxyMode_value[mode.ValueString()]
+			if !ok {
+				diagnostics.AddError("Invalid edge_proxy_mode", fmt.Sprintf("Invalid edge_proxy_mode: %s. Must be one of: %s.", mode.ValueString(), coreweave.EnumMarkdownValues(inferencev1.EdgeProxyMode_name, true)))
+				return gatewayFields{}, diagnostics
+			}
+			ec.EdgeProxyMode = inferencev1.EdgeProxyMode(val)
+			populated = true
+		}
+
+		if s := m.EndpointConfiguration.AllowedSourceIPRanges; !s.IsNull() && !s.IsUnknown() {
+			ranges := []cidrtypes.IPPrefix{}
+			diagnostics.Append(s.ElementsAs(ctx, &ranges, false)...)
+			if diagnostics.HasError() {
+				return gatewayFields{}, diagnostics
+			}
+			ec.AllowedSourceIpRanges = make([]string, len(ranges))
+			for i, r := range ranges {
+				ec.AllowedSourceIpRanges[i] = r.ValueString()
+			}
+			populated = true
+		}
+
+		if populated {
+			f.EndpointConfiguration = ec
 		}
 	}
 
@@ -832,11 +879,15 @@ func setFromGateway(m *InferenceGatewayResourceModel, gw *inferencev1.Gateway, p
 
 	// endpoint_configuration — null preservation
 	ec := spec.GetEndpointConfiguration()
-	if m.EndpointConfiguration == nil && (ec == nil || len(ec.GetAdditionalDns()) == 0) {
+	hasDNS := ec != nil && len(ec.GetAdditionalDns()) > 0
+	hasRanges := ec != nil && len(ec.GetAllowedSourceIpRanges()) > 0
+	hasMode := ec != nil && ec.GetEdgeProxyMode() != inferencev1.EdgeProxyMode_EDGE_PROXY_MODE_UNSPECIFIED
+	if m.EndpointConfiguration == nil && !hasDNS && !hasRanges && !hasMode {
 		m.EndpointConfiguration = nil
 	} else {
 		ecModel := &EndpointConfigurationModel{}
-		if ec != nil && len(ec.GetAdditionalDns()) > 0 {
+
+		if hasDNS {
 			dnsVals := make([]attr.Value, len(ec.GetAdditionalDns()))
 			for i, d := range ec.GetAdditionalDns() {
 				dnsVals[i] = types.StringValue(d)
@@ -847,6 +898,25 @@ func setFromGateway(m *InferenceGatewayResourceModel, gw *inferencev1.Gateway, p
 		} else {
 			ecModel.AdditionalDNS = types.SetNull(types.StringType)
 		}
+
+		if hasMode {
+			ecModel.EdgeProxyMode = types.StringValue(ec.GetEdgeProxyMode().String())
+		} else {
+			ecModel.EdgeProxyMode = types.StringNull()
+		}
+
+		if hasRanges {
+			rangeVals := make([]attr.Value, len(ec.GetAllowedSourceIpRanges()))
+			for i, r := range ec.GetAllowedSourceIpRanges() {
+				rangeVals[i] = cidrtypes.NewIPPrefixValue(r)
+			}
+			rangeSet, diags := types.SetValue(cidrtypes.IPPrefixType{}, rangeVals)
+			diagnostics.Append(diags...)
+			ecModel.AllowedSourceIPRanges = rangeSet
+		} else {
+			ecModel.AllowedSourceIPRanges = types.SetNull(cidrtypes.IPPrefixType{})
+		}
+
 		m.EndpointConfiguration = ecModel
 	}
 

--- a/coreweave/inference/resource_inference_gateway.go
+++ b/coreweave/inference/resource_inference_gateway.go
@@ -165,8 +165,11 @@ func (r *InferenceGatewayResource) Schema(_ context.Context, _ resource.SchemaRe
 			},
 			"name": schema.StringAttribute{
 				Required:            true,
-				MarkdownDescription: "The human-readable name of the gateway.",
+				MarkdownDescription: "The human-readable name of the gateway. Capped at 38 characters so the derived public FQDN fits within the 64-character X.509 Common Name limit.",
 				PlanModifiers:       []planmodifier.String{stringplanmodifier.RequiresReplace()},
+				Validators: []validator.String{
+					stringvalidator.LengthAtMost(38),
+				},
 			},
 			"zones": schema.SetAttribute{
 				ElementType:         types.StringType,

--- a/coreweave/inference/resource_inference_gateway_test.go
+++ b/coreweave/inference/resource_inference_gateway_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/coreweave/terraform-provider-coreweave/coreweave/inference"
 	"github.com/coreweave/terraform-provider-coreweave/internal/provider"
 	"github.com/coreweave/terraform-provider-coreweave/internal/testutil"
+	"github.com/hashicorp/terraform-plugin-framework-nettypes/cidrtypes"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	fwresource "github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -584,6 +585,192 @@ func TestToCreateGatewayRequest_AllRoutingTypes(t *testing.T) {
 			t.Error("Routing.PathBased: expected non-nil")
 		}
 	})
+}
+
+func TestToCreateGatewayRequest_EndpointConfiguration(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	m := &inference.InferenceGatewayResourceModel{
+		Name:  types.StringValue("edge-gw"),
+		Zones: types.SetValueMust(types.StringType, []attr.Value{types.StringValue("US-EAST-04A")}),
+		Auth: &inference.GatewayAuthModel{
+			CoreWeave: &inference.CoreWeaveAuthModel{},
+		},
+		Routing: &inference.GatewayRoutingModel{
+			PathBased: &inference.PathBasedRoutingModel{},
+		},
+		EndpointConfiguration: &inference.EndpointConfigurationModel{
+			AdditionalDNS: types.SetNull(types.StringType),
+			EdgeProxyMode: types.StringValue("EDGE_PROXY_MODE_DIRECT"),
+			AllowedSourceIPRanges: types.SetValueMust(cidrtypes.IPPrefixType{}, []attr.Value{
+				cidrtypes.NewIPPrefixValue("203.0.113.0/24"),
+				cidrtypes.NewIPPrefixValue("2001:db8::/32"),
+			}),
+		},
+	}
+
+	req, diags := inference.ToCreateGatewayRequest(ctx, m)
+	if diags.HasError() {
+		t.Fatalf("ToCreateGatewayRequest returned errors: %v", diags)
+	}
+
+	ec := req.GetEndpointConfiguration()
+	if ec == nil {
+		t.Fatal("EndpointConfiguration: expected non-nil")
+	}
+	if got, want := ec.GetEdgeProxyMode(), inferencev1.EdgeProxyMode_EDGE_PROXY_MODE_DIRECT; got != want {
+		t.Errorf("EdgeProxyMode: got %v, want %v", got, want)
+	}
+	got := ec.GetAllowedSourceIpRanges()
+	if len(got) != 2 {
+		t.Fatalf("AllowedSourceIpRanges: got %d entries, want 2: %v", len(got), got)
+	}
+	want := map[string]bool{"203.0.113.0/24": true, "2001:db8::/32": true}
+	for _, r := range got {
+		if !want[r] {
+			t.Errorf("AllowedSourceIpRanges: unexpected entry %q", r)
+		}
+		delete(want, r)
+	}
+	if len(want) != 0 {
+		t.Errorf("AllowedSourceIpRanges: missing entries %v", want)
+	}
+}
+
+func TestSetFromGateway_EndpointConfiguration(t *testing.T) {
+	t.Parallel()
+
+	t.Run("populated", func(t *testing.T) {
+		t.Parallel()
+
+		gw := &inferencev1.Gateway{
+			Spec: &inferencev1.GatewaySpec{
+				Id:    "gw-ec",
+				Name:  "ec-gw",
+				Zones: []string{"US-EAST-04A"},
+				Auth: &inferencev1.GatewaySpec_CoreWeaveAuth{
+					CoreWeaveAuth: &inferencev1.CoreWeaveAuth{},
+				},
+				Routing: &inferencev1.GatewaySpec_PathBasedRouting{
+					PathBasedRouting: &inferencev1.PathBasedRouting{},
+				},
+				EndpointConfiguration: &inferencev1.EndpointConfiguration{
+					EdgeProxyMode:         inferencev1.EdgeProxyMode_EDGE_PROXY_MODE_DIRECT,
+					AllowedSourceIpRanges: []string{"203.0.113.0/24"},
+				},
+			},
+			Status: &inferencev1.GatewayStatus{Status: inferencev1.Status_STATUS_READY},
+		}
+
+		m := &inference.InferenceGatewayResourceModel{}
+		diags := inference.SetFromGateway(m, gw, false)
+		if diags.HasError() {
+			t.Fatalf("SetFromGateway returned errors: %v", diags)
+		}
+
+		if m.EndpointConfiguration == nil {
+			t.Fatal("EndpointConfiguration: expected non-nil")
+		}
+		if got := m.EndpointConfiguration.EdgeProxyMode.ValueString(); got != "EDGE_PROXY_MODE_DIRECT" {
+			t.Errorf("EdgeProxyMode: got %q, want %q", got, "EDGE_PROXY_MODE_DIRECT")
+		}
+		elems := m.EndpointConfiguration.AllowedSourceIPRanges.Elements()
+		if len(elems) != 1 {
+			t.Fatalf("AllowedSourceIPRanges: got %d entries, want 1", len(elems))
+		}
+		if p, ok := elems[0].(cidrtypes.IPPrefix); !ok || p.ValueString() != "203.0.113.0/24" {
+			t.Errorf("AllowedSourceIPRanges[0]: got %v, want 203.0.113.0/24", elems[0])
+		}
+	})
+
+	t.Run("all-zero endpoint config stays nil", func(t *testing.T) {
+		t.Parallel()
+
+		gw := &inferencev1.Gateway{
+			Spec: &inferencev1.GatewaySpec{
+				Id:    "gw-ec-zero",
+				Name:  "ec-zero-gw",
+				Zones: []string{"US-EAST-04A"},
+				Auth: &inferencev1.GatewaySpec_CoreWeaveAuth{
+					CoreWeaveAuth: &inferencev1.CoreWeaveAuth{},
+				},
+				Routing: &inferencev1.GatewaySpec_PathBasedRouting{
+					PathBasedRouting: &inferencev1.PathBasedRouting{},
+				},
+				EndpointConfiguration: &inferencev1.EndpointConfiguration{},
+			},
+			Status: &inferencev1.GatewayStatus{Status: inferencev1.Status_STATUS_READY},
+		}
+
+		m := &inference.InferenceGatewayResourceModel{EndpointConfiguration: nil}
+		diags := inference.SetFromGateway(m, gw, false)
+		if diags.HasError() {
+			t.Fatalf("SetFromGateway returned errors: %v", diags)
+		}
+		if m.EndpointConfiguration != nil {
+			t.Errorf("EndpointConfiguration: expected nil when API returns an all-zero config, got %v", m.EndpointConfiguration)
+		}
+	})
+}
+
+// TestInferenceGateway_EndpointConfigurationValidation pins the client-side
+// validation for the edge proxy mode enum and the source IP range CIDRs.
+func TestInferenceGateway_EndpointConfigurationValidation(t *testing.T) {
+	// A non-empty token lets the provider configure so a plan-only create can be
+	// computed; no API call is made during plan.
+	t.Setenv("COREWEAVE_API_TOKEN", "CW-SECRET-unit-test")
+
+	t.Run("valid edge_proxy_mode and CIDR", func(t *testing.T) {
+		resource.UnitTest(t, resource.TestCase{
+			ProtoV6ProviderFactories: provider.TestProtoV6ProviderFactories,
+			Steps: []resource.TestStep{
+				{
+					Config: gatewayEndpointConfig(`edge_proxy_mode          = "EDGE_PROXY_MODE_DIRECT"
+    allowed_source_ip_ranges = ["203.0.113.0/24", "2001:db8::/32"]`),
+					PlanOnly:           true,
+					ExpectNonEmptyPlan: true,
+				},
+			},
+		})
+	})
+
+	t.Run("invalid edge_proxy_mode is rejected", func(t *testing.T) {
+		resource.UnitTest(t, resource.TestCase{
+			ProtoV6ProviderFactories: provider.TestProtoV6ProviderFactories,
+			Steps: []resource.TestStep{
+				{
+					Config:      gatewayEndpointConfig(`edge_proxy_mode = "EDGE_PROXY_MODE_BOGUS"`),
+					PlanOnly:    true,
+					ExpectError: regexp.MustCompile(`value must be one of`),
+				},
+			},
+		})
+	})
+}
+
+// gatewayEndpointConfig renders a minimal gateway whose endpoint_configuration
+// block contains only the attributes in ecAttrs. Zones are hardcoded (no data
+// source) so the plan stays local and never reaches the API.
+func gatewayEndpointConfig(ecAttrs string) string {
+	return fmt.Sprintf(`
+resource "coreweave_inference_gateway" "test" {
+  name  = "unit-test-ec"
+  zones = ["US-EAST-04A"]
+
+  auth = {
+    coreweave = {}
+  }
+
+  routing = {
+    path_based = {}
+  }
+
+  endpoint_configuration = {
+    %s
+  }
+}
+`, ecAttrs)
 }
 
 // wandbAuthGatewayConfig renders a minimal gateway whose W&B auth block contains

--- a/coreweave/inference/resource_inference_gateway_test.go
+++ b/coreweave/inference/resource_inference_gateway_test.go
@@ -712,6 +712,94 @@ func TestSetFromGateway_EndpointConfiguration(t *testing.T) {
 			t.Errorf("EndpointConfiguration: expected nil when API returns an all-zero config, got %v", m.EndpointConfiguration)
 		}
 	})
+
+	// An explicitly configured empty set (`allowed_source_ip_ranges = []`) must
+	// round-trip as an empty set, not null: the API echoes an empty list, and
+	// collapsing it to null would make the applied state differ from the plan and
+	// trip Terraform's "inconsistent result after apply" check.
+	t.Run("explicit empty allowed_source_ip_ranges preserved as empty", func(t *testing.T) {
+		t.Parallel()
+
+		gw := &inferencev1.Gateway{
+			Spec: &inferencev1.GatewaySpec{
+				Id:    "gw-ec-empty",
+				Name:  "ec-empty-gw",
+				Zones: []string{"US-EAST-04A"},
+				Auth: &inferencev1.GatewaySpec_CoreWeaveAuth{
+					CoreWeaveAuth: &inferencev1.CoreWeaveAuth{},
+				},
+				Routing: &inferencev1.GatewaySpec_PathBasedRouting{
+					PathBasedRouting: &inferencev1.PathBasedRouting{},
+				},
+				EndpointConfiguration: &inferencev1.EndpointConfiguration{},
+			},
+			Status: &inferencev1.GatewayStatus{Status: inferencev1.Status_STATUS_READY},
+		}
+
+		m := &inference.InferenceGatewayResourceModel{
+			EndpointConfiguration: &inference.EndpointConfigurationModel{
+				AdditionalDNS:         types.SetNull(types.StringType),
+				EdgeProxyMode:         types.StringNull(),
+				AllowedSourceIPRanges: types.SetValueMust(cidrtypes.IPPrefixType{}, []attr.Value{}),
+			},
+		}
+		diags := inference.SetFromGateway(m, gw, false)
+		if diags.HasError() {
+			t.Fatalf("SetFromGateway returned errors: %v", diags)
+		}
+		if m.EndpointConfiguration == nil {
+			t.Fatal("EndpointConfiguration: expected non-nil")
+		}
+		got := m.EndpointConfiguration.AllowedSourceIPRanges
+		if got.IsNull() {
+			t.Errorf("AllowedSourceIPRanges: expected empty set preserved, got null")
+		}
+		if n := len(got.Elements()); n != 0 {
+			t.Errorf("AllowedSourceIPRanges: got %d entries, want 0", n)
+		}
+	})
+
+	// The mirror case: when the attribute was null in config/state, an empty API
+	// response must stay null rather than becoming an empty set.
+	t.Run("unset allowed_source_ip_ranges stays null", func(t *testing.T) {
+		t.Parallel()
+
+		gw := &inferencev1.Gateway{
+			Spec: &inferencev1.GatewaySpec{
+				Id:    "gw-ec-null",
+				Name:  "ec-null-gw",
+				Zones: []string{"US-EAST-04A"},
+				Auth: &inferencev1.GatewaySpec_CoreWeaveAuth{
+					CoreWeaveAuth: &inferencev1.CoreWeaveAuth{},
+				},
+				Routing: &inferencev1.GatewaySpec_PathBasedRouting{
+					PathBasedRouting: &inferencev1.PathBasedRouting{},
+				},
+				EndpointConfiguration: &inferencev1.EndpointConfiguration{
+					EdgeProxyMode: inferencev1.EdgeProxyMode_EDGE_PROXY_MODE_DIRECT,
+				},
+			},
+			Status: &inferencev1.GatewayStatus{Status: inferencev1.Status_STATUS_READY},
+		}
+
+		m := &inference.InferenceGatewayResourceModel{
+			EndpointConfiguration: &inference.EndpointConfigurationModel{
+				AdditionalDNS:         types.SetNull(types.StringType),
+				EdgeProxyMode:         types.StringValue("EDGE_PROXY_MODE_DIRECT"),
+				AllowedSourceIPRanges: types.SetNull(cidrtypes.IPPrefixType{}),
+			},
+		}
+		diags := inference.SetFromGateway(m, gw, false)
+		if diags.HasError() {
+			t.Fatalf("SetFromGateway returned errors: %v", diags)
+		}
+		if m.EndpointConfiguration == nil {
+			t.Fatal("EndpointConfiguration: expected non-nil")
+		}
+		if !m.EndpointConfiguration.AllowedSourceIPRanges.IsNull() {
+			t.Errorf("AllowedSourceIPRanges: expected null preserved, got %v", m.EndpointConfiguration.AllowedSourceIPRanges)
+		}
+	})
 }
 
 // TestInferenceGateway_EndpointConfigurationValidation pins the client-side

--- a/coreweave/inference/resource_inference_gateway_test.go
+++ b/coreweave/inference/resource_inference_gateway_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math/rand/v2"
 	"regexp"
+	"strings"
 	"testing"
 	"time"
 
@@ -640,6 +641,62 @@ func TestInferenceGateway_WandBAuthValidation(t *testing.T) {
 					Config:      wandbAuthGatewayConfig(`api_key = "wandb-key"`),
 					PlanOnly:    true,
 					ExpectError: regexp.MustCompile(`server_url" must be specified when`),
+				},
+			},
+		})
+	})
+}
+
+// gatewayNameConfig renders a minimal gateway with the given name. Zones are
+// hardcoded (no data source) so the plan stays local and never reaches the API.
+func gatewayNameConfig(name string) string {
+	return fmt.Sprintf(`
+resource "coreweave_inference_gateway" "test" {
+  name  = %q
+  zones = ["US-EAST-04A"]
+
+  auth = {
+    coreweave = {}
+  }
+
+  routing = {
+    body_based = {
+      api_type = "API_TYPE_OPENAI"
+    }
+  }
+}
+`, name)
+}
+
+// TestInferenceGateway_NameLengthValidation pins the 38-character cap on the
+// gateway name, matching the proto max_len that keeps the derived FQDN within
+// the 64-character X.509 Common Name limit.
+func TestInferenceGateway_NameLengthValidation(t *testing.T) {
+	// A non-empty token lets the provider configure so a plan-only create can be
+	// computed; no API call is made during plan.
+	t.Setenv("COREWEAVE_API_TOKEN", "CW-SECRET-unit-test")
+
+	t.Run("38-character name is valid", func(t *testing.T) {
+		resource.UnitTest(t, resource.TestCase{
+			ProtoV6ProviderFactories: provider.TestProtoV6ProviderFactories,
+			Steps: []resource.TestStep{
+				{
+					Config:             gatewayNameConfig(strings.Repeat("a", 38)),
+					PlanOnly:           true,
+					ExpectNonEmptyPlan: true,
+				},
+			},
+		})
+	})
+
+	t.Run("39-character name is invalid", func(t *testing.T) {
+		resource.UnitTest(t, resource.TestCase{
+			ProtoV6ProviderFactories: provider.TestProtoV6ProviderFactories,
+			Steps: []resource.TestStep{
+				{
+					Config:      gatewayNameConfig(strings.Repeat("a", 39)),
+					PlanOnly:    true,
+					ExpectError: regexp.MustCompile(`string length must be at most 38`),
 				},
 			},
 		})

--- a/docs/resources/inference_capacity_claim.md
+++ b/docs/resources/inference_capacity_claim.md
@@ -51,8 +51,8 @@ Required:
 
 - `capacity_type` (String) The [capacity type](https://docs.coreweave.com/products/inference/scaling#capacity-claims) for the capacity claim. Must be `CAPACITY_TYPE_MANAGED`.
 - `instance_count` (Number) The number of instances to reserve. Must be at least 1.
-- `instance_type` (String) The instance type to reserve (e.g. `gb200-4x`).
-- `zones` (Set of String) The availability zones where the capacity claim may use resources from (e.g. `US-WEST-04A`). At least one is required.
+- `instance_type` (String) The instance type to reserve (e.g. `gb200-4x`). Case-sensitive.
+- `zones` (Set of String) The availability zones where the capacity claim may use resources from (e.g. `US-WEST-04A`), case-sensitive. At least one is required.
 
 
 <a id="nestedatt--conditions"></a>

--- a/docs/resources/inference_gateway.md
+++ b/docs/resources/inference_gateway.md
@@ -113,6 +113,8 @@ Required:
 Optional:
 
 - `additional_dns` (Set of String) Additional DNS names for the gateway endpoint. These DNS names must be manually configured to point to the gateway endpoint.
+- `allowed_source_ip_ranges` (Set of String) Client source IP ranges permitted to reach the gateway, in CIDR notation (IPv4 or IPv6). Up to 50 entries; an empty list applies no source restriction. Use a full-length prefix for a single address (e.g. `203.0.113.5/32`).
+- `edge_proxy_mode` (String) How client traffic reaches the gateway. Must be one of: `EDGE_PROXY_MODE_MANAGED`, `EDGE_PROXY_MODE_DIRECT`. When unset, the platform default (currently `EDGE_PROXY_MODE_MANAGED`) applies.
 
 
 <a id="nestedatt--conditions"></a>

--- a/docs/resources/inference_gateway.md
+++ b/docs/resources/inference_gateway.md
@@ -114,7 +114,7 @@ Optional:
 
 - `additional_dns` (Set of String) Additional DNS names for the gateway endpoint. These DNS names must be manually configured to point to the gateway endpoint.
 - `allowed_source_ip_ranges` (Set of String) Client source IP ranges permitted to reach the gateway, in CIDR notation (IPv4 or IPv6). Up to 50 entries; an empty list applies no source restriction. Use a full-length prefix for a single address (e.g. `203.0.113.5/32`).
-- `edge_proxy_mode` (String) How client traffic reaches the gateway. Must be one of: `EDGE_PROXY_MODE_MANAGED`, `EDGE_PROXY_MODE_DIRECT`. When unset, the platform default (currently `EDGE_PROXY_MODE_MANAGED`) applies.
+- `edge_proxy_mode` (String) How client traffic reaches the gateway. Must be one of: `EDGE_PROXY_MODE_MANAGED` (traffic is proxied through CoreWeave's managed edge network: DDoS mitigation and WAF, with TLS terminated at the edge and the origin address kept out of public DNS) or `EDGE_PROXY_MODE_DIRECT` (clients connect straight to the gateway's load balancer, with no edge filtering and the load balancer address published in DNS). When unset, the platform default (currently `EDGE_PROXY_MODE_MANAGED`) applies.
 
 
 <a id="nestedatt--conditions"></a>

--- a/docs/resources/inference_gateway.md
+++ b/docs/resources/inference_gateway.md
@@ -35,7 +35,7 @@ resource "coreweave_inference_gateway" "example" {
 ### Required
 
 - `auth` (Attributes) The [authentication configuration](https://docs.coreweave.com/products/inference/gateways) for the gateway. Exactly one of `coreweave` or `weights_and_biases` must be specified. (see [below for nested schema](#nestedatt--auth))
-- `name` (String) The human-readable name of the gateway.
+- `name` (String) The human-readable name of the gateway. Capped at 38 characters so the derived public FQDN fits within the 64-character X.509 Common Name limit.
 - `routing` (Attributes) The [routing configuration](https://docs.coreweave.com/products/inference/gateways) for the gateway. Exactly one of `body_based`, `header_based`, or `path_based` must be specified. (see [below for nested schema](#nestedatt--routing))
 - `zones` (Set of String) The zones to make the gateway available in. Limits where deployments associated with the gateway may exist.
 

--- a/go.mod
+++ b/go.mod
@@ -7,8 +7,8 @@ require (
 	buf.build/gen/go/coreweave/cks/protocolbuffers/go v1.36.11-20260326215135-be22b90e1aa6.1
 	buf.build/gen/go/coreweave/cwobject/connectrpc/go v1.19.1-20260729060712-bb1877226449.2
 	buf.build/gen/go/coreweave/cwobject/protocolbuffers/go v1.36.11-20260729060712-bb1877226449.1
-	buf.build/gen/go/coreweave/inference/connectrpc/go v1.20.0-20260629172746-aab7cbdc0c7d.1
-	buf.build/gen/go/coreweave/inference/protocolbuffers/go v1.36.11-20260629172746-aab7cbdc0c7d.1
+	buf.build/gen/go/coreweave/inference/connectrpc/go v1.20.0-20260825010541-7cc01a738b29.1
+	buf.build/gen/go/coreweave/inference/protocolbuffers/go v1.36.12-20260825010541-7cc01a738b29.1
 	buf.build/gen/go/coreweave/networking/connectrpc/go v1.19.1-20260121155637-a637e7777165.2
 	buf.build/gen/go/coreweave/networking/protocolbuffers/go v1.36.11-20260121155637-a637e7777165.1
 	buf.build/gen/go/coreweave/workload-federation/connectrpc/go v1.20.0-20260825153113-5bfae6057a98.1

--- a/go.sum
+++ b/go.sum
@@ -8,10 +8,10 @@ buf.build/gen/go/coreweave/cwobject/connectrpc/go v1.19.1-20260729060712-bb18772
 buf.build/gen/go/coreweave/cwobject/connectrpc/go v1.19.1-20260729060712-bb1877226449.2/go.mod h1:e88kN35aV9wjti8nBUgWA3S5KYcymennOZ5CRI4oY0c=
 buf.build/gen/go/coreweave/cwobject/protocolbuffers/go v1.36.11-20260729060712-bb1877226449.1 h1:h67dxeSusDhd1Jj5Dl/Gu7ycCIxHTK6YnUav8uQsbYc=
 buf.build/gen/go/coreweave/cwobject/protocolbuffers/go v1.36.11-20260729060712-bb1877226449.1/go.mod h1:3WufjtsvyOj3cbTSqpNCzrW0CmwZMoY0gRgKoXmvsEI=
-buf.build/gen/go/coreweave/inference/connectrpc/go v1.20.0-20260629172746-aab7cbdc0c7d.1 h1:VMykBNN1Pf9AqaU+isYebTEz+odUEmkK8Y9EJ51o3AY=
-buf.build/gen/go/coreweave/inference/connectrpc/go v1.20.0-20260629172746-aab7cbdc0c7d.1/go.mod h1:AbIMJQsn9NhIlum6zqtYl8VdkYVmlZdtKa+FelQuoyE=
-buf.build/gen/go/coreweave/inference/protocolbuffers/go v1.36.11-20260629172746-aab7cbdc0c7d.1 h1:dcqCkrIoz7WXkcKcP4FWgmsiUAi/GUeGgCU5x+RPiIE=
-buf.build/gen/go/coreweave/inference/protocolbuffers/go v1.36.11-20260629172746-aab7cbdc0c7d.1/go.mod h1:hTrh8mWkz7c4WFsceMlVfBHnYUjz8CZ6ROAOHPpsIS4=
+buf.build/gen/go/coreweave/inference/connectrpc/go v1.20.0-20260825010541-7cc01a738b29.1 h1:Y/4tqYLfM7hq4Mp1Pj7qwUuaJjXCvlAgPpexNUrwWhA=
+buf.build/gen/go/coreweave/inference/connectrpc/go v1.20.0-20260825010541-7cc01a738b29.1/go.mod h1:8axC+BDS3Nkyp6MDwOOFFI24ONED8SjdCJeEbI/ZosY=
+buf.build/gen/go/coreweave/inference/protocolbuffers/go v1.36.12-20260825010541-7cc01a738b29.1 h1:P20RBcTtI8Rnl/yfzoCLIG+v+HjdA0qAcLhCtHm09gk=
+buf.build/gen/go/coreweave/inference/protocolbuffers/go v1.36.12-20260825010541-7cc01a738b29.1/go.mod h1:zdff/ACEwQQ64HB1H7pjlX0EBi9kueSLgttCWXrPvS8=
 buf.build/gen/go/coreweave/networking/connectrpc/go v1.19.1-20260121155637-a637e7777165.2 h1:7/T8Tbyq8JVWu5ZXznB84IdZ6zN/oXeDcebMaTc+eyc=
 buf.build/gen/go/coreweave/networking/connectrpc/go v1.19.1-20260121155637-a637e7777165.2/go.mod h1:Ri2fOqnsxnYU4CdWVP0GNqzSYq7L+Zw1AV/ebdbNITs=
 buf.build/gen/go/coreweave/networking/protocolbuffers/go v1.36.11-20260121155637-a637e7777165.1 h1:HgaTPkFCzegYtbVOir7vdty10GHoFxMceoscwcH0x7s=


### PR DESCRIPTION
- Bump the inference buf modules to the latest snapshot to track current infr-api, and add the 38-character gateway name cap the API now enforces so it fails at plan time rather than on apply. Note capacity-claim instance type and zones are now case-sensitive.
- Expose gateway edge proxy mode and source IP allowlist