### PR TITLE
feat(auth): add refreshable access token source support

### DIFF
--- a/coreweave/access_token_source.go
+++ b/coreweave/access_token_source.go
@@ -1,0 +1,12 @@
+package coreweave
+
+import (
+	"context"
+)
+
+// AccessTokenSource supplies a token before each HTTP attempt. Implementations
+// must be safe for concurrent use and handle their own caching and refreshes.
+// The context belongs to the current attempt.
+type AccessTokenSource interface {
+	Token(ctx context.Context) (string, error)
+}

--- a/coreweave/caller_identity.go
+++ b/coreweave/caller_identity.go
@@ -35,7 +35,6 @@ func (c *Client) GetCallerIdentity(ctx context.Context) (CallerIdentity, error) 
 	}
 
 	request.Header.Set("Accept", "application/json")
-	request.Header.Set("Authorization", "Bearer "+c.token)
 	request.Header.Set("User-Agent", c.userAgent)
 
 	response, err := c.httpClient.Do(request)

--- a/coreweave/client.go
+++ b/coreweave/client.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"sync/atomic"
 	"time"
 
 	"buf.build/gen/go/coreweave/cks/connectrpc/go/coreweave/cks/v1beta1/cksv1beta1connect"
@@ -15,6 +16,7 @@ import (
 	"connectrpc.com/connect"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/coreweave/terraform-provider-coreweave/internal/auth"
 	retryablehttp "github.com/hashicorp/go-retryablehttp"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -25,19 +27,35 @@ type ClientOptions struct {
 	S3AttemptTimeout time.Duration
 }
 
-func NewClient(endpoint string, s3Endpoint string, timeout time.Duration, token string, userAgent string, interceptors ...connect.Interceptor) *Client {
-	return NewClientWithOptions(endpoint, s3Endpoint, timeout, token, userAgent, ClientOptions{}, interceptors...)
+var nextClientIdentity atomic.Uint64
+
+type cacheIdentityTokenSource interface {
+	CacheIdentity() string
+}
+
+func tokenSourceCacheIdentity(source AccessTokenSource) string {
+	if identified, ok := source.(cacheIdentityTokenSource); ok {
+		if identity := identified.CacheIdentity(); identity != "" {
+			return identity
+		}
+	}
+	return fmt.Sprintf("%T:%d", source, nextClientIdentity.Add(1))
+}
+
+// NewClient constructs a client that resolves a token for each HTTP attempt.
+func NewClient(endpoint string, s3Endpoint string, timeout time.Duration, tokenSource AccessTokenSource, userAgent string, interceptors ...connect.Interceptor) (*Client, error) {
+	return NewClientWithOptions(endpoint, s3Endpoint, timeout, tokenSource, userAgent, ClientOptions{}, interceptors...)
 }
 
 func NewClientWithOptions(
 	endpoint string,
 	s3Endpoint string,
 	timeout time.Duration,
-	token string,
+	tokenSource AccessTokenSource,
 	userAgent string,
 	options ClientOptions,
 	interceptors ...connect.Interceptor,
-) *Client {
+) (*Client, error) {
 	rc := retryablehttp.NewClient()
 	rc.HTTPClient.Timeout = timeout
 	rc.RetryMax = 10
@@ -49,29 +67,36 @@ func NewClientWithOptions(
 	// than 501 while rejecting permanent request and certificate failures.
 	rc.CheckRetry = RetryPolicy
 
+	authenticatedTransport, err := auth.NewTransport(rc.HTTPClient.Transport, tokenSource, endpoint)
+	if err != nil {
+		return nil, err
+	}
+	rc.HTTPClient.Transport = authenticatedTransport
+
 	c := rc.StandardClient()
+	authenticatedInterceptors := append([]connect.Interceptor{auth.NewConnectErrorInterceptor()}, interceptors...)
 
 	return &Client{
-		ClusterServiceClient: cksv1beta1connect.NewClusterServiceClient(c, endpoint, connect.WithInterceptors(interceptors...)),
-		VPCServiceClient:     networkingv1beta1connect.NewVPCServiceClient(c, endpoint, connect.WithInterceptors(interceptors...)),
+		ClusterServiceClient: cksv1beta1connect.NewClusterServiceClient(c, endpoint, connect.WithInterceptors(authenticatedInterceptors...)),
+		VPCServiceClient:     networkingv1beta1connect.NewVPCServiceClient(c, endpoint, connect.WithInterceptors(authenticatedInterceptors...)),
 		WFControlPlaneServiceClient: control_planev1beta1connect.NewWFControlPlaneServiceClient(
 			c,
 			endpoint,
-			connect.WithInterceptors(interceptors...),
+			connect.WithInterceptors(authenticatedInterceptors...),
 		),
-		CWObjectClient: cwobjectv1connect.NewCWObjectClient(c, endpoint, connect.WithInterceptors(interceptors...)),
+		CWObjectClient: cwobjectv1connect.NewCWObjectClient(c, endpoint, connect.WithInterceptors(authenticatedInterceptors...)),
 		Inference: &InferenceClient{
-			DeploymentServiceClient:    inferencev1alpha1connect.NewDeploymentServiceClient(c, endpoint, connect.WithInterceptors(interceptors...)),
-			CapacityClaimServiceClient: inferencev1alpha1connect.NewCapacityClaimServiceClient(c, endpoint, connect.WithInterceptors(interceptors...)),
-			GatewayServiceClient:       inferencev1alpha1connect.NewGatewayServiceClient(c, endpoint, connect.WithInterceptors(interceptors...)),
+			DeploymentServiceClient:    inferencev1alpha1connect.NewDeploymentServiceClient(c, endpoint, connect.WithInterceptors(authenticatedInterceptors...)),
+			CapacityClaimServiceClient: inferencev1alpha1connect.NewCapacityClaimServiceClient(c, endpoint, connect.WithInterceptors(authenticatedInterceptors...)),
+			GatewayServiceClient:       inferencev1alpha1connect.NewGatewayServiceClient(c, endpoint, connect.WithInterceptors(authenticatedInterceptors...)),
 		},
 		apiEndpoint:      endpoint,
 		httpClient:       c,
 		s3Endpoint:       s3Endpoint,
 		s3AttemptTimeout: options.S3AttemptTimeout,
-		token:            token,
+		s3CacheIdentity:  tokenSourceCacheIdentity(tokenSource),
 		userAgent:        userAgent,
-	}
+	}, nil
 }
 
 // InferenceClient groups all inference service clients.
@@ -96,7 +121,7 @@ type Client struct {
 	s3HTTPTransport  http.RoundTripper
 	s3Retryer        func() aws.Retryer
 	s3Now            func() time.Time
-	token            string
+	s3CacheIdentity  string
 	userAgent        string
 }
 
@@ -201,6 +226,24 @@ func HandleAPIError(ctx context.Context, err error, diagnostics *diag.Diagnostic
 	case connect.CodeUnauthenticated:
 		diagnostics.AddError(
 			"Unauthenticated",
+			connectErr.Error(),
+		)
+
+	case connect.CodeCanceled:
+		diagnostics.AddError(
+			"Request Canceled",
+			connectErr.Error(),
+		)
+
+	case connect.CodeDeadlineExceeded:
+		diagnostics.AddError(
+			"Request Timed Out",
+			connectErr.Error(),
+		)
+
+	case connect.CodeUnavailable:
+		diagnostics.AddError(
+			"Service Unavailable",
 			connectErr.Error(),
 		)
 

--- a/coreweave/client_internal_test.go
+++ b/coreweave/client_internal_test.go
@@ -1,0 +1,29 @@
+package coreweave
+
+import (
+	"testing"
+	"time"
+
+	"github.com/coreweave/terraform-provider-coreweave/internal/auth"
+)
+
+func TestNewClientWithOptionsAppliesS3AttemptTimeout(t *testing.T) {
+	t.Parallel()
+
+	const timeout = 17 * time.Second
+	client, err := NewClientWithOptions(
+		"https://api.example.test",
+		"https://objects.example.test",
+		time.Second,
+		auth.NewStaticTokenSource("token"),
+		"test-user-agent",
+		ClientOptions{S3AttemptTimeout: timeout},
+	)
+	if err != nil {
+		t.Fatalf("create client: %v", err)
+	}
+
+	if got := client.s3HttpClient().Timeout; got != timeout {
+		t.Fatalf("S3 HTTP attempt timeout = %s, want %s", got, timeout)
+	}
+}

--- a/coreweave/client_test.go
+++ b/coreweave/client_test.go
@@ -1,14 +1,228 @@
 package coreweave_test
 
 import (
+	"context"
 	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"testing"
+	"time"
 
+	cksv1beta1 "buf.build/gen/go/coreweave/cks/protocolbuffers/go/coreweave/cks/v1beta1"
 	"connectrpc.com/connect"
 	"github.com/coreweave/terraform-provider-coreweave/coreweave"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+var _ coreweave.AccessTokenSource = accessTokenSourceFunc(nil)
+
+type accessTokenSourceFunc func(context.Context) (string, error)
+
+func (f accessTokenSourceFunc) Token(ctx context.Context) (string, error) {
+	return f(ctx)
+}
+
+func TestNewClientValidatesItsInputs(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		endpoint string
+		source   coreweave.AccessTokenSource
+		wantErr  string
+	}{
+		"nil token source": {
+			endpoint: "https://api.example.test",
+			source:   nil,
+			wantErr:  "access token source is required",
+		},
+		"unparseable endpoint": {
+			endpoint: "https://api.example.test:port",
+			source:   accessTokenSourceFunc(func(context.Context) (string, error) { return "token", nil }),
+			wantErr:  "parsing endpoint",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			client, err := coreweave.NewClient(test.endpoint, "https://objects.example.test", time.Second, test.source, "test-user-agent")
+			require.ErrorContains(t, err, test.wantErr)
+			assert.Nil(t, client)
+		})
+	}
+}
+
+func TestNewClientAuthenticatesRequests(t *testing.T) {
+	t.Parallel()
+
+	var authorization string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		authorization = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"principal":{"uid":"principal-123","orgUid":"org-456"}}`))
+	}))
+	t.Cleanup(server.Close)
+
+	source := accessTokenSourceFunc(func(context.Context) (string, error) { return "static-token", nil })
+	client, err := coreweave.NewClient(server.URL, "https://objects.example.test", time.Second, source, "test-user-agent")
+	require.NoError(t, err)
+
+	_, err = client.GetCallerIdentity(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, "Bearer static-token", authorization)
+}
+
+func TestClientPropagatesTokenSourceErrors(t *testing.T) {
+	t.Parallel()
+
+	calls := 0
+	source := accessTokenSourceFunc(func(context.Context) (string, error) {
+		calls++
+		return "", errors.New("token refresh failed")
+	})
+	client, err := coreweave.NewClient(
+		"https://api.example.test",
+		"https://objects.example.test",
+		time.Second,
+		source,
+		"test-user-agent",
+	)
+	require.NoError(t, err)
+
+	t.Run("ConnectRPC", func(t *testing.T) {
+		_, err := client.GetCluster(t.Context(), connect.NewRequest(&cksv1beta1.GetClusterRequest{}))
+		require.ErrorContains(t, err, "getting access token: token refresh failed")
+
+		var connectErr *connect.Error
+		require.ErrorAs(t, err, &connectErr)
+		assert.Equal(t, connect.CodeUnauthenticated, connectErr.Code())
+
+		var diagnostics diag.Diagnostics
+		coreweave.HandleAPIError(t.Context(), err, &diagnostics)
+		require.Len(t, diagnostics, 1)
+		assert.Equal(t, "Unauthenticated", diagnostics[0].Summary())
+	})
+
+	t.Run("raw HTTP", func(t *testing.T) {
+		_, err := client.GetCallerIdentity(t.Context())
+		require.ErrorContains(t, err, "getting access token: token refresh failed")
+	})
+
+	assert.Equal(t, 2, calls, "token-source failures must not be retried")
+}
+
+func TestClientPreservesTokenSourceCancellation(t *testing.T) {
+	t.Parallel()
+
+	calls := 0
+	source := accessTokenSourceFunc(func(context.Context) (string, error) {
+		calls++
+		return "", context.Canceled
+	})
+	client, err := coreweave.NewClient(
+		"https://api.example.test",
+		"https://objects.example.test",
+		time.Second,
+		source,
+		"test-user-agent",
+	)
+	require.NoError(t, err)
+
+	_, err = client.GetCluster(t.Context(), connect.NewRequest(&cksv1beta1.GetClusterRequest{}))
+	var connectErr *connect.Error
+	require.ErrorAs(t, err, &connectErr)
+	assert.Equal(t, connect.CodeCanceled, connectErr.Code())
+	assert.Equal(t, 1, calls, "a canceled request must not be retried")
+}
+
+// A deadline belongs to a single attempt, so a token refresh that runs out of
+// time gets another one -- unlike every other token source failure, which means
+// the source itself gave up.
+func TestClientRetriesTokenSourceDeadline(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"principal":{"uid":"principal-123","orgUid":"org-456"}}`))
+	}))
+	t.Cleanup(server.Close)
+
+	calls := 0
+	source := accessTokenSourceFunc(func(context.Context) (string, error) {
+		calls++
+		if calls == 1 {
+			return "", context.DeadlineExceeded
+		}
+		return "token", nil
+	})
+	client, err := coreweave.NewClient(server.URL, "https://objects.example.test", time.Second, source, "test-user-agent")
+	require.NoError(t, err)
+
+	identity, err := client.GetCallerIdentity(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, "principal-123", identity.PrincipalID)
+	assert.Equal(t, 2, calls, "the attempt that ran out of time must be retried")
+}
+
+func TestClientRefreshesTokenForRawHTTPRetry(t *testing.T) {
+	t.Parallel()
+
+	var authorizationHeaders []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		authorizationHeaders = append(authorizationHeaders, r.Header.Get("Authorization"))
+		if len(authorizationHeaders) == 1 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"principal":{"uid":"principal-123","orgUid":"org-456"}}`))
+	}))
+	t.Cleanup(server.Close)
+
+	call := 0
+	source := accessTokenSourceFunc(func(context.Context) (string, error) {
+		call++
+		return fmt.Sprintf("token-%d", call), nil
+	})
+	client, err := coreweave.NewClient(server.URL, "https://objects.example.test", time.Second, source, "test-user-agent")
+	require.NoError(t, err)
+
+	identity, err := client.GetCallerIdentity(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, "principal-123", identity.PrincipalID)
+	assert.Equal(t, []string{"Bearer token-1", "Bearer token-2"}, authorizationHeaders)
+}
+
+func TestClientRefreshesTokenForConnectRetry(t *testing.T) {
+	t.Parallel()
+
+	var authorizationHeaders []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		authorizationHeaders = append(authorizationHeaders, r.Header.Get("Authorization"))
+		if len(authorizationHeaders) == 1 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(server.Close)
+
+	call := 0
+	source := accessTokenSourceFunc(func(context.Context) (string, error) {
+		call++
+		return fmt.Sprintf("token-%d", call), nil
+	})
+	client, err := coreweave.NewClient(server.URL, "https://objects.example.test", time.Second, source, "test-user-agent")
+	require.NoError(t, err)
+
+	_, err = client.GetCluster(t.Context(), connect.NewRequest(&cksv1beta1.GetClusterRequest{}))
+	require.Error(t, err)
+	assert.Equal(t, []string{"Bearer token-1", "Bearer token-2"}, authorizationHeaders)
+}
 
 func TestHandleAPIError(t *testing.T) {
 	t.Parallel()
@@ -26,11 +240,32 @@ func TestHandleAPIError(t *testing.T) {
 				"An unexpected error occurred: \"weird error\". Please check the provider logs for more details.",
 			)},
 		}, {
-			name: "Permission denied error",
+			name: "Internal error",
 			err:  connect.NewError(connect.CodeInternal, errors.New("Internal server error")),
 			want: diag.Diagnostics{diag.NewErrorDiagnostic(
 				"Internal Error",
 				"An unexpected server error occurred: \"internal: Internal server error\". Please check the provider logs for more details.",
+			)},
+		}, {
+			name: "Canceled error",
+			err:  connect.NewError(connect.CodeCanceled, errors.New("token request canceled")),
+			want: diag.Diagnostics{diag.NewErrorDiagnostic(
+				"Request Canceled",
+				"canceled: token request canceled",
+			)},
+		}, {
+			name: "Deadline exceeded error",
+			err:  connect.NewError(connect.CodeDeadlineExceeded, errors.New("token request timed out")),
+			want: diag.Diagnostics{diag.NewErrorDiagnostic(
+				"Request Timed Out",
+				"deadline_exceeded: token request timed out",
+			)},
+		}, {
+			name: "Unavailable error",
+			err:  connect.NewError(connect.CodeUnavailable, errors.New("identity provider unreachable")),
+			want: diag.Diagnostics{diag.NewErrorDiagnostic(
+				"Service Unavailable",
+				"unavailable: identity provider unreachable",
 			)},
 		},
 	}

--- a/coreweave/retry.go
+++ b/coreweave/retry.go
@@ -8,6 +8,8 @@ import (
 	"net/http"
 	"net/url"
 	"regexp"
+
+	"github.com/coreweave/terraform-provider-coreweave/internal/auth"
 )
 
 var (
@@ -102,8 +104,14 @@ func RetryPolicy(ctx context.Context, resp *http.Response, err error) (bool, err
 		return true, ctx.Err()
 	}
 
+	// Retry an attempt-level timeout with a freshly resolved token.
 	if errors.Is(err, context.DeadlineExceeded) {
 		return true, err
+	}
+
+	// Token sources own their retry policy; do not retry their other failures.
+	if auth.IsTokenSourceError(err) {
+		return false, err
 	}
 
 	return baseRetryPolicy(resp, err)

--- a/coreweave/retry_test.go
+++ b/coreweave/retry_test.go
@@ -3,8 +3,12 @@ package coreweave
 import (
 	"crypto/tls"
 	"errors"
+	"net/http"
 	"net/url"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestBaseRetryPolicyRejectsWrappedPermanentRequestErrors(t *testing.T) {
@@ -26,12 +30,65 @@ func TestBaseRetryPolicyRejectsWrappedPermanentRequestErrors(t *testing.T) {
 			t.Parallel()
 
 			retry, err := baseRetryPolicy(nil, requestErr)
-			if retry {
-				t.Fatal("baseRetryPolicy() marked a permanent request error retryable")
+			assert.False(t, retry)
+			require.ErrorIs(t, err, requestErr)
+		})
+	}
+}
+
+func TestRetryPolicyTransportErrors(t *testing.T) {
+	t.Parallel()
+
+	urlErr := func(err error) error {
+		return &url.Error{Op: "Get", URL: "https://api.example.test", Err: err}
+	}
+
+	tests := map[string]struct {
+		err       error
+		wantRetry bool
+	}{
+		"too many redirects":          {err: urlErr(errors.New("stopped after 10 redirects"))},
+		"unsupported protocol scheme": {err: urlErr(errors.New(`unsupported protocol scheme "ftp"`))},
+		"invalid header":              {err: urlErr(errors.New("net/http: invalid header field value"))},
+		"untrusted certificate": {
+			err: urlErr(&tls.CertificateVerificationError{Err: errors.New("certificate is not trusted")}),
+		},
+		"connection reset": {err: urlErr(errors.New("read: connection reset by peer")), wantRetry: true},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			retry, err := RetryPolicy(t.Context(), nil, test.err)
+			assert.Equal(t, test.wantRetry, retry)
+			if !test.wantRetry {
+				require.Error(t, err, "non-retryable transport errors must be surfaced to the caller")
 			}
-			if !errors.Is(err, requestErr) {
-				t.Fatalf("baseRetryPolicy() error = %v, want wrapped request error %v", err, requestErr)
-			}
+		})
+	}
+}
+
+func TestRetryPolicyResponses(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		status    int
+		wantRetry bool
+	}{
+		"too many requests":   {status: http.StatusTooManyRequests, wantRetry: true},
+		"service unavailable": {status: http.StatusServiceUnavailable, wantRetry: true},
+		"not implemented":     {status: http.StatusNotImplemented},
+		"unauthorized":        {status: http.StatusUnauthorized},
+		"ok":                  {status: http.StatusOK},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			retry, _ := RetryPolicy(t.Context(), &http.Response{StatusCode: test.status}, nil)
+			assert.Equal(t, test.wantRetry, retry)
 		})
 	}
 }

--- a/coreweave/s3.go
+++ b/coreweave/s3.go
@@ -38,7 +38,7 @@ type s3ClientCache struct {
 	accessKeyInfo  *cwobjectv1.CreateAccessKeyFromJWTResponse
 	apiEndpoint    string
 	endpoint       string
-	token          string
+	authIdentity   string
 	attemptTimeout time.Duration
 	refresh        *s3ClientRefresh
 }
@@ -172,7 +172,7 @@ func (c *Client) S3Client(ctx context.Context, zone string) (*s3.Client, error) 
 		sharedS3ClientCache.mu.Lock()
 		identityMatches := sharedS3ClientCache.apiEndpoint == c.apiEndpoint &&
 			sharedS3ClientCache.endpoint == c.s3Endpoint &&
-			sharedS3ClientCache.token == c.token &&
+			sharedS3ClientCache.authIdentity == c.s3CacheIdentity &&
 			sharedS3ClientCache.attemptTimeout == c.effectiveS3AttemptTimeout()
 		if sharedS3ClientCache.refresh != nil && !identityMatches {
 			refresh := sharedS3ClientCache.refresh
@@ -187,7 +187,7 @@ func (c *Client) S3Client(ctx context.Context, zone string) (*s3.Client, error) 
 			sharedS3ClientCache.accessKeyInfo = nil
 			sharedS3ClientCache.apiEndpoint = c.apiEndpoint
 			sharedS3ClientCache.endpoint = c.s3Endpoint
-			sharedS3ClientCache.token = c.token
+			sharedS3ClientCache.authIdentity = c.s3CacheIdentity
 			sharedS3ClientCache.attemptTimeout = c.effectiveS3AttemptTimeout()
 		}
 
@@ -306,7 +306,7 @@ func resetS3ClientCache() {
 	sharedS3ClientCache.accessKeyInfo = nil
 	sharedS3ClientCache.apiEndpoint = ""
 	sharedS3ClientCache.endpoint = ""
-	sharedS3ClientCache.token = ""
+	sharedS3ClientCache.authIdentity = ""
 	sharedS3ClientCache.attemptTimeout = 0
 	sharedS3ClientCache.refresh = nil
 }

--- a/coreweave/s3_test.go
+++ b/coreweave/s3_test.go
@@ -433,10 +433,10 @@ func TestS3ClientWaitersShareRefreshFailure(t *testing.T) {
 		err:     refreshErr,
 	}
 	client := &Client{
-		CWObjectClient: stub,
-		apiEndpoint:    "https://api.example.test",
-		s3Endpoint:     "https://objects.example.test",
-		token:          "test-token",
+		CWObjectClient:  stub,
+		apiEndpoint:     "https://api.example.test",
+		s3Endpoint:      "https://objects.example.test",
+		s3CacheIdentity: "test-token",
 	}
 
 	type result struct {
@@ -498,7 +498,7 @@ func TestS3ClientCanceledLeaderDoesNotFailHealthyWaiter(t *testing.T) {
 		apiEndpoint:     "https://api.example.test",
 		s3Endpoint:      "https://objects.example.test",
 		s3HTTPTransport: successfulListBucketsRoundTripper{},
-		token:           "test-token",
+		s3CacheIdentity: "test-token",
 	}
 	type result struct {
 		client *s3.Client
@@ -565,7 +565,7 @@ func TestS3ClientServesUnexpiredClientDuringRefresh(t *testing.T) {
 	}
 	sharedS3ClientCache.apiEndpoint = "https://api.example.test"
 	sharedS3ClientCache.endpoint = "https://objects.example.test"
-	sharedS3ClientCache.token = "test-token"
+	sharedS3ClientCache.authIdentity = "test-token"
 	sharedS3ClientCache.attemptTimeout = DefaultS3AttemptTimeout
 	sharedS3ClientCache.mu.Unlock()
 
@@ -575,11 +575,11 @@ func TestS3ClientServesUnexpiredClientDuringRefresh(t *testing.T) {
 		err:     errors.New("refresh failed"),
 	}
 	client := &Client{
-		CWObjectClient: stub,
-		apiEndpoint:    "https://api.example.test",
-		s3Endpoint:     "https://objects.example.test",
-		token:          "test-token",
-		s3Now:          func() time.Time { return now },
+		CWObjectClient:  stub,
+		apiEndpoint:     "https://api.example.test",
+		s3Endpoint:      "https://objects.example.test",
+		s3CacheIdentity: "test-token",
+		s3Now:           func() time.Time { return now },
 	}
 
 	type result struct {

--- a/coreweave/s3_test.go
+++ b/coreweave/s3_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/smithy-go"
 	smithyhttp "github.com/aws/smithy-go/transport/http"
+	"github.com/coreweave/terraform-provider-coreweave/internal/auth"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -357,6 +358,129 @@ func TestCreateS3Client_UsesOneBoundedRetryLayer(t *testing.T) {
 	}
 	if got := transport.count.Load(); got != s3MaxAttempts {
 		t.Fatalf("transport sends = %d, want exactly %d", got, s3MaxAttempts)
+	}
+}
+
+type principalS3CWObjectClientStub struct {
+	cwobjectv1connect.CWObjectClient
+	accessKeyID string
+	calls       atomic.Int32
+}
+
+func (s *principalS3CWObjectClientStub) CreateAccessKeyFromJWT(
+	context.Context,
+	*connect.Request[cwobjectv1.CreateAccessKeyFromJWTRequest],
+) (*connect.Response[cwobjectv1.CreateAccessKeyFromJWTResponse], error) {
+	s.calls.Add(1)
+	return connect.NewResponse(&cwobjectv1.CreateAccessKeyFromJWTResponse{
+		AccessKeyId: s.accessKeyID,
+		SecretKey:   "secret-" + s.accessKeyID,
+		Expiry:      timestamppb.New(time.Now().Add(15 * time.Minute)),
+	}), nil
+}
+
+func newS3CacheTestClient(t *testing.T, token string, service cwobjectv1connect.CWObjectClient) *Client {
+	t.Helper()
+
+	client, err := NewClient(
+		"https://api.example.test",
+		"https://objects.example.test",
+		time.Second,
+		auth.NewStaticTokenSource(token),
+		"test-user-agent",
+	)
+	if err != nil {
+		t.Fatalf("create client: %v", err)
+	}
+	client.CWObjectClient = service
+	client.s3HTTPTransport = successfulListBucketsRoundTripper{}
+	return client
+}
+
+func s3AccessKeyID(t *testing.T, client *s3.Client) string {
+	t.Helper()
+
+	credentials, err := client.Options().Credentials.Retrieve(t.Context())
+	if err != nil {
+		t.Fatalf("retrieve S3 credentials: %v", err)
+	}
+	return credentials.AccessKeyID
+}
+
+func TestS3ClientCacheIsolatedAcrossAuthPrincipals(t *testing.T) {
+	resetS3ClientCache()
+	t.Cleanup(resetS3ClientCache)
+
+	principalA := &principalS3CWObjectClientStub{accessKeyID: "principal-a-key"}
+	clientA := newS3CacheTestClient(t, "principal-a-token", principalA)
+	s3ClientA, err := clientA.S3Client(t.Context(), "US-TEST-01A")
+	if err != nil {
+		t.Fatalf("create principal A S3 client: %v", err)
+	}
+
+	principalB := &principalS3CWObjectClientStub{accessKeyID: "principal-b-key"}
+	clientB := newS3CacheTestClient(t, "principal-b-token", principalB)
+	s3ClientB, err := clientB.S3Client(t.Context(), "US-TEST-01A")
+	if err != nil {
+		t.Fatalf("create principal B S3 client: %v", err)
+	}
+
+	if s3ClientA == s3ClientB {
+		t.Fatal("different auth principals reused the same cached S3 client")
+	}
+	if got := s3AccessKeyID(t, s3ClientA); got != "principal-a-key" {
+		t.Fatalf("principal A access key = %q, want %q", got, "principal-a-key")
+	}
+	if got := s3AccessKeyID(t, s3ClientB); got != "principal-b-key" {
+		t.Fatalf("principal B access key = %q, want %q", got, "principal-b-key")
+	}
+	if got := principalA.calls.Load(); got != 1 {
+		t.Fatalf("principal A access-key requests = %d, want 1", got)
+	}
+	if got := principalB.calls.Load(); got != 1 {
+		t.Fatalf("principal B access-key requests = %d, want 1", got)
+	}
+}
+
+func TestS3ClientCacheReusedForSameStaticCredential(t *testing.T) {
+	resetS3ClientCache()
+	t.Cleanup(resetS3ClientCache)
+
+	firstService := &principalS3CWObjectClientStub{accessKeyID: "shared-key"}
+	firstClient := newS3CacheTestClient(t, "shared-token", firstService)
+	firstS3Client, err := firstClient.S3Client(t.Context(), "US-TEST-01A")
+	if err != nil {
+		t.Fatalf("create first S3 client: %v", err)
+	}
+
+	secondService := &principalS3CWObjectClientStub{accessKeyID: "unexpected-key"}
+	secondClient := newS3CacheTestClient(t, "shared-token", secondService)
+	secondS3Client, err := secondClient.S3Client(t.Context(), "US-TEST-01A")
+	if err != nil {
+		t.Fatalf("get cached S3 client: %v", err)
+	}
+
+	if firstS3Client != secondS3Client {
+		t.Fatal("clients with the same static credential did not share the cached S3 client")
+	}
+	if got := secondService.calls.Load(); got != 0 {
+		t.Fatalf("second access-key service calls = %d, want 0", got)
+	}
+}
+
+type unkeyedTokenSource func(context.Context) (string, error)
+
+func (s unkeyedTokenSource) Token(ctx context.Context) (string, error) {
+	return s(ctx)
+}
+
+func TestTokenSourcesWithoutCacheIdentityAreIsolated(t *testing.T) {
+	source := unkeyedTokenSource(func(context.Context) (string, error) { return "token", nil })
+	first := tokenSourceCacheIdentity(source)
+	second := tokenSourceCacheIdentity(source)
+
+	if first == second {
+		t.Fatal("token source without a stable cache identity was shared across clients")
 	}
 }
 

--- a/internal/auth/connect.go
+++ b/internal/auth/connect.go
@@ -1,0 +1,57 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"net"
+
+	"connectrpc.com/connect"
+)
+
+// NewConnectErrorInterceptor classifies authentication transport errors for
+// unary Connect calls.
+func NewConnectErrorInterceptor() connect.Interceptor {
+	return connect.UnaryInterceptorFunc(func(next connect.UnaryFunc) connect.UnaryFunc {
+		return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
+			resp, err := next(ctx, req)
+			if err != nil {
+				return nil, classifyError(err)
+			}
+			return resp, nil
+		}
+	})
+}
+
+// classifyError gives the transport's own errors a Connect code. Errors that
+// did not originate in the transport are returned untouched, so a code the
+// server assigned is never overwritten.
+func classifyError(err error) error {
+	if err == nil || !IsTokenSourceError(err) {
+		return err
+	}
+
+	var code connect.Code
+	switch {
+	case errors.Is(err, context.Canceled):
+		code = connect.CodeCanceled
+	case errors.Is(err, context.DeadlineExceeded):
+		code = connect.CodeDeadlineExceeded
+	case tokenSourceFailedOnNetwork(err):
+		// Point operators at connectivity rather than credentials.
+		code = connect.CodeUnavailable
+	default:
+		code = connect.CodeUnauthenticated
+	}
+	return connect.NewError(code, err)
+}
+
+// Inspect the source error rather than http.Client's outer *url.Error.
+func tokenSourceFailedOnNetwork(err error) bool {
+	var tokenErr *TokenSourceError
+	if !errors.As(err, &tokenErr) {
+		return false
+	}
+
+	var netErr net.Error
+	return errors.As(tokenErr.Unwrap(), &netErr)
+}

--- a/internal/auth/connect_internal_test.go
+++ b/internal/auth/connect_internal_test.go
@@ -1,0 +1,77 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/url"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// wrapAsTransportError mimics what reaches an interceptor: http.Client wraps
+// every RoundTrip error in a *url.Error, which is itself a net.Error.
+func wrapAsTransportError(err error) error {
+	return &url.Error{Op: "Post", URL: "https://api.example.test", Err: err}
+}
+
+func TestClassifyError(t *testing.T) {
+	t.Parallel()
+
+	unreachable := &net.OpError{Op: "dial", Err: errors.New("connection refused")}
+
+	tests := map[string]struct {
+		err           error
+		wantCode      connect.Code
+		wantUntouched bool
+	}{
+		"nil": {
+			err:           nil,
+			wantUntouched: true,
+		},
+		"not from the transport": {
+			err:           wrapAsTransportError(errors.New("connection reset by peer")),
+			wantUntouched: true,
+		},
+		"already classified by the server": {
+			err:           connect.NewError(connect.CodeNotFound, errors.New("no such cluster")),
+			wantUntouched: true,
+		},
+		"canceled": {
+			err:      wrapAsTransportError(&TokenSourceError{err: context.Canceled}),
+			wantCode: connect.CodeCanceled,
+		},
+		"deadline exceeded": {
+			err:      wrapAsTransportError(&TokenSourceError{err: context.DeadlineExceeded}),
+			wantCode: connect.CodeDeadlineExceeded,
+		},
+		"token endpoint unreachable": {
+			err:      wrapAsTransportError(&TokenSourceError{err: unreachable}),
+			wantCode: connect.CodeUnavailable,
+		},
+		"credentials rejected": {
+			err:      wrapAsTransportError(&TokenSourceError{err: errors.New("invalid client secret")}),
+			wantCode: connect.CodeUnauthenticated,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := classifyError(test.err)
+			if test.wantUntouched {
+				assert.Equal(t, test.err, got)
+				return
+			}
+
+			var connectErr *connect.Error
+			require.ErrorAs(t, got, &connectErr)
+			assert.Equal(t, test.wantCode, connectErr.Code())
+			require.ErrorIs(t, got, test.err, "the original error must stay in the chain")
+		})
+	}
+}

--- a/internal/auth/errors.go
+++ b/internal/auth/errors.go
@@ -1,0 +1,22 @@
+package auth
+
+import "errors"
+
+// TokenSourceError reports that a request could not obtain an access token.
+// It deliberately contains only the source error, never the token value.
+type TokenSourceError struct {
+	err error
+}
+
+func (e *TokenSourceError) Error() string {
+	return "getting access token: " + e.err.Error()
+}
+
+func (e *TokenSourceError) Unwrap() error {
+	return e.err
+}
+
+func IsTokenSourceError(err error) bool {
+	var tokenErr *TokenSourceError
+	return errors.As(err, &tokenErr)
+}

--- a/internal/auth/token_source.go
+++ b/internal/auth/token_source.go
@@ -1,0 +1,55 @@
+package auth
+
+import (
+	"context"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"net/http"
+)
+
+type accessTokenSource interface {
+	Token(ctx context.Context) (string, error)
+}
+
+// StaticTokenSource supplies the same non-expiring token for every request.
+type StaticTokenSource struct {
+	token string
+}
+
+// NewStaticTokenSource returns an access token source backed by token.
+func NewStaticTokenSource(token string) *StaticTokenSource {
+	return &StaticTokenSource{token: token}
+}
+
+// Token returns the static token, which never expires and never fails.
+//
+//nolint:unparam // The error return is required by AccessTokenSource.
+func (s *StaticTokenSource) Token(context.Context) (string, error) {
+	return s.token, nil
+}
+
+// CacheIdentity identifies clients using the same static credential without
+// retaining that credential in the S3 client cache.
+func (s *StaticTokenSource) CacheIdentity() string {
+	return fmt.Sprintf("static:%x", sha256.Sum256([]byte(s.token)))
+}
+
+// SetAuthorizationHeader obtains the current access token and adds it to the
+// supplied headers without exposing the token to callers or error messages.
+func SetAuthorizationHeader(ctx context.Context, header http.Header, source accessTokenSource) error {
+	if source == nil {
+		return &TokenSourceError{err: errors.New("access token source is required")}
+	}
+
+	token, err := source.Token(ctx)
+	if err != nil {
+		return &TokenSourceError{err: err}
+	}
+	if token == "" {
+		return &TokenSourceError{err: errors.New("access token source returned an empty token")}
+	}
+
+	header.Set("Authorization", "Bearer "+token)
+	return nil
+}

--- a/internal/auth/token_source_test.go
+++ b/internal/auth/token_source_test.go
@@ -167,6 +167,7 @@ func TestTransportAuthenticatesOnlyTheConfiguredOrigin(t *testing.T) {
 			require.NoError(t, err)
 			req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, test.requestURL, nil)
 			require.NoError(t, err)
+			req.Header.Set("Authorization", "Bearer caller-token")
 			_, err = transport.RoundTrip(req)
 			require.NoError(t, err)
 
@@ -176,6 +177,7 @@ func TestTransportAuthenticatesOnlyTheConfiguredOrigin(t *testing.T) {
 			} else {
 				assert.Empty(t, authorization)
 			}
+			assert.Equal(t, "Bearer caller-token", req.Header.Get("Authorization"), "transport must not mutate the caller's request")
 		})
 	}
 }

--- a/internal/auth/token_source_test.go
+++ b/internal/auth/token_source_test.go
@@ -36,6 +36,18 @@ func TestStaticTokenSource(t *testing.T) {
 	assert.Equal(t, "static-token", token)
 }
 
+func TestStaticTokenSourceCacheIdentity(t *testing.T) {
+	t.Parallel()
+
+	first := auth.NewStaticTokenSource("first-token")
+	same := auth.NewStaticTokenSource("first-token")
+	different := auth.NewStaticTokenSource("different-token")
+
+	assert.Equal(t, first.CacheIdentity(), same.CacheIdentity())
+	assert.NotEqual(t, first.CacheIdentity(), different.CacheIdentity())
+	assert.NotContains(t, first.CacheIdentity(), "first-token")
+}
+
 func TestTransportGetsTokenForEachAttempt(t *testing.T) {
 	t.Parallel()
 

--- a/internal/auth/token_source_test.go
+++ b/internal/auth/token_source_test.go
@@ -1,0 +1,329 @@
+package auth_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/coreweave/terraform-provider-coreweave/internal/auth"
+	"github.com/hashicorp/terraform-plugin-log/tflogtest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type tokenSourceFunc func(context.Context) (string, error)
+
+func (f tokenSourceFunc) Token(ctx context.Context) (string, error) {
+	return f(ctx)
+}
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func TestStaticTokenSource(t *testing.T) {
+	t.Parallel()
+
+	source := auth.NewStaticTokenSource("static-token")
+	token, err := source.Token(t.Context())
+
+	require.NoError(t, err)
+	assert.Equal(t, "static-token", token)
+}
+
+func TestTransportGetsTokenForEachAttempt(t *testing.T) {
+	t.Parallel()
+
+	tokens := []string{"first-token", "refreshed-token"}
+	call := 0
+	source := tokenSourceFunc(func(context.Context) (string, error) {
+		token := tokens[call]
+		call++
+		return token, nil
+	})
+
+	var authorizationHeaders []string
+	base := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		authorizationHeaders = append(authorizationHeaders, req.Header.Get("Authorization"))
+		return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody}, nil
+	})
+	transport, err := auth.NewTransport(base, source, "https://api.example.test")
+	require.NoError(t, err)
+
+	for range tokens {
+		req, reqErr := http.NewRequestWithContext(t.Context(), http.MethodGet, "https://api.example.test", nil)
+		require.NoError(t, reqErr)
+		_, roundTripErr := transport.RoundTrip(req)
+		require.NoError(t, roundTripErr)
+	}
+
+	assert.Equal(t, []string{"Bearer first-token", "Bearer refreshed-token"}, authorizationHeaders)
+}
+
+func TestTransportReturnsTypedTokenSourceError(t *testing.T) {
+	t.Parallel()
+
+	source := tokenSourceFunc(func(context.Context) (string, error) {
+		return "", errors.New("exchange unavailable")
+	})
+	baseCalled := false
+	base := roundTripperFunc(func(*http.Request) (*http.Response, error) {
+		baseCalled = true
+		return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody}, nil
+	})
+	transport, err := auth.NewTransport(base, source, "https://api.example.test")
+	require.NoError(t, err)
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "https://api.example.test", nil)
+	require.NoError(t, err)
+	_, err = transport.RoundTrip(req)
+
+	require.ErrorContains(t, err, "getting access token: exchange unavailable")
+	assert.True(t, auth.IsTokenSourceError(err))
+	assert.False(t, baseCalled)
+}
+
+func TestTransportAuthenticatesOnlyTheConfiguredOrigin(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		endpoint        string
+		requestURL      string
+		wantAuthemitted bool
+	}{
+		"same origin": {
+			endpoint:        "https://api.example.test",
+			requestURL:      "https://api.example.test",
+			wantAuthemitted: true,
+		},
+		"host differing only in case": {
+			endpoint:        "https://api.example.test",
+			requestURL:      "https://API.EXAMPLE.TEST",
+			wantAuthemitted: true,
+		},
+		"redirect to another host": {
+			endpoint:        "https://api.example.test",
+			requestURL:      "https://redirected.example.test",
+			wantAuthemitted: false,
+		},
+		"same host upgraded to https": {
+			endpoint:        "http://api.example.test",
+			requestURL:      "https://api.example.test",
+			wantAuthemitted: true,
+		},
+		"same host downgraded to http": {
+			endpoint:        "https://api.example.test",
+			requestURL:      "http://api.example.test",
+			wantAuthemitted: false,
+		},
+		"explicit default https port": {
+			endpoint:        "https://api.example.test",
+			requestURL:      "https://api.example.test:443",
+			wantAuthemitted: true,
+		},
+		"explicit default http port": {
+			endpoint:        "http://api.example.test:80",
+			requestURL:      "http://api.example.test",
+			wantAuthemitted: true,
+		},
+		"non-default port": {
+			endpoint:        "https://api.example.test",
+			requestURL:      "https://api.example.test:8443",
+			wantAuthemitted: false,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			sourceCalled := false
+			source := tokenSourceFunc(func(context.Context) (string, error) {
+				sourceCalled = true
+				return "secret-token", nil
+			})
+			var authorization string
+			base := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+				authorization = req.Header.Get("Authorization")
+				return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody}, nil
+			})
+			transport, err := auth.NewTransport(base, source, test.endpoint)
+			require.NoError(t, err)
+			req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, test.requestURL, nil)
+			require.NoError(t, err)
+			_, err = transport.RoundTrip(req)
+			require.NoError(t, err)
+
+			assert.Equal(t, test.wantAuthemitted, sourceCalled)
+			if test.wantAuthemitted {
+				assert.Equal(t, "Bearer secret-token", authorization)
+			} else {
+				assert.Empty(t, authorization)
+			}
+		})
+	}
+}
+
+func TestNewTransportRejectsUnusableEndpoints(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		endpoint string
+		wantErr  string
+	}{
+		"unparseable": {
+			endpoint: "https://api.example.test:port",
+			wantErr:  "parsing endpoint",
+		},
+		"empty": {
+			endpoint: "",
+			wantErr:  "must be an absolute http or https URL",
+		},
+		"no scheme or host": {
+			endpoint: "api.example.test/v1",
+			wantErr:  "must be an absolute http or https URL",
+		},
+		"scheme-relative": {
+			endpoint: "//api.example.test",
+			wantErr:  "must be an absolute http or https URL",
+		},
+		"non-http scheme": {
+			endpoint: "ftp://api.example.test",
+			wantErr:  "must be an absolute http or https URL",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			transport, err := auth.NewTransport(nil, auth.NewStaticTokenSource("token"), test.endpoint)
+			require.ErrorContains(t, err, test.wantErr)
+			assert.Nil(t, transport)
+		})
+	}
+}
+
+func TestNewTransportRequiresATokenSource(t *testing.T) {
+	t.Parallel()
+
+	var typedNil *auth.StaticTokenSource
+	tests := map[string]coreweaveAccessTokenSource{
+		"nil interface": nil,
+		"typed nil":     typedNil,
+	}
+
+	for name, source := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			transport, err := auth.NewTransport(nil, source, "https://api.example.test")
+
+			require.ErrorContains(t, err, "access token source is required")
+			assert.Nil(t, transport)
+		})
+	}
+}
+
+type coreweaveAccessTokenSource interface {
+	Token(context.Context) (string, error)
+}
+
+func TestTransportWarnsWhenAuthenticationIsSkipped(t *testing.T) {
+	t.Parallel()
+
+	var logbuf bytes.Buffer
+	ctx := tflogtest.RootLogger(t.Context(), &logbuf)
+	base := roundTripperFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: http.StatusUnauthorized, Body: http.NoBody}, nil
+	})
+	transport, err := auth.NewTransport(base, auth.NewStaticTokenSource("token"), "https://api.example.test:8443")
+	require.NoError(t, err)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://api.example.test/path?secret=do-not-log", nil)
+	require.NoError(t, err)
+
+	_, err = transport.RoundTrip(req)
+	require.NoError(t, err)
+
+	entries, err := tflogtest.MultilineJSONDecode(bytes.NewReader(logbuf.Bytes()))
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.Equal(t, "warn", entries[0]["@level"])
+	assert.Equal(t, "https://api.example.test", entries[0]["request_origin"])
+	assert.Equal(t, "https://api.example.test:8443", entries[0]["configured_origin"])
+	assert.NotContains(t, logbuf.String(), "do-not-log")
+}
+
+// http.RoundTripper requires RoundTrip to close the request body even when it
+// returns an error; net/http leaves that to the RoundTripper.
+func TestTransportClosesRequestBodyOnError(t *testing.T) {
+	t.Parallel()
+
+	newRequest := func(t *testing.T, body *trackedBody) *http.Request {
+		t.Helper()
+
+		req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, "https://api.example.test", body)
+		require.NoError(t, err)
+		return req
+	}
+
+	t.Run("token source failure", func(t *testing.T) {
+		t.Parallel()
+
+		source := tokenSourceFunc(func(context.Context) (string, error) {
+			return "", errors.New("exchange unavailable")
+		})
+		transport, err := auth.NewTransport(nil, source, "https://api.example.test")
+		require.NoError(t, err)
+
+		body := &trackedBody{}
+		_, err = transport.RoundTrip(newRequest(t, body))
+
+		require.Error(t, err)
+		assert.True(t, body.closed, "the request body must be closed when RoundTrip fails")
+	})
+}
+
+type trackedBody struct {
+	closed bool
+}
+
+func (b *trackedBody) Read([]byte) (int, error) {
+	return 0, io.EOF
+}
+
+//nolint:unparam // The error return is required by io.ReadCloser.
+func (b *trackedBody) Close() error {
+	b.closed = true
+	return nil
+}
+
+func TestTransportForwardsCloseIdleConnections(t *testing.T) {
+	t.Parallel()
+
+	base := &closeIdleRoundTripper{}
+	transport, err := auth.NewTransport(base, auth.NewStaticTokenSource("token"), "https://api.example.test")
+	require.NoError(t, err)
+
+	closer, ok := transport.(interface{ CloseIdleConnections() })
+	require.True(t, ok, "transport must expose CloseIdleConnections so http.Client can forward to it")
+	closer.CloseIdleConnections()
+
+	assert.Equal(t, 1, base.closed)
+}
+
+type closeIdleRoundTripper struct {
+	closed int
+}
+
+func (r *closeIdleRoundTripper) RoundTrip(*http.Request) (*http.Response, error) {
+	return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody}, nil
+}
+
+func (r *closeIdleRoundTripper) CloseIdleConnections() {
+	r.closed++
+}

--- a/internal/auth/transport.go
+++ b/internal/auth/transport.go
@@ -50,7 +50,9 @@ func (t *transport) RoundTrip(req *http.Request) (*http.Response, error) {
 			"request_origin":    requestOrigin(req.URL),
 			"configured_origin": t.allowedScheme + "://" + t.allowedHost,
 		})
-		return t.base.RoundTrip(req)
+		request := req.Clone(req.Context())
+		request.Header.Del("Authorization")
+		return t.base.RoundTrip(request)
 	}
 
 	request := req.Clone(req.Context())

--- a/internal/auth/transport.go
+++ b/internal/auth/transport.go
@@ -1,0 +1,127 @@
+package auth
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"reflect"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+type transport struct {
+	base          http.RoundTripper
+	source        accessTokenSource
+	allowedScheme string
+	allowedHost   string
+}
+
+// NewTransport attaches a fresh bearer token to each request attempt addressed
+// to the configured API origin.
+func NewTransport(base http.RoundTripper, source accessTokenSource, endpoint string) (http.RoundTripper, error) {
+	if base == nil {
+		base = http.DefaultTransport
+	}
+	if isNilTokenSource(source) {
+		return nil, errors.New("access token source is required")
+	}
+
+	parsedEndpoint, err := url.Parse(endpoint)
+	if err != nil {
+		return nil, fmt.Errorf("parsing endpoint: %w", err)
+	}
+	if !isHTTPScheme(parsedEndpoint.Scheme) || parsedEndpoint.Host == "" {
+		return nil, fmt.Errorf("endpoint %q must be an absolute http or https URL", endpoint)
+	}
+
+	return &transport{
+		base:          base,
+		source:        source,
+		allowedScheme: parsedEndpoint.Scheme,
+		allowedHost:   canonicalHost(parsedEndpoint.Scheme, parsedEndpoint.Host),
+	}, nil
+}
+
+func (t *transport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if !t.shouldAuthenticate(req.URL) {
+		tflog.Warn(req.Context(), "sending request without authentication: it is not addressed to the configured API endpoint", map[string]any{
+			"request_origin":    requestOrigin(req.URL),
+			"configured_origin": t.allowedScheme + "://" + t.allowedHost,
+		})
+		return t.base.RoundTrip(req)
+	}
+
+	request := req.Clone(req.Context())
+	if request.Header == nil {
+		request.Header = make(http.Header)
+	}
+	if err := SetAuthorizationHeader(request.Context(), request.Header, t.source); err != nil {
+		closeRequestBody(req)
+		return nil, err
+	}
+	return t.base.RoundTrip(request)
+}
+
+func isNilTokenSource(source accessTokenSource) bool {
+	if source == nil {
+		return true
+	}
+
+	value := reflect.ValueOf(source)
+	kind := value.Kind()
+	nilable := kind == reflect.Chan || kind == reflect.Func || kind == reflect.Interface ||
+		kind == reflect.Map || kind == reflect.Pointer || kind == reflect.Slice
+	return nilable && value.IsNil()
+}
+
+func requestOrigin(target *url.URL) string {
+	return target.Scheme + "://" + canonicalHost(target.Scheme, target.Host)
+}
+
+// RoundTripper must close the request body even when it returns an error.
+func closeRequestBody(req *http.Request) {
+	if req != nil && req.Body != nil {
+		_ = req.Body.Close()
+	}
+}
+
+// CloseIdleConnections forwards cleanup to the wrapped transport.
+func (t *transport) CloseIdleConnections() {
+	if closer, ok := t.base.(interface{ CloseIdleConnections() }); ok {
+		closer.CloseIdleConnections()
+	}
+}
+
+// Authenticate only the configured origin or a same-host HTTPS upgrade.
+func (t *transport) shouldAuthenticate(target *url.URL) bool {
+	if !strings.EqualFold(canonicalHost(target.Scheme, target.Host), t.allowedHost) {
+		return false
+	}
+	return strings.EqualFold(target.Scheme, t.allowedScheme) || strings.EqualFold(target.Scheme, schemeHTTPS)
+}
+
+const (
+	schemeHTTP  = "http"
+	schemeHTTPS = "https"
+)
+
+// isHTTPScheme reports whether scheme is one net/http can actually request.
+func isHTTPScheme(scheme string) bool {
+	return strings.EqualFold(scheme, schemeHTTP) || strings.EqualFold(scheme, schemeHTTPS)
+}
+
+// canonicalHost drops the port when it is the default for scheme, so that
+// https://api.example.test and https://api.example.test:443 are recognized as
+// the same origin.
+func canonicalHost(scheme, host string) string {
+	switch {
+	case strings.EqualFold(scheme, schemeHTTP):
+		return strings.TrimSuffix(host, ":80")
+	case strings.EqualFold(scheme, schemeHTTPS):
+		return strings.TrimSuffix(host, ":443")
+	default:
+		return host
+	}
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -15,6 +15,7 @@ import (
 	"github.com/coreweave/terraform-provider-coreweave/coreweave/networking"
 	objectstorage "github.com/coreweave/terraform-provider-coreweave/coreweave/object_storage"
 	workloadfederation "github.com/coreweave/terraform-provider-coreweave/coreweave/workload_federation"
+	"github.com/coreweave/terraform-provider-coreweave/internal/auth"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/function"
 	"github.com/hashicorp/terraform-plugin-framework/provider"
@@ -206,10 +207,10 @@ func BuildClient(ctx context.Context, model CoreweaveProviderModel, tfVersion, p
 	tflog.Debug(ctx, fmt.Sprintf("using http client timeout: %v", timeout))
 	userAgent := fmt.Sprintf("Terraform/%s terraform-provider-coreweave/%s (+https://github.com/coreweave/terraform-provider-coreweave)", tfVersion, providerVersion)
 
-	headerInterceptor := connect.UnaryInterceptorFunc(
+	tokenSource := auth.NewStaticTokenSource(token)
+	userAgentInterceptor := connect.UnaryInterceptorFunc(
 		func(next connect.UnaryFunc) connect.UnaryFunc {
 			return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
-				req.Header().Add("Authorization", fmt.Sprintf("Bearer %s", token))
 				req.Header().Set("User-Agent", userAgent)
 				return next(ctx, req)
 			}
@@ -220,12 +221,12 @@ func BuildClient(ctx context.Context, model CoreweaveProviderModel, tfVersion, p
 		endpoint,
 		s3Endpoint,
 		timeout,
-		token,
+		tokenSource,
 		userAgent,
 		coreweave.ClientOptions{S3AttemptTimeout: s3Timeout},
-		headerInterceptor,
+		userAgentInterceptor,
 		coreweave.TFLogInterceptor(),
-	), nil
+	)
 }
 
 func (p *CoreweaveProvider) Resources(ctx context.Context) []func() resource.Resource {

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -1,0 +1,80 @@
+package provider_test
+
+import (
+	"testing"
+
+	"github.com/coreweave/terraform-provider-coreweave/internal/provider"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// clearProviderEnv neutralizes every environment variable BuildClient reads, so
+// that an ambient value (routine in this repo when running acceptance tests)
+// cannot change which code path a unit test exercises. BuildClient treats an
+// empty value the same as an unset one and falls back to its default.
+func clearProviderEnv(t *testing.T) {
+	t.Helper()
+
+	for _, name := range []string{
+		provider.CoreweaveApiTokenEnvVar,
+		provider.CoreweaveApiEndpointEnvVar,
+		provider.CoreWeaveS3EndpointEnvVar,
+		provider.CoreweaveHTTPTimeoutEnvVar,
+	} {
+		t.Setenv(name, "")
+	}
+}
+
+// The endpoint attribute validator only runs against the provider config, so an
+// endpoint supplied through the environment reaches BuildClient unvalidated.
+func TestBuildClientRejectsUnusableEndpointFromEnv(t *testing.T) {
+	tests := map[string]struct {
+		endpoint string
+		wantErr  string
+	}{
+		"unparseable": {
+			endpoint: "https://api.coreweave.com:port",
+			wantErr:  "parsing endpoint",
+		},
+		"scheme-relative": {
+			endpoint: "//api.coreweave.com",
+			wantErr:  "must be an absolute http or https URL",
+		},
+		"non-http scheme": {
+			endpoint: "ftp://api.coreweave.com",
+			wantErr:  "must be an absolute http or https URL",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			clearProviderEnv(t)
+			t.Setenv(provider.CoreweaveApiTokenEnvVar, "CW-SECRET-token")
+			t.Setenv(provider.CoreweaveApiEndpointEnvVar, test.endpoint)
+
+			client, err := provider.BuildClient(t.Context(), provider.CoreweaveProviderModel{}, "", "")
+
+			require.ErrorContains(t, err, test.wantErr)
+			assert.Nil(t, client)
+		})
+	}
+}
+
+func TestBuildClientRequiresTokenSource(t *testing.T) {
+	clearProviderEnv(t)
+
+	client, err := provider.BuildClient(t.Context(), provider.CoreweaveProviderModel{}, "", "")
+
+	require.ErrorContains(t, err, "token is required")
+	assert.Nil(t, client)
+}
+
+func TestBuildClientUsesDefaultEndpoint(t *testing.T) {
+	clearProviderEnv(t)
+	t.Setenv(provider.CoreweaveApiTokenEnvVar, "CW-SECRET-token")
+
+	client, err := provider.BuildClient(t.Context(), provider.CoreweaveProviderModel{}, "", "")
+
+	require.NoError(t, err)
+	require.NotNil(t, client)
+}


### PR DESCRIPTION
## Summary

Implements CLDIAM-592 by introducing an access-token source abstraction for CoreWeave API clients.

The provider continues to use static API tokens today, while the client can now support refreshable token sources required by future workload identity authentication.

## Changes

- Add the `AccessTokenSource` interface and static-token implementation.
- Resolve authorization tokens within the HTTP transport for every request attempt.
- Apply the same authentication path to:
  - ConnectRPC requests
  - Caller identity raw HTTP requests
  - CWObject access-key creation
- Refresh the token between retry attempts instead of replaying the original bearer token.
- Classify token-source failures into appropriate ConnectRPC error codes.
- Surface canceled, timed-out, unavailable, and unauthenticated failures through clear Terraform diagnostics.
- Prevent bearer tokens from being forwarded to a different origin.
- Warn when a request is intentionally sent without authentication due to an origin mismatch.
- Reject nil and typed-nil token sources during client construction.
- Correct transport error classification in the retry policy.

## Security

- Tokens are not included in state, diagnostics, or provider logs.
- Cross-origin requests do not receive the configured bearer token.
- Origin-mismatch warnings contain only sanitized origins, excluding URL paths and query parameters.

## Testing

- Static-token authentication
- Token refresh across raw HTTP and ConnectRPC retries
- Token-source error propagation and ConnectRPC classification
- Terraform diagnostic mapping
- Origin and redirect authentication behavior
- Typed-nil token-source rejection
- Sensitive query data exclusion from logs
- Retry behavior for transport and HTTP errors

Validation completed with:

- `go test ./...`
- `go test -race ./coreweave ./internal/auth ./internal/provider`
- `go vet ./...`
- `make lint`
- `git diff --check`

## Ticket

[CLDIAM-592](https://coreweave.atlassian.net/browse/CLDIAM-592)

[CLDIAM-592]: https://coreweave.atlassian.net/browse/CLDIAM-592?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ