### PR TITLE
fix(object_storage): bound bucket creation reconciliation

### DIFF
--- a/coreweave/client.go
+++ b/coreweave/client.go
@@ -14,13 +14,30 @@ import (
 	"buf.build/gen/go/coreweave/workload-federation/connectrpc/go/coreweave/workload_federation/control_plane/v1beta1/control_planev1beta1connect"
 	"connectrpc.com/connect"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	retryablehttp "github.com/hashicorp/go-retryablehttp"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"google.golang.org/genproto/googleapis/rpc/errdetails"
 )
 
+type ClientOptions struct {
+	S3AttemptTimeout time.Duration
+}
+
 func NewClient(endpoint string, s3Endpoint string, timeout time.Duration, token string, userAgent string, interceptors ...connect.Interceptor) *Client {
+	return NewClientWithOptions(endpoint, s3Endpoint, timeout, token, userAgent, ClientOptions{}, interceptors...)
+}
+
+func NewClientWithOptions(
+	endpoint string,
+	s3Endpoint string,
+	timeout time.Duration,
+	token string,
+	userAgent string,
+	options ClientOptions,
+	interceptors ...connect.Interceptor,
+) *Client {
 	rc := retryablehttp.NewClient()
 	rc.HTTPClient.Timeout = timeout
 	rc.RetryMax = 10
@@ -28,7 +45,8 @@ func NewClient(endpoint string, s3Endpoint string, timeout time.Duration, token 
 	rc.RetryWaitMax = 5 * time.Second
 	// Jittered exponential back-off (min*2^n) with capping.
 	rc.Backoff = retryablehttp.DefaultBackoff
-	// Treat only idempotent verbs + 502/503/504 + transport errors as retryable.
+	// Retry transient transport failures, 429 responses, and server errors other
+	// than 501 while rejecting permanent request and certificate failures.
 	rc.CheckRetry = RetryPolicy
 
 	c := rc.StandardClient()
@@ -47,11 +65,12 @@ func NewClient(endpoint string, s3Endpoint string, timeout time.Duration, token 
 			CapacityClaimServiceClient: inferencev1alpha1connect.NewCapacityClaimServiceClient(c, endpoint, connect.WithInterceptors(interceptors...)),
 			GatewayServiceClient:       inferencev1alpha1connect.NewGatewayServiceClient(c, endpoint, connect.WithInterceptors(interceptors...)),
 		},
-		apiEndpoint: endpoint,
-		httpClient:  c,
-		s3Endpoint:  s3Endpoint,
-		token:       token,
-		userAgent:   userAgent,
+		apiEndpoint:      endpoint,
+		httpClient:       c,
+		s3Endpoint:       s3Endpoint,
+		s3AttemptTimeout: options.S3AttemptTimeout,
+		token:            token,
+		userAgent:        userAgent,
 	}
 }
 
@@ -70,11 +89,15 @@ type Client struct {
 
 	Inference *InferenceClient
 
-	apiEndpoint string
-	httpClient  *http.Client
-	s3Endpoint  string
-	token       string
-	userAgent   string
+	apiEndpoint      string
+	httpClient       *http.Client
+	s3Endpoint       string
+	s3AttemptTimeout time.Duration
+	s3HTTPTransport  http.RoundTripper
+	s3Retryer        func() aws.Retryer
+	s3Now            func() time.Time
+	token            string
+	userAgent        string
 }
 
 func IsNotFoundError(err error) bool {

--- a/coreweave/object_storage/bucket_create.go
+++ b/coreweave/object_storage/bucket_create.go
@@ -1,0 +1,522 @@
+package objectstorage
+
+import (
+	"context"
+	cryptorand "crypto/rand"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"math/big"
+	"net"
+	standardhttp "net/http"
+	"net/url"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/aws/smithy-go"
+	smithyhttp "github.com/aws/smithy-go/transport/http"
+	"github.com/coreweave/terraform-provider-coreweave/coreweave"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+const (
+	bucketPreflightPageSize  int32 = 10000
+	bucketPreflightMaxPages        = 10000
+	ambiguousCreateTimeout         = time.Minute
+	postCreateTimeout              = 5 * time.Minute
+	postCreateInitialBackoff       = 500 * time.Millisecond
+	postCreateMaxBackoff           = 5 * time.Second
+)
+
+type bucketCreateAPI interface {
+	ListBuckets(context.Context, *s3.ListBucketsInput, ...func(*s3.Options)) (*s3.ListBucketsOutput, error)
+	CreateBucket(context.Context, *s3.CreateBucketInput, ...func(*s3.Options)) (*s3.CreateBucketOutput, error)
+	GetBucketLocation(context.Context, *s3.GetBucketLocationInput, ...func(*s3.Options)) (*s3.GetBucketLocationOutput, error)
+}
+
+type bucketPostCreateAPI interface {
+	HeadBucket(context.Context, *s3.HeadBucketInput, ...func(*s3.Options)) (*s3.HeadBucketOutput, error)
+	PutBucketTagging(context.Context, *s3.PutBucketTaggingInput, ...func(*s3.Options)) (*s3.PutBucketTaggingOutput, error)
+	GetBucketTagging(context.Context, *s3.GetBucketTaggingInput, ...func(*s3.Options)) (*s3.GetBucketTaggingOutput, error)
+}
+
+type bucketDeleteAPI interface {
+	DeleteBucket(context.Context, *s3.DeleteBucketInput, ...func(*s3.Options)) (*s3.DeleteBucketOutput, error)
+}
+
+type bucketAlreadyExistsError struct {
+	bucket string
+	cause  error
+}
+
+func (e *bucketAlreadyExistsError) Error() string {
+	if e.cause == nil {
+		return fmt.Sprintf("bucket %q already exists", e.bucket)
+	}
+	return fmt.Sprintf("bucket %q already exists: %v", e.bucket, e.cause)
+}
+
+func (e *bucketAlreadyExistsError) Unwrap() error {
+	return e.cause
+}
+
+// bucketNameOwned enumerates the caller's complete owned-bucket inventory from
+// the base endpoint. Any ambiguity fails closed so CreateBucket is never used
+// to probe ownership.
+func bucketNameOwned(ctx context.Context, client interface {
+	ListBuckets(context.Context, *s3.ListBucketsInput, ...func(*s3.Options)) (*s3.ListBucketsOutput, error)
+}, bucket string) (bool, error) {
+	input := &s3.ListBucketsInput{MaxBuckets: aws.Int32(bucketPreflightPageSize)}
+	seenTokens := make(map[string]struct{})
+
+	for page := 1; page <= bucketPreflightMaxPages; page++ {
+		output, err := client.ListBuckets(ctx, input)
+		if err != nil {
+			return false, fmt.Errorf("owned-bucket preflight page %d: %w", page, err)
+		}
+		if output == nil {
+			return false, fmt.Errorf("owned-bucket preflight page %d returned no response", page)
+		}
+
+		for _, ownedBucket := range output.Buckets {
+			if ownedBucket.Name != nil && *ownedBucket.Name == bucket {
+				return true, nil
+			}
+		}
+
+		if output.ContinuationToken == nil {
+			if len(output.Buckets) >= int(bucketPreflightPageSize) {
+				return false, fmt.Errorf(
+					"owned-bucket preflight page %d returned %d buckets without a continuation token",
+					page,
+					len(output.Buckets),
+				)
+			}
+			return false, nil
+		}
+
+		nextToken := *output.ContinuationToken
+		if strings.TrimSpace(nextToken) == "" {
+			return false, fmt.Errorf("owned-bucket preflight page %d returned an empty continuation token", page)
+		}
+		if input.ContinuationToken != nil && nextToken == *input.ContinuationToken {
+			return false, fmt.Errorf("owned-bucket preflight page %d returned a non-advancing continuation token", page)
+		}
+		if _, seen := seenTokens[nextToken]; seen {
+			return false, fmt.Errorf("owned-bucket preflight page %d repeated a continuation token", page)
+		}
+		seenTokens[nextToken] = struct{}{}
+		input.ContinuationToken = aws.String(nextToken)
+	}
+
+	return false, fmt.Errorf("owned-bucket preflight exceeded %d pages", bucketPreflightMaxPages)
+}
+
+// createBucketSafely creates once after proving the name is absent. A lost
+// response is accepted only when a fresh inventory and location lookup prove
+// that the caller owns the bucket in the requested zone.
+func createBucketSafely(ctx context.Context, client bucketCreateAPI, bucket, zone string) error {
+	return createBucketSafelyWithOptions(ctx, client, bucket, zone, s3PhaseOptions{})
+}
+
+func createBucketSafelyWithOptions(
+	ctx context.Context,
+	client bucketCreateAPI,
+	bucket, zone string,
+	options s3PhaseOptions,
+) error {
+	owned, err := bucketNameOwned(ctx, client, bucket)
+	if err != nil {
+		return fmt.Errorf("bucket ownership preflight: %w", err)
+	}
+	if owned {
+		return &bucketAlreadyExistsError{bucket: bucket}
+	}
+
+	_, err = client.CreateBucket(ctx, &s3.CreateBucketInput{
+		Bucket: aws.String(bucket),
+		CreateBucketConfiguration: &s3types.CreateBucketConfiguration{
+			LocationConstraint: s3types.BucketLocationConstraint(zone),
+		},
+	}, func(options *s3.Options) {
+		// A lost create response is reconciled through owned inventory and zone
+		// proof. Retrying CreateBucket itself would send the mutation again.
+		options.Retryer = aws.NopRetryer{}
+	})
+	if err == nil {
+		return nil
+	}
+
+	var bucketExistsErr *s3types.BucketAlreadyExists
+	var bucketOwnedByYouErr *s3types.BucketAlreadyOwnedByYou
+	if errors.As(err, &bucketExistsErr) || errors.As(err, &bucketOwnedByYouErr) {
+		return &bucketAlreadyExistsError{bucket: bucket, cause: err}
+	}
+	if !isAmbiguousCreateError(ctx, err) {
+		return fmt.Errorf("create bucket: %w", err)
+	}
+
+	if reconcileErr := reconcileAmbiguousCreate(ctx, client, bucket, zone, options); reconcileErr != nil {
+		return fmt.Errorf("reconcile ambiguous create: %w", errors.Join(err, reconcileErr))
+	}
+
+	tflog.Warn(ctx, "reconciled an ambiguous S3 create response", map[string]interface{}{
+		"bucket": bucket,
+		"phase":  "create",
+		"zone":   zone,
+	})
+	return nil
+}
+
+func reconcileAmbiguousCreate(
+	parentCtx context.Context,
+	client bucketCreateAPI,
+	bucket, zone string,
+	options s3PhaseOptions,
+) error {
+	ctx, cancel := context.WithTimeout(parentCtx, ambiguousCreateTimeout)
+	defer cancel()
+
+	return runS3Phase(ctx, "ambiguous bucket create", bucket, zone, options, func(ctx context.Context) (bool, error) {
+		owned, err := bucketNameOwned(ctx, client, bucket)
+		if err != nil || !owned {
+			return false, err
+		}
+
+		location, err := client.GetBucketLocation(ctx, &s3.GetBucketLocationInput{Bucket: aws.String(bucket)})
+		if err != nil {
+			return false, err
+		}
+		if location == nil || location.LocationConstraint == "" {
+			return false, nil
+		}
+		actualZone := string(location.LocationConstraint)
+		if actualZone != zone {
+			return false, fmt.Errorf("owned bucket %q is in zone %q, want %q", bucket, actualZone, zone)
+		}
+		return true, nil
+	}, isPostCreateRetryableS3Error)
+}
+
+type s3PhaseOptions struct {
+	now   func() time.Time
+	delay func(attempt int) time.Duration
+	wait  func(context.Context, time.Duration) error
+}
+
+func (options s3PhaseOptions) withDefaults() s3PhaseOptions {
+	if options.now == nil {
+		options.now = time.Now
+	}
+	if options.delay == nil {
+		options.delay = postCreateBackoff
+	}
+	if options.wait == nil {
+		options.wait = waitForS3Backoff
+	}
+	return options
+}
+
+type s3PhaseError struct {
+	phase    string
+	attempts int
+	elapsed  time.Duration
+	err      error
+}
+
+func (e *s3PhaseError) Error() string {
+	return fmt.Sprintf("%s failed after %d attempt(s) in %s: %v", e.phase, e.attempts, e.elapsed.Round(time.Millisecond), e.err)
+}
+
+func (e *s3PhaseError) Unwrap() error {
+	return e.err
+}
+
+func runS3Phase(
+	ctx context.Context,
+	phase, bucket, zone string,
+	options s3PhaseOptions,
+	attempt func(context.Context) (bool, error),
+	retryable func(error) bool,
+) error {
+	options = options.withDefaults()
+	started := options.now()
+
+	for attemptNumber := 1; ; attemptNumber++ {
+		if err := ctx.Err(); err != nil {
+			return &s3PhaseError{phase: phase, attempts: attemptNumber - 1, elapsed: options.now().Sub(started), err: err}
+		}
+
+		done, err := attempt(ctx)
+		if err == nil && done {
+			return nil
+		}
+		if err != nil && !retryable(err) {
+			return &s3PhaseError{phase: phase, attempts: attemptNumber, elapsed: options.now().Sub(started), err: err}
+		}
+
+		delay := options.delay(attemptNumber)
+		errorClass, errorCode := s3ErrorMetadata(err)
+		tflog.Debug(ctx, "waiting for S3 operation convergence", map[string]interface{}{
+			"attempt":     attemptNumber,
+			"bucket":      bucket,
+			"elapsed":     options.now().Sub(started).String(),
+			"error_class": errorClass,
+			"error_code":  errorCode,
+			"next_delay":  delay.String(),
+			"phase":       phase,
+			"zone":        zone,
+		})
+		if waitErr := options.wait(ctx, delay); waitErr != nil {
+			return &s3PhaseError{phase: phase, attempts: attemptNumber, elapsed: options.now().Sub(started), err: waitErr}
+		}
+	}
+}
+
+func reconcileBucketAfterCreate(
+	parentCtx context.Context,
+	client bucketPostCreateAPI,
+	bucket, zone string,
+	expectedTags []s3types.Tag,
+	applyTags bool,
+	options s3PhaseOptions,
+) error {
+	ctx, cancel := context.WithTimeout(parentCtx, postCreateTimeout)
+	defer cancel()
+
+	if err := runS3Phase(ctx, "bucket readiness", bucket, zone, options, func(ctx context.Context) (bool, error) {
+		_, err := client.HeadBucket(ctx, &s3.HeadBucketInput{Bucket: aws.String(bucket)})
+		return err == nil, err
+	}, isBucketReadinessRetryableS3Error); err != nil {
+		return err
+	}
+
+	if !applyTags {
+		return nil
+	}
+
+	tagInput := &s3.PutBucketTaggingInput{
+		Bucket:  aws.String(bucket),
+		Tagging: &s3types.Tagging{TagSet: expectedTags},
+	}
+	if err := runS3Phase(ctx, "bucket tag application", bucket, zone, options, func(ctx context.Context) (bool, error) {
+		_, err := client.PutBucketTagging(ctx, tagInput)
+		return err == nil, err
+	}, isPostCreateRetryableS3Error); err != nil {
+		return err
+	}
+
+	expected := append([]s3types.Tag(nil), expectedTags...)
+	slices.SortFunc(expected, cmpTag)
+	return runS3Phase(ctx, "bucket tag readback", bucket, zone, options, func(ctx context.Context) (bool, error) {
+		output, err := client.GetBucketTagging(ctx, &s3.GetBucketTaggingInput{Bucket: aws.String(bucket)})
+		if err != nil {
+			return false, err
+		}
+		if output == nil {
+			return false, nil
+		}
+		actual := append([]s3types.Tag(nil), output.TagSet...)
+		slices.SortFunc(actual, cmpTag)
+		return slices.EqualFunc(expected, actual, eqTag), nil
+	}, isPostCreateRetryableS3Error)
+}
+
+func deleteBucketWithRetry(
+	parentCtx context.Context,
+	client bucketDeleteAPI,
+	bucket, zone string,
+	options s3PhaseOptions,
+) error {
+	ctx, cancel := context.WithTimeout(parentCtx, postCreateTimeout)
+	defer cancel()
+
+	return runS3Phase(ctx, "bucket deletion request", bucket, zone, options, func(ctx context.Context) (bool, error) {
+		_, err := client.DeleteBucket(ctx, &s3.DeleteBucketInput{Bucket: aws.String(bucket)})
+		if err == nil || isBucketNotFoundError(err) {
+			return true, nil
+		}
+		return false, err
+	}, isPostCreateRetryableS3Error)
+}
+
+func postCreateBackoff(attempt int) time.Duration {
+	shift := min(max(attempt-1, 0), 4)
+	delay := postCreateInitialBackoff << shift
+	if delay > postCreateMaxBackoff {
+		delay = postCreateMaxBackoff
+	}
+	half := delay / 2
+	jitter, err := cryptorand.Int(cryptorand.Reader, big.NewInt(int64(half)+1))
+	if err != nil {
+		return delay
+	}
+	return half + time.Duration(jitter.Int64())
+}
+
+func waitForS3Backoff(ctx context.Context, delay time.Duration) error {
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+func isAmbiguousCreateError(ctx context.Context, err error) bool {
+	if err == nil || ctx.Err() != nil || isPermanentTransportError(err) {
+		return false
+	}
+
+	var apiErr smithy.APIError
+	hasAPIError := errors.As(err, &apiErr)
+	if hasAPIError && isPermanentBucketAPIError(apiErr.ErrorCode()) {
+		return false
+	}
+
+	if status, ok := s3HTTPStatus(err); ok && isTransientS3HTTPStatus(status, false) {
+		return true
+	}
+	if hasAPIError {
+		return isTransientBucketAPIError(apiErr.ErrorCode(), false)
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		// The operation context is still live, so the deadline belongs to one
+		// HTTP attempt and the server may have accepted the mutation.
+		return true
+	}
+
+	var urlErr *url.Error
+	if errors.As(err, &urlErr) {
+		return true
+	}
+	var netErr net.Error
+	return errors.As(err, &netErr)
+}
+
+func isPostCreateRetryableS3Error(err error) bool {
+	if err == nil || errors.Is(err, context.Canceled) || isPermanentTransportError(err) {
+		return false
+	}
+
+	var apiErr smithy.APIError
+	hasAPIError := errors.As(err, &apiErr)
+	if hasAPIError && isPermanentBucketAPIError(apiErr.ErrorCode()) {
+		return false
+	}
+
+	if status, ok := s3HTTPStatus(err); ok && isTransientS3HTTPStatus(status, true) {
+		return true
+	}
+	if hasAPIError {
+		return isTransientBucketAPIError(apiErr.ErrorCode(), true)
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+
+	var urlErr *url.Error
+	if errors.As(err, &urlErr) {
+		return true
+	}
+	var netErr net.Error
+	return errors.As(err, &netErr)
+}
+
+func isPermanentBucketAPIError(code string) bool {
+	switch code {
+	case "AccessDenied", "AuthorizationHeaderMalformed", "InvalidAccessKeyId",
+		"InvalidArgument", "InvalidBucketName", "InvalidRequest", "InvalidToken",
+		"SignatureDoesNotMatch":
+		return true
+	default:
+		return false
+	}
+}
+
+func isTransientBucketAPIError(code string, includePropagation bool) bool {
+	if includePropagation {
+		switch code {
+		case errInvalidRegion, ErrNoSuchBucket, errNotFound, errNoSuchTagSet:
+			return true
+		}
+	}
+
+	switch code {
+	case "BadGateway", "GatewayTimeout", "InternalError", "InternalServerError",
+		"RequestTimeout", "RequestTimeoutException", "ServiceUnavailable", "SlowDown",
+		"TooManyRequests":
+		return true
+	default:
+		return false
+	}
+}
+
+func isTransientS3HTTPStatus(status int, includeNotFound bool) bool {
+	if includeNotFound && status == standardhttp.StatusNotFound {
+		return true
+	}
+	return status == standardhttp.StatusRequestTimeout ||
+		status == standardhttp.StatusTooManyRequests ||
+		status == standardhttp.StatusInternalServerError ||
+		status == standardhttp.StatusBadGateway ||
+		status == standardhttp.StatusServiceUnavailable ||
+		status == standardhttp.StatusGatewayTimeout
+}
+
+func isBucketReadinessRetryableS3Error(err error) bool {
+	if isPostCreateRetryableS3Error(err) {
+		return true
+	}
+
+	// During initial virtual-host routing convergence, HeadBucket can collapse
+	// the backend InvalidRegion response into a generic HTTP 400 BadRequest.
+	// Restrict this exception to readiness; other named 400s and all tag calls
+	// still fail immediately.
+	var apiErr smithy.APIError
+	status, hasStatus := s3HTTPStatus(err)
+	return errors.As(err, &apiErr) &&
+		apiErr.ErrorCode() == "BadRequest" &&
+		hasStatus &&
+		status == standardhttp.StatusBadRequest
+}
+
+func isPermanentTransportError(err error) bool {
+	return coreweave.IsPermanentRequestError(err)
+}
+
+func s3HTTPStatus(err error) (int, bool) {
+	var responseErr *smithyhttp.ResponseError
+	if !errors.As(err, &responseErr) || responseErr.Response == nil {
+		return 0, false
+	}
+	return responseErr.Response.StatusCode, true
+}
+
+func s3ErrorMetadata(err error) (class, code string) {
+	if err == nil {
+		return "not_converged", ""
+	}
+	var apiErr smithy.APIError
+	if errors.As(err, &apiErr) {
+		return "api", apiErr.ErrorCode()
+	}
+	if status, ok := s3HTTPStatus(err); ok {
+		return "http", fmt.Sprintf("%d", status)
+	}
+	var certificateErr *tls.CertificateVerificationError
+	if errors.As(err, &certificateErr) {
+		return "tls_certificate", ""
+	}
+	var urlErr *url.Error
+	if errors.As(err, &urlErr) {
+		return "network", ""
+	}
+	return "unknown", ""
+}

--- a/coreweave/object_storage/resource_bucket.go
+++ b/coreweave/object_storage/resource_bucket.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	awsretry "github.com/aws/aws-sdk-go-v2/aws/retry"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/smithy-go"
 	"github.com/aws/smithy-go/transport/http"
@@ -36,9 +37,10 @@ var (
 const (
 	errInvalidRegion = "InvalidRegion"
 
-	ErrNoSuchBucket string = "NoSuchBucket"
-	errNotFound     string = "NotFound"
-	errNoSuchTagSet string = "NoSuchTagSet"
+	ErrNoSuchBucket       string = "NoSuchBucket"
+	errNotFound           string = "NotFound"
+	errNoSuchTagSet       string = "NoSuchTagSet"
+	bucketReadMaxAttempts        = 8
 )
 
 func NewBucketResource() resource.Resource {
@@ -229,7 +231,10 @@ func (r bucketReadRetryer) GetAttemptToken(ctx context.Context) (func(error) err
 }
 
 func withBucketReadRetry(options *s3.Options) {
-	options.Retryer = bucketReadRetryer{Retryer: options.Retryer}
+	options.Retryer = awsretry.AddWithMaxAttempts(
+		bucketReadRetryer{Retryer: options.Retryer},
+		bucketReadMaxAttempts,
+	)
 }
 
 // waitForBucket polls HeadBucket every 'interval' until the bucket

--- a/coreweave/object_storage/resource_bucket.go
+++ b/coreweave/object_storage/resource_bucket.go
@@ -168,6 +168,21 @@ func isMissingBucketTagSetError(err error) bool {
 	return errors.As(err, &apiErr) && apiErr.ErrorCode() == errNoSuchTagSet
 }
 
+func bucketTagsForState(previous types.Map, remote []s3types.Tag) (types.Map, diag.Diagnostics) {
+	if len(remote) == 0 {
+		if previous.IsNull() {
+			return types.MapNull(types.StringType), nil
+		}
+		return types.MapValue(types.StringType, map[string]attr.Value{})
+	}
+
+	tagMap := make(map[string]attr.Value, len(remote))
+	for _, tag := range remote {
+		tagMap[*tag.Key] = types.StringValue(*tag.Value)
+	}
+	return types.MapValue(types.StringType, tagMap)
+}
+
 func isHTTPNotFoundError(err error) bool {
 	var httpErr *http.ResponseError
 	return errors.As(err, &httpErr) &&
@@ -359,7 +374,6 @@ func (b *BucketResource) Create(ctx context.Context, req resource.CreateRequest,
 	}
 
 	tags := []s3types.Tag(nil)
-	applyTags := !data.Tags.IsNull()
 	if !data.Tags.IsNull() {
 		tagMap := map[string]string{}
 
@@ -376,6 +390,7 @@ func (b *BucketResource) Create(ctx context.Context, req resource.CreateRequest,
 			})
 		}
 	}
+	applyTags := len(tags) > 0
 
 	if err := reconcileBucketAfterCreate(
 		ctx,
@@ -453,21 +468,11 @@ func (b *BucketResource) Read(ctx context.Context, req resource.ReadRequest, res
 		}
 	}
 
-	tags := types.MapNull(types.StringType)
-	if len(tagSet.TagSet) > 0 {
-		tagMap := map[string]attr.Value{}
-		for _, t := range tagSet.TagSet {
-			tagMap[*t.Key] = types.StringValue(*t.Value)
-		}
-		tagMapValue, diag := types.MapValue(types.StringType, tagMap)
-		resp.Diagnostics.Append(diag...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
-
-		tags = tagMapValue
+	tags, diagnostics := bucketTagsForState(data.Tags, tagSet.TagSet)
+	resp.Diagnostics.Append(diagnostics...)
+	if resp.Diagnostics.HasError() {
+		return
 	}
-
 	data.Tags = tags
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
@@ -486,8 +491,8 @@ func (b *BucketResource) Update(ctx context.Context, req resource.UpdateRequest,
 		return
 	}
 
+	tags := []s3types.Tag(nil)
 	if !data.Tags.IsNull() {
-		tags := []s3types.Tag{}
 		tagMap := map[string]string{}
 
 		if diag := data.Tags.ElementsAs(ctx, &tagMap, false); diag.HasError() {
@@ -501,6 +506,9 @@ func (b *BucketResource) Update(ctx context.Context, req resource.UpdateRequest,
 				Value: aws.String(value),
 			})
 		}
+	}
+
+	if len(tags) > 0 {
 		_, err = s3Client.PutBucketTagging(ctx, &s3.PutBucketTaggingInput{
 			Bucket: aws.String(data.Name.ValueString()),
 			Tagging: &s3types.Tagging{
@@ -530,7 +538,9 @@ func (b *BucketResource) Update(ctx context.Context, req resource.UpdateRequest,
 			return
 		}
 
-		data.Tags = types.MapNull(types.StringType)
+		if data.Tags.IsNull() {
+			data.Tags = types.MapNull(types.StringType)
+		}
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
@@ -585,19 +595,10 @@ func (b *BucketResource) ImportState(ctx context.Context, req resource.ImportSta
 		return
 	}
 
-	tags := types.MapNull(types.StringType)
-	if len(bucketTagging.TagSet) > 0 {
-		tagMap := map[string]attr.Value{}
-		for _, t := range bucketTagging.TagSet {
-			tagMap[*t.Key] = types.StringValue(*t.Value)
-		}
-		tagMapValue, diag := types.MapValue(types.StringType, tagMap)
-		resp.Diagnostics.Append(diag...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
-
-		tags = tagMapValue
+	tags, diagnostics := bucketTagsForState(types.MapNull(types.StringType), bucketTagging.TagSet)
+	resp.Diagnostics.Append(diagnostics...)
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
 	data := BucketResourceModel{
@@ -628,7 +629,11 @@ func MustRenderBucketResource(ctx context.Context, resourceName string, bucket *
 		for key, value := range tagMap {
 			tags[key] = cty.StringVal(value)
 		}
-		resourceBody.SetAttributeValue("tags", cty.MapVal(tags))
+		if len(tags) == 0 {
+			resourceBody.SetAttributeValue("tags", cty.MapValEmpty(cty.String))
+		} else {
+			resourceBody.SetAttributeValue("tags", cty.MapVal(tags))
+		}
 	}
 
 	var buf bytes.Buffer

--- a/coreweave/object_storage/resource_bucket.go
+++ b/coreweave/object_storage/resource_bucket.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	awsretry "github.com/aws/aws-sdk-go-v2/aws/retry"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/smithy-go"
 	"github.com/aws/smithy-go/transport/http"
@@ -35,14 +34,11 @@ var (
 )
 
 const (
-	errInvalidRegion               = "InvalidRegion"
-	postCreateTaggingRetryInterval = 5 * time.Second
-	postCreateTaggingRetryTimeout  = time.Minute
+	errInvalidRegion = "InvalidRegion"
 
-	ErrNoSuchBucket       string = "NoSuchBucket"
-	errNotFound           string = "NotFound"
-	errNoSuchTagSet       string = "NoSuchTagSet"
-	bucketReadMaxAttempts        = 8
+	ErrNoSuchBucket string = "NoSuchBucket"
+	errNotFound     string = "NotFound"
+	errNoSuchTagSet string = "NoSuchTagSet"
 )
 
 func NewBucketResource() resource.Resource {
@@ -51,7 +47,9 @@ func NewBucketResource() resource.Resource {
 
 // BucketResource defines the resource implementation.
 type BucketResource struct {
-	client *coreweave.Client
+	client            *coreweave.Client
+	s3ClientForZone   func(context.Context, string) (*s3.Client, error)
+	postCreateOptions s3PhaseOptions
 }
 
 type BucketResourceModel struct {
@@ -66,7 +64,7 @@ func (b *BucketResource) Metadata(ctx context.Context, req resource.MetadataRequ
 
 func (b *BucketResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		MarkdownDescription: "Buckets are the primary organizational containers for your data in CoreWeave AI Object Storage. Bucket names must be globally-unique and not begin with `cw-` or `vip-`, which are reserved for internal use. Learn more about [creating buckets](https://docs.coreweave.com/products/storage/object-storage/buckets/create-bucket).",
+		MarkdownDescription: "Buckets are the primary organizational containers for your data in CoreWeave AI Object Storage. Bucket names must be globally-unique and not begin with `cw-` or `vip-`, which are reserved for internal use. Before creation, the provider verifies the complete list of buckets owned by the organization and fails without sending a create request if that inventory cannot be completed; an existing bucket with the requested name must be imported. Learn more about [creating buckets](https://docs.coreweave.com/products/storage/object-storage/buckets/create-bucket).",
 		Attributes: map[string]schema.Attribute{
 			"name": schema.StringAttribute{
 				Required:            true,
@@ -108,6 +106,13 @@ func (b *BucketResource) Configure(_ context.Context, req resource.ConfigureRequ
 	}
 
 	b.client = client
+}
+
+func (b *BucketResource) getS3Client(ctx context.Context, zone string) (*s3.Client, error) {
+	if b.s3ClientForZone != nil {
+		return b.s3ClientForZone(ctx, zone)
+	}
+	return b.client.S3Client(ctx, zone)
 }
 
 func handleS3Error(
@@ -209,10 +214,7 @@ func (r bucketReadRetryer) GetAttemptToken(ctx context.Context) (func(error) err
 }
 
 func withBucketReadRetry(options *s3.Options) {
-	options.Retryer = awsretry.AddWithMaxAttempts(
-		bucketReadRetryer{Retryer: options.Retryer},
-		bucketReadMaxAttempts,
-	)
+	options.Retryer = bucketReadRetryer{Retryer: options.Retryer}
 }
 
 // waitForBucket polls HeadBucket every 'interval' until the bucket
@@ -320,43 +322,6 @@ func waitForBucketTags(parentCtx context.Context, client *s3.Client, bucket stri
 	})
 }
 
-// putBucketTagsAfterCreate retries InvalidRegion while the new bucket's location propagates.
-func putBucketTagsAfterCreate(parentCtx context.Context, client *s3.Client, bucket string, tags []s3types.Tag) error {
-	input := &s3.PutBucketTaggingInput{
-		Bucket: aws.String(bucket),
-		Tagging: &s3types.Tagging{
-			TagSet: tags,
-		},
-	}
-
-	putTags := func(ctx context.Context) (bool, error) {
-		_, err := client.PutBucketTagging(ctx, input)
-		if err == nil {
-			return true, nil
-		}
-
-		var apiErr smithy.APIError
-		if errors.As(err, &apiErr) && apiErr.ErrorCode() == errInvalidRegion {
-			return false, nil
-		}
-
-		return false, err
-	}
-
-	tagged, err := putTags(parentCtx)
-	if err != nil || tagged {
-		return err
-	}
-
-	return coreweave.PollUntil(
-		"bucket tagging after creation",
-		parentCtx,
-		postCreateTaggingRetryInterval,
-		postCreateTaggingRetryTimeout,
-		putTags,
-	)
-}
-
 func (b *BucketResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var data BucketResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
@@ -365,21 +330,19 @@ func (b *BucketResource) Create(ctx context.Context, req resource.CreateRequest,
 		return
 	}
 
-	s3Client, err := b.client.S3Client(ctx, data.Zone.ValueString())
+	s3Client, err := b.getS3Client(ctx, data.Zone.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to create S3 client", err.Error())
 		return
 	}
 
-	// check if bucket already exists - we need to HeadBucket here because the cwobject API only errors
-	// if you try to create a bucket with the same name in a different zone.
-	// If a CreateBucket request is sent for a name/zone combo that already exists, it will succeed.
-	// So we HeadBucket here and check if the request succeeds; if it does, error and tell the user the bucket already exists
-	// so they can import the existing state
-	_, err = s3Client.HeadBucket(ctx, &s3.HeadBucketInput{
-		Bucket: aws.String(data.Name.ValueString()),
-	})
-	if err == nil {
+	err = createBucketSafely(ctx, s3Client, data.Name.ValueString(), data.Zone.ValueString())
+	if err != nil {
+		var alreadyExistsErr *bucketAlreadyExistsError
+		if !errors.As(err, &alreadyExistsErr) {
+			resp.Diagnostics.AddError("Bucket creation failed", err.Error())
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Already Exists",
 			fmt.Sprintf("Bucket '%s' already exists, specify a different name and try again, or import the bucket using `terraform import`.", data.Name.ValueString()),
@@ -387,53 +350,17 @@ func (b *BucketResource) Create(ctx context.Context, req resource.CreateRequest,
 		return
 	}
 
-	createReq := &s3.CreateBucketInput{
-		Bucket: aws.String(data.Name.ValueString()),
-		CreateBucketConfiguration: &s3types.CreateBucketConfiguration{
-			LocationConstraint: s3types.BucketLocationConstraint(data.Zone.ValueString()),
-		},
-	}
-
-	_, err = s3Client.CreateBucket(ctx, createReq)
-	if err != nil {
-		// These two error types are only returned in a situation where a user
-		// tries to create a bucket with the same name but a different zone.
-		// The HeadBucket call before CreateBucket should ensure that Terraform will error on
-		// a bucket that already exists in the same zone
-		var bucketExistsErr *s3types.BucketAlreadyExists
-		var bucketOwnedByYouErr *s3types.BucketAlreadyOwnedByYou
-		if errors.As(err, &bucketExistsErr) || errors.As(err, &bucketOwnedByYouErr) {
-			// Bucket was already created in a previous attempt, return an error
-			message := bucketExistsErr.Message
-			if message == nil {
-				message = bucketOwnedByYouErr.Message
-			}
-
-			resp.Diagnostics.AddError(
-				"Already Exists",
-				fmt.Sprintf("Bucket '%s' already exists, specify a different name and try again, or import the bucket using `terraform import`: %s", data.Name.ValueString(), *message),
-			)
-			return
-		}
-
-		handleS3Error(err, &resp.Diagnostics, data.Name.ValueString())
-		return
-	}
-
-	// set state while we wait for the bucket to finish
+	// Persist recoverable identity before readiness and tag propagation. If the
+	// shared post-create deadline expires, refresh/import/destroy can still find
+	// the accepted bucket rather than orphaning it.
 	if diag := resp.State.Set(ctx, &data); diag.HasError() {
-		// if we fail to set state, return early as the resource will be orphaned
 		resp.Diagnostics.Append(diag...)
 		return
 	}
 
-	if err := waitForBucket(ctx, s3Client, data.Name.ValueString(), true); err != nil {
-		handleS3Error(err, &resp.Diagnostics, data.Name.ValueString())
-		return
-	}
-
+	tags := []s3types.Tag(nil)
+	applyTags := !data.Tags.IsNull()
 	if !data.Tags.IsNull() {
-		tags := []s3types.Tag{}
 		tagMap := map[string]string{}
 
 		if diag := data.Tags.ElementsAs(ctx, &tagMap, false); diag.HasError() {
@@ -448,23 +375,19 @@ func (b *BucketResource) Create(ctx context.Context, req resource.CreateRequest,
 				Value: aws.String(value),
 			})
 		}
+	}
 
-		if err := putBucketTagsAfterCreate(ctx, s3Client, data.Name.ValueString(), tags); err != nil {
-			handleS3Error(err, &resp.Diagnostics, data.Name.ValueString())
-			return
-		}
-
-		// set state while we wait for the tags to propagate
-		if diag := resp.State.Set(ctx, &data); diag.HasError() {
-			// if we fail to set state, return early as the resource will be orphaned
-			resp.Diagnostics.Append(diag...)
-			return
-		}
-
-		if err := waitForBucketTags(ctx, s3Client, data.Name.ValueString(), tags); err != nil {
-			handleS3Error(err, &resp.Diagnostics, data.Name.ValueString())
-			return
-		}
+	if err := reconcileBucketAfterCreate(
+		ctx,
+		s3Client,
+		data.Name.ValueString(),
+		data.Zone.ValueString(),
+		tags,
+		applyTags,
+		b.postCreateOptions,
+	); err != nil {
+		resp.Diagnostics.AddError("Bucket post-create reconciliation failed", err.Error())
+		return
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
@@ -478,7 +401,7 @@ func (b *BucketResource) Read(ctx context.Context, req resource.ReadRequest, res
 		return
 	}
 
-	s3Client, err := b.client.S3Client(ctx, data.Zone.ValueString())
+	s3Client, err := b.getS3Client(ctx, data.Zone.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to create S3 client", err.Error())
 		return
@@ -557,7 +480,7 @@ func (b *BucketResource) Update(ctx context.Context, req resource.UpdateRequest,
 		return
 	}
 
-	s3Client, err := b.client.S3Client(ctx, data.Zone.ValueString())
+	s3Client, err := b.getS3Client(ctx, data.Zone.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to create S3 client", err.Error())
 		return
@@ -621,23 +544,14 @@ func (b *BucketResource) Delete(ctx context.Context, req resource.DeleteRequest,
 		return
 	}
 
-	s3Client, err := b.client.S3Client(ctx, data.Zone.ValueString())
+	s3Client, err := b.getS3Client(ctx, data.Zone.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to create S3 client", err.Error())
 		return
 	}
 
-	_, err = s3Client.DeleteBucket(ctx, &s3.DeleteBucketInput{
-		Bucket: aws.String(data.Name.ValueString()),
-	})
-	if err != nil {
-		var apiErr smithy.APIError
-		if errors.As(err, &apiErr) && apiErr.ErrorCode() == ErrNoSuchBucket {
-			// bucket doesn’t exist, return as it will be removed from state
-			return
-		}
-
-		handleS3Error(err, &resp.Diagnostics, data.Name.ValueString())
+	if err := deleteBucketWithRetry(ctx, s3Client, data.Name.ValueString(), data.Zone.ValueString(), s3PhaseOptions{}); err != nil {
+		resp.Diagnostics.AddError("Bucket deletion failed", err.Error())
 		return
 	}
 
@@ -649,7 +563,7 @@ func (b *BucketResource) Delete(ctx context.Context, req resource.DeleteRequest,
 }
 
 func (b *BucketResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	s3Client, err := b.client.S3Client(ctx, "")
+	s3Client, err := b.getS3Client(ctx, "")
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to create S3 client", err.Error())
 		return

--- a/coreweave/object_storage/resource_bucket_create_unit_test.go
+++ b/coreweave/object_storage/resource_bucket_create_unit_test.go
@@ -1,0 +1,727 @@
+package objectstorage
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"io"
+	standardhttp "net/http"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/aws/smithy-go"
+	fwresource "github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+type scriptedBucketClient struct {
+	listOutputs []*s3.ListBucketsOutput
+	listErrors  []error
+	listInputs  []*s3.ListBucketsInput
+
+	createErrors      []error
+	createCalls       int
+	createMaxAttempts int
+
+	locationOutputs []*s3.GetBucketLocationOutput
+	locationErrors  []error
+	locationCalls   int
+
+	headErrors []error
+	headCalls  int
+
+	putTagErrors []error
+	putTagCalls  int
+
+	getTagOutputs []*s3.GetBucketTaggingOutput
+	getTagErrors  []error
+	getTagCalls   int
+
+	deleteErrors []error
+	deleteCalls  int
+}
+
+func (c *scriptedBucketClient) ListBuckets(
+	_ context.Context,
+	input *s3.ListBucketsInput,
+	_ ...func(*s3.Options),
+) (*s3.ListBucketsOutput, error) {
+	c.listInputs = append(c.listInputs, input)
+	index := len(c.listInputs) - 1
+	if index < len(c.listErrors) && c.listErrors[index] != nil {
+		return nil, c.listErrors[index]
+	}
+	if index >= len(c.listOutputs) {
+		return &s3.ListBucketsOutput{}, nil
+	}
+	return c.listOutputs[index], nil
+}
+
+func (c *scriptedBucketClient) CreateBucket(
+	_ context.Context,
+	_ *s3.CreateBucketInput,
+	options ...func(*s3.Options),
+) (*s3.CreateBucketOutput, error) {
+	callOptions := s3.Options{}
+	for _, option := range options {
+		option(&callOptions)
+	}
+	if callOptions.Retryer != nil {
+		c.createMaxAttempts = callOptions.Retryer.MaxAttempts()
+	}
+	index := c.createCalls
+	c.createCalls++
+	if index < len(c.createErrors) {
+		return &s3.CreateBucketOutput{}, c.createErrors[index]
+	}
+	return &s3.CreateBucketOutput{}, nil
+}
+
+func (c *scriptedBucketClient) GetBucketLocation(
+	_ context.Context,
+	_ *s3.GetBucketLocationInput,
+	_ ...func(*s3.Options),
+) (*s3.GetBucketLocationOutput, error) {
+	index := c.locationCalls
+	c.locationCalls++
+	if index < len(c.locationErrors) && c.locationErrors[index] != nil {
+		return nil, c.locationErrors[index]
+	}
+	if index >= len(c.locationOutputs) {
+		return &s3.GetBucketLocationOutput{}, nil
+	}
+	return c.locationOutputs[index], nil
+}
+
+func (c *scriptedBucketClient) HeadBucket(
+	_ context.Context,
+	_ *s3.HeadBucketInput,
+	_ ...func(*s3.Options),
+) (*s3.HeadBucketOutput, error) {
+	index := c.headCalls
+	c.headCalls++
+	if index < len(c.headErrors) {
+		return &s3.HeadBucketOutput{}, c.headErrors[index]
+	}
+	return &s3.HeadBucketOutput{}, nil
+}
+
+func (c *scriptedBucketClient) PutBucketTagging(
+	_ context.Context,
+	_ *s3.PutBucketTaggingInput,
+	_ ...func(*s3.Options),
+) (*s3.PutBucketTaggingOutput, error) {
+	index := c.putTagCalls
+	c.putTagCalls++
+	if index < len(c.putTagErrors) {
+		return &s3.PutBucketTaggingOutput{}, c.putTagErrors[index]
+	}
+	return &s3.PutBucketTaggingOutput{}, nil
+}
+
+func (c *scriptedBucketClient) GetBucketTagging(
+	_ context.Context,
+	_ *s3.GetBucketTaggingInput,
+	_ ...func(*s3.Options),
+) (*s3.GetBucketTaggingOutput, error) {
+	index := c.getTagCalls
+	c.getTagCalls++
+	if index < len(c.getTagErrors) && c.getTagErrors[index] != nil {
+		return nil, c.getTagErrors[index]
+	}
+	if index >= len(c.getTagOutputs) {
+		return &s3.GetBucketTaggingOutput{}, nil
+	}
+	return c.getTagOutputs[index], nil
+}
+
+func (c *scriptedBucketClient) DeleteBucket(
+	_ context.Context,
+	_ *s3.DeleteBucketInput,
+	_ ...func(*s3.Options),
+) (*s3.DeleteBucketOutput, error) {
+	index := c.deleteCalls
+	c.deleteCalls++
+	if index < len(c.deleteErrors) {
+		return &s3.DeleteBucketOutput{}, c.deleteErrors[index]
+	}
+	return &s3.DeleteBucketOutput{}, nil
+}
+
+func bucket(name string) s3types.Bucket {
+	return s3types.Bucket{Name: aws.String(name)}
+}
+
+func TestBucketNameOwnedPreflight(t *testing.T) {
+	t.Parallel()
+
+	t.Run("exact name on later page", func(t *testing.T) {
+		t.Parallel()
+
+		client := &scriptedBucketClient{listOutputs: []*s3.ListBucketsOutput{
+			{Buckets: []s3types.Bucket{bucket("target-prefix"), bucket("suffix-target")}, ContinuationToken: aws.String("page-2")},
+			{Buckets: []s3types.Bucket{bucket("target")}},
+		}}
+
+		owned, err := bucketNameOwned(t.Context(), client, "target")
+		if err != nil {
+			t.Fatalf("bucketNameOwned() error = %v", err)
+		}
+		if !owned {
+			t.Fatal("bucketNameOwned() = false, want exact later-page match")
+		}
+		if got := aws.ToString(client.listInputs[1].ContinuationToken); got != "page-2" {
+			t.Fatalf("second continuation token = %q, want page-2", got)
+		}
+	})
+
+	t.Run("opaque continuation token is sent verbatim", func(t *testing.T) {
+		t.Parallel()
+
+		client := &scriptedBucketClient{listOutputs: []*s3.ListBucketsOutput{
+			{ContinuationToken: aws.String(" token with spaces ")},
+			{},
+		}}
+		if _, err := bucketNameOwned(t.Context(), client, "target"); err != nil {
+			t.Fatalf("bucketNameOwned() error = %v", err)
+		}
+		if got := aws.ToString(client.listInputs[1].ContinuationToken); got != " token with spaces " {
+			t.Fatalf("second continuation token = %q, want verbatim opaque token", got)
+		}
+	})
+
+	t.Run("lookalikes do not match", func(t *testing.T) {
+		t.Parallel()
+
+		client := &scriptedBucketClient{listOutputs: []*s3.ListBucketsOutput{{
+			Buckets: []s3types.Bucket{bucket("target-prefix"), bucket("suffix-target")},
+		}}}
+		owned, err := bucketNameOwned(t.Context(), client, "target")
+		if err != nil {
+			t.Fatalf("bucketNameOwned() error = %v", err)
+		}
+		if owned {
+			t.Fatal("bucketNameOwned() = true for prefix/suffix lookalikes")
+		}
+	})
+
+	t.Run("missing continuation token fails closed", func(t *testing.T) {
+		t.Parallel()
+
+		buckets := make([]s3types.Bucket, bucketPreflightPageSize)
+		for i := range buckets {
+			buckets[i] = bucket(fmt.Sprintf("other-%d", i))
+		}
+		client := &scriptedBucketClient{listOutputs: []*s3.ListBucketsOutput{{Buckets: buckets}}}
+
+		owned, err := bucketNameOwned(t.Context(), client, "target")
+		if err == nil {
+			t.Fatal("bucketNameOwned() error = nil, want incomplete-enumeration error")
+		}
+		if owned {
+			t.Fatal("bucketNameOwned() = true on incomplete enumeration")
+		}
+	})
+
+	t.Run("repeated continuation token fails closed", func(t *testing.T) {
+		t.Parallel()
+
+		client := &scriptedBucketClient{listOutputs: []*s3.ListBucketsOutput{
+			{ContinuationToken: aws.String("page-2")},
+			{ContinuationToken: aws.String("page-2")},
+		}}
+
+		owned, err := bucketNameOwned(t.Context(), client, "target")
+		if err == nil {
+			t.Fatal("bucketNameOwned() error = nil, want non-advancing-token error")
+		}
+		if owned {
+			t.Fatal("bucketNameOwned() = true on incomplete enumeration")
+		}
+	})
+
+	t.Run("empty continuation token fails closed", func(t *testing.T) {
+		t.Parallel()
+
+		client := &scriptedBucketClient{listOutputs: []*s3.ListBucketsOutput{{
+			ContinuationToken: aws.String("   "),
+		}}}
+		if owned, err := bucketNameOwned(t.Context(), client, "target"); err == nil || owned {
+			t.Fatalf("bucketNameOwned() = (%t, %v), want false and an unusable-token error", owned, err)
+		}
+	})
+}
+
+func TestCreateBucketSafely(t *testing.T) {
+	t.Parallel()
+
+	t.Run("normal create is sent once", func(t *testing.T) {
+		t.Parallel()
+
+		client := &scriptedBucketClient{listOutputs: []*s3.ListBucketsOutput{{}}}
+		if err := createBucketSafely(t.Context(), client, "target", "US-EAST-04A"); err != nil {
+			t.Fatalf("createBucketSafely() error = %v", err)
+		}
+		if client.createCalls != 1 {
+			t.Fatalf("CreateBucket calls = %d, want 1", client.createCalls)
+		}
+		if client.createMaxAttempts != 1 {
+			t.Fatalf("CreateBucket max attempts = %d, want 1", client.createMaxAttempts)
+		}
+	})
+
+	t.Run("owned exact name is not created", func(t *testing.T) {
+		t.Parallel()
+
+		client := &scriptedBucketClient{listOutputs: []*s3.ListBucketsOutput{
+			{Buckets: []s3types.Bucket{bucket("target-prefix")}, ContinuationToken: aws.String("page-2")},
+			{Buckets: []s3types.Bucket{bucket("target")}},
+		}}
+		err := createBucketSafely(t.Context(), client, "target", "US-EAST-04A")
+		var alreadyExistsErr *bucketAlreadyExistsError
+		if !errors.As(err, &alreadyExistsErr) {
+			t.Fatalf("createBucketSafely() error = %v, want already-exists error", err)
+		}
+		if client.createCalls != 0 {
+			t.Fatalf("CreateBucket calls = %d, want 0", client.createCalls)
+		}
+	})
+
+	t.Run("incomplete inventory is not created", func(t *testing.T) {
+		t.Parallel()
+
+		buckets := make([]s3types.Bucket, bucketPreflightPageSize)
+		client := &scriptedBucketClient{listOutputs: []*s3.ListBucketsOutput{{Buckets: buckets}}}
+		if err := createBucketSafely(t.Context(), client, "target", "US-EAST-04A"); err == nil {
+			t.Fatal("createBucketSafely() error = nil, want incomplete-enumeration error")
+		}
+		if client.createCalls != 0 {
+			t.Fatalf("CreateBucket calls = %d, want 0", client.createCalls)
+		}
+	})
+
+	t.Run("ambiguous create converges only with owned name and zone", func(t *testing.T) {
+		t.Parallel()
+
+		client := &scriptedBucketClient{
+			listOutputs: []*s3.ListBucketsOutput{
+				{},
+				{Buckets: []s3types.Bucket{bucket("target")}},
+			},
+			createErrors: []error{responseError(t, 503)},
+			locationOutputs: []*s3.GetBucketLocationOutput{{
+				LocationConstraint: s3types.BucketLocationConstraint("US-EAST-04A"),
+			}},
+		}
+
+		if err := createBucketSafely(t.Context(), client, "target", "US-EAST-04A"); err != nil {
+			t.Fatalf("createBucketSafely() error = %v", err)
+		}
+		if client.createCalls != 1 {
+			t.Fatalf("CreateBucket calls = %d, want 1", client.createCalls)
+		}
+		if len(client.listInputs) != 2 || client.locationCalls != 1 {
+			t.Fatalf("reconciliation calls: ListBuckets=%d GetBucketLocation=%d, want 2 and 1", len(client.listInputs), client.locationCalls)
+		}
+	})
+
+	t.Run("ambiguous create retries transient location propagation", func(t *testing.T) {
+		t.Parallel()
+
+		client := &scriptedBucketClient{
+			listOutputs: []*s3.ListBucketsOutput{
+				{},
+				{Buckets: []s3types.Bucket{bucket("target")}},
+				{Buckets: []s3types.Bucket{bucket("target")}},
+			},
+			createErrors:   []error{responseError(t, 503)},
+			locationErrors: []error{&smithy.GenericAPIError{Code: errInvalidRegion}, nil},
+			locationOutputs: []*s3.GetBucketLocationOutput{
+				nil,
+				{LocationConstraint: s3types.BucketLocationConstraint("US-EAST-04A")},
+			},
+		}
+		waits := 0
+
+		if err := createBucketSafelyWithOptions(
+			t.Context(),
+			client,
+			"target",
+			"US-EAST-04A",
+			immediatePhaseOptions(&waits),
+		); err != nil {
+			t.Fatalf("createBucketSafelyWithOptions() error = %v", err)
+		}
+		if client.createCalls != 1 || len(client.listInputs) != 3 || client.locationCalls != 2 || waits != 1 {
+			t.Fatalf("calls: Create=%d List=%d Location=%d waits=%d, want 1, 3, 2, 1", client.createCalls, len(client.listInputs), client.locationCalls, waits)
+		}
+	})
+
+	t.Run("ambiguous create rejects conflicting zone", func(t *testing.T) {
+		t.Parallel()
+
+		client := &scriptedBucketClient{
+			listOutputs: []*s3.ListBucketsOutput{
+				{},
+				{Buckets: []s3types.Bucket{bucket("target")}},
+			},
+			createErrors: []error{responseError(t, 503)},
+			locationOutputs: []*s3.GetBucketLocationOutput{{
+				LocationConstraint: s3types.BucketLocationConstraint("US-EAST-02A"),
+			}},
+		}
+
+		if err := createBucketSafely(t.Context(), client, "target", "US-EAST-04A"); err == nil {
+			t.Fatal("createBucketSafely() error = nil, want conflicting-zone rejection")
+		}
+		if client.createCalls != 1 {
+			t.Fatalf("CreateBucket calls = %d, want 1", client.createCalls)
+		}
+	})
+}
+
+func immediatePhaseOptions(waits *int) s3PhaseOptions {
+	return s3PhaseOptions{
+		now:   time.Now,
+		delay: func(int) time.Duration { return 0 },
+		wait: func(ctx context.Context, _ time.Duration) error {
+			*waits++
+			return ctx.Err()
+		},
+	}
+}
+
+func TestReconcileBucketAfterCreate(t *testing.T) {
+	t.Parallel()
+
+	expectedTags := []s3types.Tag{{Key: aws.String("env"), Value: aws.String("test")}}
+	client := &scriptedBucketClient{
+		headErrors: []error{
+			responseErrorWithCause(t, 400, &smithy.GenericAPIError{Code: "BadRequest"}),
+			&smithy.GenericAPIError{Code: errInvalidRegion},
+			responseError(t, 404),
+			nil,
+		},
+		putTagErrors: []error{
+			&smithy.GenericAPIError{Code: errInvalidRegion},
+			nil,
+		},
+		getTagOutputs: []*s3.GetBucketTaggingOutput{
+			{TagSet: []s3types.Tag{{Key: aws.String("env"), Value: aws.String("stale")}}},
+			{TagSet: expectedTags},
+		},
+	}
+	waits := 0
+
+	err := reconcileBucketAfterCreate(
+		t.Context(),
+		client,
+		"target",
+		"US-EAST-04A",
+		expectedTags,
+		true,
+		immediatePhaseOptions(&waits),
+	)
+	if err != nil {
+		t.Fatalf("reconcileBucketAfterCreate() error = %v", err)
+	}
+	if client.headCalls != 4 || client.putTagCalls != 2 || client.getTagCalls != 2 {
+		t.Fatalf("calls: Head=%d PutTags=%d GetTags=%d, want 4, 2, 2", client.headCalls, client.putTagCalls, client.getTagCalls)
+	}
+	if waits != 5 {
+		t.Fatalf("backoff waits = %d, want 5", waits)
+	}
+}
+
+func TestReconcileBucketAfterCreateDoesNotRetryUnrelated400(t *testing.T) {
+	t.Parallel()
+
+	client := &scriptedBucketClient{headErrors: []error{
+		&smithy.GenericAPIError{Code: "InvalidBucketName"},
+		nil,
+	}}
+	waits := 0
+	err := reconcileBucketAfterCreate(
+		t.Context(),
+		client,
+		"target",
+		"US-EAST-04A",
+		nil,
+		false,
+		immediatePhaseOptions(&waits),
+	)
+	if err == nil {
+		t.Fatal("reconcileBucketAfterCreate() error = nil, want permanent failure")
+	}
+	if client.headCalls != 1 || waits != 0 {
+		t.Fatalf("calls: Head=%d waits=%d, want 1 and 0", client.headCalls, waits)
+	}
+}
+
+func TestDeleteBucketWithRetryHandlesLocationPropagation(t *testing.T) {
+	t.Parallel()
+
+	client := &scriptedBucketClient{deleteErrors: []error{
+		&smithy.GenericAPIError{Code: errInvalidRegion},
+		nil,
+	}}
+	waits := 0
+	if err := deleteBucketWithRetry(
+		t.Context(),
+		client,
+		"target",
+		"US-EAST-04A",
+		immediatePhaseOptions(&waits),
+	); err != nil {
+		t.Fatalf("deleteBucketWithRetry() error = %v", err)
+	}
+	if client.deleteCalls != 2 || waits != 1 {
+		t.Fatalf("calls: Delete=%d waits=%d, want 2 and 1", client.deleteCalls, waits)
+	}
+}
+
+func TestIsPostCreateRetryableS3Error(t *testing.T) {
+	t.Parallel()
+
+	tlsErr := &url.Error{
+		Op:  "Head",
+		URL: "https://bucket.example.test",
+		Err: &tls.CertificateVerificationError{Err: errors.New("unknown authority")},
+	}
+	tests := map[string]struct {
+		err  error
+		want bool
+	}{
+		"InvalidRegion":       {err: &smithy.GenericAPIError{Code: errInvalidRegion}, want: true},
+		"404":                 {err: responseError(t, 404), want: true},
+		"408":                 {err: responseError(t, 408), want: true},
+		"429":                 {err: responseError(t, 429), want: true},
+		"429 with API code":   {err: responseErrorWithCause(t, 429, &smithy.GenericAPIError{Code: "TooManyRequests"}), want: true},
+		"500 with API code":   {err: responseErrorWithCause(t, 500, &smithy.GenericAPIError{Code: "InternalServerError"}), want: true},
+		"502 with API code":   {err: responseErrorWithCause(t, 502, &smithy.GenericAPIError{Code: "BadGateway"}), want: true},
+		"503":                 {err: responseError(t, 503), want: true},
+		"504 with API code":   {err: responseErrorWithCause(t, 504, &smithy.GenericAPIError{Code: "GatewayTimeout"}), want: true},
+		"wrapped network":     {err: fmt.Errorf("head bucket: %w", &url.Error{Op: "Head", URL: "https://example.test", Err: errors.New("connection reset")}), want: true},
+		"wrapped certificate": {err: fmt.Errorf("head bucket: %w", tlsErr)},
+		"unrelated 400":       {err: &smithy.GenericAPIError{Code: "InvalidBucketName"}},
+		"access denied":       {err: &smithy.GenericAPIError{Code: "AccessDenied"}},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			if got := isPostCreateRetryableS3Error(tt.err); got != tt.want {
+				t.Fatalf("isPostCreateRetryableS3Error() = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsAmbiguousCreateError(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		ctx  context.Context
+		err  error
+		want bool
+	}{
+		"HTTP 503":          {ctx: t.Context(), err: responseError(t, 503), want: true},
+		"429 with API code": {ctx: t.Context(), err: responseErrorWithCause(t, 429, &smithy.GenericAPIError{Code: "TooManyRequests"}), want: true},
+		"500 with API code": {ctx: t.Context(), err: responseErrorWithCause(t, 500, &smithy.GenericAPIError{Code: "InternalServerError"}), want: true},
+		"502 with API code": {ctx: t.Context(), err: responseErrorWithCause(t, 502, &smithy.GenericAPIError{Code: "BadGateway"}), want: true},
+		"504 with API code": {ctx: t.Context(), err: responseErrorWithCause(t, 504, &smithy.GenericAPIError{Code: "GatewayTimeout"}), want: true},
+		"InternalError":     {ctx: t.Context(), err: &smithy.GenericAPIError{Code: "InternalError"}, want: true},
+		"wrapped network":   {ctx: t.Context(), err: fmt.Errorf("create bucket: %w", &url.Error{Op: "Put", URL: "https://example.test", Err: errors.New("connection reset")}), want: true},
+		"attempt deadline":  {ctx: t.Context(), err: fmt.Errorf("create bucket: %w", &url.Error{Op: "Put", URL: "https://example.test", Err: context.DeadlineExceeded}), want: true},
+		"certificate":       {ctx: t.Context(), err: &url.Error{Op: "Put", URL: "https://example.test", Err: &tls.CertificateVerificationError{Err: errors.New("unknown authority")}}},
+		"unrelated API 400": {ctx: t.Context(), err: &smithy.GenericAPIError{Code: "InvalidBucketName"}},
+	}
+	canceledCtx, cancel := context.WithCancel(t.Context())
+	cancel()
+	tests["operation canceled"] = struct {
+		ctx  context.Context
+		err  error
+		want bool
+	}{ctx: canceledCtx, err: context.Canceled}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			if got := isAmbiguousCreateError(tt.ctx, tt.err); got != tt.want {
+				t.Fatalf("isAmbiguousCreateError() = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}
+
+type ambiguousTimeoutRoundTripper struct {
+	bucket      string
+	zone        string
+	createCalls int
+	listCalls   int
+	zoneCalls   int
+}
+
+func (r *ambiguousTimeoutRoundTripper) RoundTrip(request *standardhttp.Request) (*standardhttp.Response, error) {
+	if request.Method == standardhttp.MethodPut {
+		r.createCalls++
+		<-request.Context().Done()
+		return nil, request.Context().Err()
+	}
+
+	body := ""
+	switch {
+	case request.Method == standardhttp.MethodGet && request.URL.Query().Has("location"):
+		r.zoneCalls++
+		body = fmt.Sprintf(`<LocationConstraint xmlns="http://s3.amazonaws.com/doc/2006-03-01/">%s</LocationConstraint>`, r.zone)
+	case request.Method == standardhttp.MethodGet:
+		r.listCalls++
+		bucketXML := ""
+		if r.listCalls > 1 {
+			bucketXML = fmt.Sprintf("<Bucket><Name>%s</Name></Bucket>", r.bucket)
+		}
+		body = fmt.Sprintf(`<ListAllMyBucketsResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Buckets>%s</Buckets></ListAllMyBucketsResult>`, bucketXML)
+	default:
+		return nil, fmt.Errorf("unexpected S3 request %s %s", request.Method, request.URL.String())
+	}
+
+	return &standardhttp.Response{
+		StatusCode: standardhttp.StatusOK,
+		Status:     "200 OK",
+		Header:     make(standardhttp.Header),
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Request:    request,
+	}, nil
+}
+
+func TestCreateBucketSafelyReconcilesHTTPAttemptTimeout(t *testing.T) {
+	const (
+		bucketName = "accepted-after-timeout"
+		zone       = "US-EAST-04A"
+	)
+	transport := &ambiguousTimeoutRoundTripper{bucket: bucketName, zone: zone}
+	client := s3.New(s3.Options{
+		BaseEndpoint: aws.String("https://objects.example.test"),
+		Credentials:  credentials.NewStaticCredentialsProvider("access-key", "secret-key", ""),
+		HTTPClient: &standardhttp.Client{
+			Timeout:   10 * time.Millisecond,
+			Transport: transport,
+		},
+		Region:  zone,
+		Retryer: aws.NopRetryer{},
+	})
+	waits := 0
+
+	if err := createBucketSafelyWithOptions(
+		t.Context(),
+		client,
+		bucketName,
+		zone,
+		immediatePhaseOptions(&waits),
+	); err != nil {
+		t.Fatalf("createBucketSafelyWithOptions() error = %v", err)
+	}
+	if transport.createCalls != 1 {
+		t.Fatalf("CreateBucket sends = %d, want 1", transport.createCalls)
+	}
+	if transport.listCalls != 2 || transport.zoneCalls != 1 {
+		t.Fatalf("reconciliation calls: List=%d Location=%d, want 2 and 1", transport.listCalls, transport.zoneCalls)
+	}
+}
+
+type stateRetentionRoundTripper struct {
+	createCalls int
+	headCalls   int
+}
+
+func (r *stateRetentionRoundTripper) RoundTrip(request *standardhttp.Request) (*standardhttp.Response, error) {
+	status := standardhttp.StatusOK
+	body := ""
+	switch request.Method {
+	case standardhttp.MethodGet:
+		body = `<ListAllMyBucketsResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Buckets></Buckets></ListAllMyBucketsResult>`
+	case standardhttp.MethodPut:
+		r.createCalls++
+	case standardhttp.MethodHead:
+		r.headCalls++
+		status = standardhttp.StatusNotFound
+	default:
+		return nil, fmt.Errorf("unexpected S3 method %s", request.Method)
+	}
+
+	return &standardhttp.Response{
+		StatusCode: status,
+		Status:     fmt.Sprintf("%d %s", status, standardhttp.StatusText(status)),
+		Header:     make(standardhttp.Header),
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Request:    request,
+	}, nil
+}
+
+func TestBucketCreateRetainsIdentityWhenReadinessTimesOut(t *testing.T) {
+	transport := &stateRetentionRoundTripper{}
+	s3Client := s3.New(s3.Options{
+		BaseEndpoint: aws.String("https://objects.example.test"),
+		Credentials:  credentials.NewStaticCredentialsProvider("access-key", "secret-key", ""),
+		HTTPClient:   &standardhttp.Client{Transport: transport},
+		Region:       "US-EAST-04A",
+		Retryer:      aws.NopRetryer{},
+	})
+
+	resourceUnderTest := &BucketResource{
+		s3ClientForZone: func(context.Context, string) (*s3.Client, error) {
+			return s3Client, nil
+		},
+		postCreateOptions: s3PhaseOptions{
+			now:   time.Now,
+			delay: func(int) time.Duration { return 0 },
+			wait: func(context.Context, time.Duration) error {
+				return context.DeadlineExceeded
+			},
+		},
+	}
+	var schemaResponse fwresource.SchemaResponse
+	resourceUnderTest.Schema(t.Context(), fwresource.SchemaRequest{}, &schemaResponse)
+	if schemaResponse.Diagnostics.HasError() {
+		t.Fatalf("bucket schema diagnostics: %v", schemaResponse.Diagnostics)
+	}
+
+	model := BucketResourceModel{
+		Name: types.StringValue("state-retention-test"),
+		Zone: types.StringValue("US-EAST-04A"),
+		Tags: types.MapNull(types.StringType),
+	}
+	plan := tfsdk.Plan{Schema: schemaResponse.Schema}
+	if diagnostics := plan.Set(t.Context(), &model); diagnostics.HasError() {
+		t.Fatalf("set test plan: %v", diagnostics)
+	}
+	response := &fwresource.CreateResponse{State: tfsdk.State{Schema: schemaResponse.Schema}}
+
+	resourceUnderTest.Create(t.Context(), fwresource.CreateRequest{Plan: plan}, response)
+
+	if !response.Diagnostics.HasError() {
+		t.Fatal("Create() diagnostics contain no error, want readiness timeout")
+	}
+	if transport.createCalls != 1 {
+		t.Fatalf("CreateBucket sends = %d, want 1", transport.createCalls)
+	}
+	if transport.headCalls == 0 {
+		t.Fatal("HeadBucket sends = 0, want immediate readiness check")
+	}
+
+	var retained BucketResourceModel
+	if diagnostics := response.State.Get(t.Context(), &retained); diagnostics.HasError() {
+		t.Fatalf("read retained state: %v", diagnostics)
+	}
+	if retained.Name.ValueString() != model.Name.ValueString() || retained.Zone.ValueString() != model.Zone.ValueString() {
+		t.Fatalf("retained identity = (%q, %q), want (%q, %q)", retained.Name.ValueString(), retained.Zone.ValueString(), model.Name.ValueString(), model.Zone.ValueString())
+	}
+}

--- a/coreweave/object_storage/resource_bucket_create_unit_test.go
+++ b/coreweave/object_storage/resource_bucket_create_unit_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/aws/smithy-go"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	fwresource "github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -640,6 +641,83 @@ func TestCreateBucketSafelyReconcilesHTTPAttemptTimeout(t *testing.T) {
 type stateRetentionRoundTripper struct {
 	createCalls int
 	headCalls   int
+}
+
+type emptyTagsCreateRoundTripper struct {
+	createCalls int
+	tagCalls    int
+}
+
+func (r *emptyTagsCreateRoundTripper) RoundTrip(request *standardhttp.Request) (*standardhttp.Response, error) {
+	if request.URL.Query().Has("tagging") {
+		r.tagCalls++
+		return nil, errors.New("tagging API must not be called for an explicitly empty tag map")
+	}
+
+	body := ""
+	switch request.Method {
+	case standardhttp.MethodGet:
+		body = `<ListAllMyBucketsResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Buckets></Buckets></ListAllMyBucketsResult>`
+	case standardhttp.MethodPut:
+		r.createCalls++
+	case standardhttp.MethodHead:
+	default:
+		return nil, fmt.Errorf("unexpected S3 method %s", request.Method)
+	}
+
+	return &standardhttp.Response{
+		StatusCode: standardhttp.StatusOK,
+		Status:     "200 OK",
+		Header:     make(standardhttp.Header),
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Request:    request,
+	}, nil
+}
+
+func TestBucketCreateWithEmptyTagsSkipsTaggingAndPreservesState(t *testing.T) {
+	transport := &emptyTagsCreateRoundTripper{}
+	s3Client := s3.New(s3.Options{
+		BaseEndpoint: aws.String("https://objects.example.test"),
+		Credentials:  credentials.NewStaticCredentialsProvider("access-key", "secret-key", ""),
+		HTTPClient:   &standardhttp.Client{Transport: transport},
+		Region:       "US-EAST-04A",
+		Retryer:      aws.NopRetryer{},
+	})
+	resourceUnderTest := &BucketResource{s3ClientForZone: func(context.Context, string) (*s3.Client, error) {
+		return s3Client, nil
+	}}
+	var schemaResponse fwresource.SchemaResponse
+	resourceUnderTest.Schema(t.Context(), fwresource.SchemaRequest{}, &schemaResponse)
+	if schemaResponse.Diagnostics.HasError() {
+		t.Fatalf("bucket schema diagnostics: %v", schemaResponse.Diagnostics)
+	}
+
+	model := BucketResourceModel{
+		Name: types.StringValue("empty-tags-test"),
+		Zone: types.StringValue("US-EAST-04A"),
+		Tags: types.MapValueMust(types.StringType, map[string]attr.Value{}),
+	}
+	plan := tfsdk.Plan{Schema: schemaResponse.Schema}
+	if diagnostics := plan.Set(t.Context(), &model); diagnostics.HasError() {
+		t.Fatalf("set test plan: %v", diagnostics)
+	}
+	response := &fwresource.CreateResponse{State: tfsdk.State{Schema: schemaResponse.Schema}}
+
+	resourceUnderTest.Create(t.Context(), fwresource.CreateRequest{Plan: plan}, response)
+
+	if response.Diagnostics.HasError() {
+		t.Fatalf("Create() diagnostics = %v", response.Diagnostics)
+	}
+	if transport.createCalls != 1 || transport.tagCalls != 0 {
+		t.Fatalf("S3 calls: Create=%d Tags=%d, want 1 and 0", transport.createCalls, transport.tagCalls)
+	}
+	var retained BucketResourceModel
+	if diagnostics := response.State.Get(t.Context(), &retained); diagnostics.HasError() {
+		t.Fatalf("read retained state: %v", diagnostics)
+	}
+	if retained.Tags.IsNull() || len(retained.Tags.Elements()) != 0 {
+		t.Fatalf("retained tags = %#v, want known empty map", retained.Tags)
+	}
 }
 
 func (r *stateRetentionRoundTripper) RoundTrip(request *standardhttp.Request) (*standardhttp.Response, error) {

--- a/coreweave/object_storage/resource_bucket_test.go
+++ b/coreweave/object_storage/resource_bucket_test.go
@@ -90,18 +90,30 @@ func TestBucketResource(t *testing.T) {
 		ProtoV6ProviderFactories: provider.TestProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			createBucketTestStep(ctx, t, bucketTestStep{
-				TestName:     "initial bucket with tags",
+				TestName:     "initial bucket with explicit empty tags",
 				ResourceName: "test_acc_bucket",
 				Bucket: objectstorage.BucketResourceModel{
 					Name: types.StringValue(bucketName),
 					Zone: types.StringValue(zone),
-					Tags: types.MapValueMust(types.StringType, map[string]attr.Value{
-						"test-tag": types.StringValue("initial"),
-					}),
+					Tags: types.MapValueMust(types.StringType, map[string]attr.Value{}),
 				},
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
 						plancheck.ExpectResourceAction(fmt.Sprintf("coreweave_object_storage_bucket.%s", "test_acc_bucket"), plancheck.ResourceActionCreate),
+					},
+				},
+			}),
+			createBucketTestStep(ctx, t, bucketTestStep{
+				TestName:     "explicit empty tags remain stable after refresh",
+				ResourceName: "test_acc_bucket",
+				Bucket: objectstorage.BucketResourceModel{
+					Name: types.StringValue(bucketName),
+					Zone: types.StringValue(zone),
+					Tags: types.MapValueMust(types.StringType, map[string]attr.Value{}),
+				},
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(fmt.Sprintf("coreweave_object_storage_bucket.%s", "test_acc_bucket"), plancheck.ResourceActionNoop),
 					},
 				},
 			}),
@@ -123,7 +135,35 @@ func TestBucketResource(t *testing.T) {
 				},
 			}),
 			createBucketTestStep(ctx, t, bucketTestStep{
-				TestName:     "remove tags",
+				TestName:     "clear tags with explicit empty map",
+				ResourceName: "test_acc_bucket",
+				Bucket: objectstorage.BucketResourceModel{
+					Name: types.StringValue(bucketName),
+					Zone: types.StringValue(zone),
+					Tags: types.MapValueMust(types.StringType, map[string]attr.Value{}),
+				},
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(fmt.Sprintf("coreweave_object_storage_bucket.%s", "test_acc_bucket"), plancheck.ResourceActionUpdate),
+					},
+				},
+			}),
+			createBucketTestStep(ctx, t, bucketTestStep{
+				TestName:     "explicit empty tags remain stable after update",
+				ResourceName: "test_acc_bucket",
+				Bucket: objectstorage.BucketResourceModel{
+					Name: types.StringValue(bucketName),
+					Zone: types.StringValue(zone),
+					Tags: types.MapValueMust(types.StringType, map[string]attr.Value{}),
+				},
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(fmt.Sprintf("coreweave_object_storage_bucket.%s", "test_acc_bucket"), plancheck.ResourceActionNoop),
+					},
+				},
+			}),
+			createBucketTestStep(ctx, t, bucketTestStep{
+				TestName:     "omit tags",
 				ResourceName: "test_acc_bucket",
 				Bucket: objectstorage.BucketResourceModel{
 					Name: types.StringValue(bucketName),

--- a/coreweave/object_storage/resource_bucket_test.go
+++ b/coreweave/object_storage/resource_bucket_test.go
@@ -81,7 +81,7 @@ func createBucketTestStep(ctx context.Context, t *testing.T, opts bucketTestStep
 }
 
 func TestBucketResource(t *testing.T) {
-	randomInt := rand.IntN(100)
+	randomInt := rand.IntN(1000000)
 	bucketName := fmt.Sprintf("%stest-bucket-%d", AcceptanceTestPrefix, randomInt)
 	zone := "US-EAST-04A"
 
@@ -90,30 +90,18 @@ func TestBucketResource(t *testing.T) {
 		ProtoV6ProviderFactories: provider.TestProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			createBucketTestStep(ctx, t, bucketTestStep{
-				TestName:     "initial bucket with explicit empty tags",
+				TestName:     "initial bucket with tags",
 				ResourceName: "test_acc_bucket",
 				Bucket: objectstorage.BucketResourceModel{
 					Name: types.StringValue(bucketName),
 					Zone: types.StringValue(zone),
-					Tags: types.MapValueMust(types.StringType, map[string]attr.Value{}),
+					Tags: types.MapValueMust(types.StringType, map[string]attr.Value{
+						"test-tag": types.StringValue("initial"),
+					}),
 				},
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
 						plancheck.ExpectResourceAction(fmt.Sprintf("coreweave_object_storage_bucket.%s", "test_acc_bucket"), plancheck.ResourceActionCreate),
-					},
-				},
-			}),
-			createBucketTestStep(ctx, t, bucketTestStep{
-				TestName:     "explicit empty tags remain stable after refresh",
-				ResourceName: "test_acc_bucket",
-				Bucket: objectstorage.BucketResourceModel{
-					Name: types.StringValue(bucketName),
-					Zone: types.StringValue(zone),
-					Tags: types.MapValueMust(types.StringType, map[string]attr.Value{}),
-				},
-				ConfigPlanChecks: resource.ConfigPlanChecks{
-					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectResourceAction(fmt.Sprintf("coreweave_object_storage_bucket.%s", "test_acc_bucket"), plancheck.ResourceActionNoop),
 					},
 				},
 			}),
@@ -177,11 +165,12 @@ func TestBucketResource(t *testing.T) {
 				},
 			}),
 			createBucketTestStep(ctx, t, bucketTestStep{
-				TestName:     "requires replace zone",
+				TestName:     "requires replace zone with explicit empty tags",
 				ResourceName: "test_acc_bucket",
 				Bucket: objectstorage.BucketResourceModel{
 					Name: types.StringValue(bucketName),
 					Zone: types.StringValue("US-EAST-02A"),
+					Tags: types.MapValueMust(types.StringType, map[string]attr.Value{}),
 				},
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{

--- a/coreweave/object_storage/resource_bucket_unit_test.go
+++ b/coreweave/object_storage/resource_bucket_unit_test.go
@@ -5,12 +5,16 @@ import (
 	"errors"
 	"fmt"
 	standardhttp "net/http"
+	"strings"
 	"testing"
 
 	awsretry "github.com/aws/aws-sdk-go-v2/aws/retry"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/aws/smithy-go"
 	smithyhttp "github.com/aws/smithy-go/transport/http"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 type bucketHeadCheckerStub struct {
@@ -139,4 +143,69 @@ func TestBucketExists(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestBucketTagsForState(t *testing.T) {
+	t.Parallel()
+
+	explicitEmpty := types.MapValueMust(types.StringType, map[string]attr.Value{})
+	t.Run("preserves an explicitly empty configured map", func(t *testing.T) {
+		t.Parallel()
+
+		got, diagnostics := bucketTagsForState(explicitEmpty, nil)
+		if diagnostics.HasError() {
+			t.Fatalf("bucketTagsForState() diagnostics = %v", diagnostics)
+		}
+		if got.IsNull() || len(got.Elements()) != 0 {
+			t.Fatalf("bucketTagsForState() = %#v, want known empty map", got)
+		}
+	})
+
+	t.Run("keeps an unconfigured empty tag set null", func(t *testing.T) {
+		t.Parallel()
+
+		got, diagnostics := bucketTagsForState(types.MapNull(types.StringType), nil)
+		if diagnostics.HasError() {
+			t.Fatalf("bucketTagsForState() diagnostics = %v", diagnostics)
+		}
+		if !got.IsNull() {
+			t.Fatalf("bucketTagsForState() = %#v, want null map", got)
+		}
+	})
+
+	t.Run("remote tags replace the previous value", func(t *testing.T) {
+		t.Parallel()
+
+		got, diagnostics := bucketTagsForState(explicitEmpty, []s3types.Tag{{
+			Key:   stringPointer("env"),
+			Value: stringPointer("test"),
+		}})
+		if diagnostics.HasError() {
+			t.Fatalf("bucketTagsForState() diagnostics = %v", diagnostics)
+		}
+		var values map[string]string
+		if diagnostics := got.ElementsAs(t.Context(), &values, false); diagnostics.HasError() {
+			t.Fatalf("read bucket tag state: %v", diagnostics)
+		}
+		if values["env"] != "test" || len(values) != 1 {
+			t.Fatalf("bucketTagsForState() values = %#v, want env=test", values)
+		}
+	})
+}
+
+func TestMustRenderBucketResourceWithEmptyTags(t *testing.T) {
+	t.Parallel()
+
+	config := MustRenderBucketResource(t.Context(), "empty_tags", &BucketResourceModel{
+		Name: types.StringValue("empty-tags-test"),
+		Zone: types.StringValue("US-EAST-04A"),
+		Tags: types.MapValueMust(types.StringType, map[string]attr.Value{}),
+	})
+	if !strings.Contains(config, "tags = {}") {
+		t.Fatalf("rendered config does not preserve an explicit empty tag map:\n%s", config)
+	}
+}
+
+func stringPointer(value string) *string {
+	return &value
 }

--- a/coreweave/object_storage/resource_bucket_unit_test.go
+++ b/coreweave/object_storage/resource_bucket_unit_test.go
@@ -4,11 +4,15 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	standardhttp "net/http"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	awsretry "github.com/aws/aws-sdk-go-v2/aws/retry"
+	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/aws/smithy-go"
@@ -88,14 +92,17 @@ func TestIsMissingBucketTagSetError(t *testing.T) {
 func TestWithBucketReadRetry(t *testing.T) {
 	t.Parallel()
 
-	const maxAttempts = 3
+	const (
+		globalMaxAttempts    = 3
+		expectedReadAttempts = 8
+	)
 	options := s3.Options{Retryer: awsretry.NewStandard(func(options *awsretry.StandardOptions) {
-		options.MaxAttempts = maxAttempts
+		options.MaxAttempts = globalMaxAttempts
 	})}
 	withBucketReadRetry(&options)
 
-	if got := options.Retryer.MaxAttempts(); got != maxAttempts {
-		t.Errorf("MaxAttempts() = %d, want preserved cap %d", got, maxAttempts)
+	if got := options.Retryer.MaxAttempts(); got != expectedReadAttempts {
+		t.Errorf("MaxAttempts() = %d, want bucket read cap %d", got, expectedReadAttempts)
 	}
 	if !options.Retryer.IsErrorRetryable(&smithy.GenericAPIError{Code: ErrNoSuchBucket}) {
 		t.Error("NoSuchBucket should be retryable")
@@ -108,6 +115,88 @@ func TestWithBucketReadRetry(t *testing.T) {
 	}
 	if options.Retryer.IsErrorRetryable(&smithy.GenericAPIError{Code: errNoSuchTagSet}) {
 		t.Error("NoSuchTagSet should not be retryable")
+	}
+}
+
+type eventuallyVisibleBucketTransport struct {
+	attempts          int
+	transientFailures int
+}
+
+type immediateBackoff struct{}
+
+func (immediateBackoff) BackoffDelay(int, error) (time.Duration, error) {
+	return 0, nil
+}
+
+func (t *eventuallyVisibleBucketTransport) RoundTrip(request *standardhttp.Request) (*standardhttp.Response, error) {
+	t.attempts++
+	status := standardhttp.StatusOK
+	if t.attempts <= t.transientFailures {
+		status = standardhttp.StatusNotFound
+	}
+
+	return &standardhttp.Response{
+		StatusCode: status,
+		Status:     standardhttp.StatusText(status),
+		Header:     make(standardhttp.Header),
+		Body:       io.NopCloser(strings.NewReader("")),
+		Request:    request,
+	}, nil
+}
+
+func TestBucketExistsOutlivesGlobalS3RetryBudget(t *testing.T) {
+	t.Parallel()
+
+	const globalS3RetryAttempts = 3
+	transport := &eventuallyVisibleBucketTransport{transientFailures: globalS3RetryAttempts}
+	client := s3.New(s3.Options{
+		BaseEndpoint: aws.String("https://objects.example.test"),
+		Credentials:  credentials.NewStaticCredentialsProvider("access-key", "secret-key", ""),
+		HTTPClient:   &standardhttp.Client{Transport: transport},
+		Region:       "US-EAST-04A",
+		Retryer: awsretry.NewStandard(func(options *awsretry.StandardOptions) {
+			options.Backoff = immediateBackoff{}
+			options.MaxAttempts = globalS3RetryAttempts
+		}),
+	})
+
+	exists, err := bucketExists(t.Context(), client, "eventually-visible")
+	if err != nil {
+		t.Fatalf("bucketExists() error = %v", err)
+	}
+	if !exists {
+		t.Fatal("bucketExists() = false after transient 404 responses, want true")
+	}
+	if got, want := transport.attempts, globalS3RetryAttempts+1; got != want {
+		t.Fatalf("HeadBucket attempts = %d, want %d", got, want)
+	}
+}
+
+func TestBucketExistsStopsAtReadRetryBudget(t *testing.T) {
+	t.Parallel()
+
+	transport := &eventuallyVisibleBucketTransport{transientFailures: bucketReadMaxAttempts}
+	client := s3.New(s3.Options{
+		BaseEndpoint: aws.String("https://objects.example.test"),
+		Credentials:  credentials.NewStaticCredentialsProvider("access-key", "secret-key", ""),
+		HTTPClient:   &standardhttp.Client{Transport: transport},
+		Region:       "US-EAST-04A",
+		Retryer: awsretry.NewStandard(func(options *awsretry.StandardOptions) {
+			options.Backoff = immediateBackoff{}
+			options.MaxAttempts = 3
+		}),
+	})
+
+	exists, err := bucketExists(t.Context(), client, "absent-bucket")
+	if err != nil {
+		t.Fatalf("bucketExists() error = %v", err)
+	}
+	if exists {
+		t.Fatal("bucketExists() = true after exhausting transient 404 responses, want false")
+	}
+	if got := transport.attempts; got != bucketReadMaxAttempts {
+		t.Fatalf("HeadBucket attempts = %d, want capped at %d", got, bucketReadMaxAttempts)
 	}
 }
 

--- a/coreweave/object_storage/resource_bucket_unit_test.go
+++ b/coreweave/object_storage/resource_bucket_unit_test.go
@@ -7,7 +7,7 @@ import (
 	standardhttp "net/http"
 	"testing"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
+	awsretry "github.com/aws/aws-sdk-go-v2/aws/retry"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/smithy-go"
 	smithyhttp "github.com/aws/smithy-go/transport/http"
@@ -84,11 +84,14 @@ func TestIsMissingBucketTagSetError(t *testing.T) {
 func TestWithBucketReadRetry(t *testing.T) {
 	t.Parallel()
 
-	options := s3.Options{Retryer: aws.NopRetryer{}}
+	const maxAttempts = 3
+	options := s3.Options{Retryer: awsretry.NewStandard(func(options *awsretry.StandardOptions) {
+		options.MaxAttempts = maxAttempts
+	})}
 	withBucketReadRetry(&options)
 
-	if got := options.Retryer.MaxAttempts(); got != bucketReadMaxAttempts {
-		t.Errorf("MaxAttempts() = %d, want %d", got, bucketReadMaxAttempts)
+	if got := options.Retryer.MaxAttempts(); got != maxAttempts {
+		t.Errorf("MaxAttempts() = %d, want preserved cap %d", got, maxAttempts)
 	}
 	if !options.Retryer.IsErrorRetryable(&smithy.GenericAPIError{Code: ErrNoSuchBucket}) {
 		t.Error("NoSuchBucket should be retryable")

--- a/coreweave/retry.go
+++ b/coreweave/retry.go
@@ -34,30 +34,8 @@ var (
 
 func baseRetryPolicy(resp *http.Response, err error) (bool, error) {
 	if err != nil {
-		var v *url.Error
-		if errors.Is(err, v) {
-			// Don't retry if the error was due to too many redirects.
-			if redirectsErrorRe.MatchString(v.Error()) {
-				return false, v
-			}
-
-			// Don't retry if the error was due to an invalid protocol scheme.
-			if schemeErrorRe.MatchString(v.Error()) {
-				return false, v
-			}
-
-			// Don't retry if the error was due to an invalid header.
-			if invalidHeaderErrorRe.MatchString(v.Error()) {
-				return false, v
-			}
-
-			// Don't retry if the error was due to TLS cert verification failure.
-			if notTrustedErrorRe.MatchString(v.Error()) {
-				return false, v
-			}
-			if errors.Is(v, &tls.CertificateVerificationError{}) {
-				return false, v
-			}
+		if permanentErr := permanentRequestError(err); permanentErr != nil {
+			return false, permanentErr
 		}
 
 		// The error is likely recoverable so retry.
@@ -80,6 +58,37 @@ func baseRetryPolicy(resp *http.Response, err error) (bool, error) {
 	}
 
 	return false, nil
+}
+
+// permanentRequestError returns the request error when retrying cannot change
+// the outcome, such as malformed requests, exhausted redirects, or certificate
+// verification failures.
+func permanentRequestError(err error) error {
+	var certificateErr *tls.CertificateVerificationError
+	if errors.As(err, &certificateErr) {
+		return err
+	}
+
+	var urlErr *url.Error
+	if !errors.As(err, &urlErr) {
+		return nil
+	}
+
+	if redirectsErrorRe.MatchString(urlErr.Error()) ||
+		schemeErrorRe.MatchString(urlErr.Error()) ||
+		invalidHeaderErrorRe.MatchString(urlErr.Error()) ||
+		notTrustedErrorRe.MatchString(urlErr.Error()) {
+		return urlErr
+	}
+
+	return nil
+}
+
+// IsPermanentRequestError reports whether retrying a malformed request,
+// exhausted redirect, or certificate-verification failure cannot change the
+// outcome.
+func IsPermanentRequestError(err error) bool {
+	return permanentRequestError(err) != nil
 }
 
 func RetryPolicy(ctx context.Context, resp *http.Response, err error) (bool, error) {

--- a/coreweave/retry_test.go
+++ b/coreweave/retry_test.go
@@ -1,0 +1,37 @@
+package coreweave
+
+import (
+	"crypto/tls"
+	"errors"
+	"net/url"
+	"testing"
+)
+
+func TestBaseRetryPolicyRejectsWrappedPermanentRequestErrors(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]error{
+		"redirect exhaustion": &url.Error{Op: "Get", URL: "https://example.test", Err: errors.New("stopped after 10 redirects")},
+		"invalid scheme":      &url.Error{Op: "Get", URL: "example.test", Err: errors.New("unsupported protocol scheme")},
+		"invalid header":      &url.Error{Op: "Get", URL: "https://example.test", Err: errors.New("invalid header field value")},
+		"certificate": &url.Error{
+			Op:  "Get",
+			URL: "https://example.test",
+			Err: &tls.CertificateVerificationError{Err: errors.New("certificate is not trusted")},
+		},
+	}
+
+	for name, requestErr := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			retry, err := baseRetryPolicy(nil, requestErr)
+			if retry {
+				t.Fatal("baseRetryPolicy() marked a permanent request error retryable")
+			}
+			if !errors.Is(err, requestErr) {
+				t.Fatalf("baseRetryPolicy() error = %v, want wrapped request error %v", err, requestErr)
+			}
+		})
+	}
+}

--- a/coreweave/s3.go
+++ b/coreweave/s3.go
@@ -11,44 +11,116 @@ import (
 	cwobjectv1 "buf.build/gen/go/coreweave/cwobject/protocolbuffers/go/cwobject/v1"
 	"connectrpc.com/connect"
 	"github.com/aws/aws-sdk-go-v2/aws"
+	awsretry "github.com/aws/aws-sdk-go-v2/aws/retry"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/smithy-go"
 	"github.com/hashicorp/go-cleanhttp"
-	retryablehttp "github.com/hashicorp/go-retryablehttp"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
-var (
-	// We use global variables here because the ConfigureProvider RPC is called on every Create/Update/Delete
-	// operation within a plan/apply which leads to the provider rebuilding a fresh client on each Terraform operation.
-	// Using global variables allows the s3 client to be persisted across Terraform operations
-	// and prevents us from generating excess access keys
-	s3Mu              sync.Mutex
-	singletonS3Client *s3.Client
-	s3AccessKeyInfo   *cwobjectv1.CreateAccessKeyFromJWTResponse
-)
-
 const (
+	// DefaultS3AttemptTimeout preserves the historical per-attempt timeout when
+	// the provider's http_timeout setting is not configured.
+	DefaultS3AttemptTimeout    = 30 * time.Second
+	s3CredentialRefreshTimeout = 2 * time.Minute
+	s3MaxAttempts              = 3
+	s3MaxBackoff               = 5 * time.Second
+
 	errAccessDenied string = "AccessDenied"
 )
 
-func (c *Client) s3HttpClient() *http.Client {
-	rc := retryablehttp.NewClient()
-	rc.HTTPClient.Timeout = 30 * time.Second
-	// cleanhttp.DefaultTransport disables keep-alives & idle connections
-	// this helps us avoid S3 DNS caching, which can make creating/deleting buckets inconsistent
-	rc.HTTPClient.Transport = cleanhttp.DefaultTransport()
-	rc.RetryMax = 10
-	rc.RetryWaitMin = 200 * time.Millisecond
-	rc.RetryWaitMax = 5 * time.Second
-	// Jittered exponential back-off (min*2^n) with capping.
-	rc.Backoff = retryablehttp.DefaultBackoff
-	// Treat only idempotent verbs + 502/503/504 + transport errors as retryable.
-	rc.CheckRetry = RetryPolicy
+type s3ClientCache struct {
+	mu sync.Mutex
 
-	return rc.StandardClient()
+	client         *s3.Client
+	accessKeyInfo  *cwobjectv1.CreateAccessKeyFromJWTResponse
+	apiEndpoint    string
+	endpoint       string
+	token          string
+	attemptTimeout time.Duration
+	refresh        *s3ClientRefresh
+}
+
+type s3ClientRefresh struct {
+	done   chan struct{}
+	client *s3.Client
+	err    error
+}
+
+// ConfigureProvider is invoked for each Terraform operation. Keeping the
+// short-lived S3 client in a process-wide cache prevents excess access-key
+// creation while the cache identity prevents reuse across provider configs.
+var sharedS3ClientCache s3ClientCache
+
+type s3Retryer struct {
+	aws.Retryer
+}
+
+func (r s3Retryer) IsErrorRetryable(err error) bool {
+	if IsPermanentRequestError(err) || isPermanentS3APIError(err) {
+		return false
+	}
+	return r.Retryer.IsErrorRetryable(err)
+}
+
+func (r s3Retryer) GetAttemptToken(ctx context.Context) (func(error) error, error) {
+	if retryer, ok := r.Retryer.(aws.RetryerV2); ok {
+		return retryer.GetAttemptToken(ctx)
+	}
+	return r.GetInitialToken(), nil
+}
+
+func isPermanentS3APIError(err error) bool {
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) {
+		return false
+	}
+
+	switch apiErr.ErrorCode() {
+	case "AccessDenied", "AuthorizationHeaderMalformed", "InvalidAccessKeyId",
+		"InvalidArgument", "InvalidRequest", "InvalidToken", "SignatureDoesNotMatch":
+		return true
+	default:
+		return false
+	}
+}
+
+func newS3Retryer(options ...func(*awsretry.StandardOptions)) aws.Retryer {
+	standard := awsretry.NewStandard(func(standardOptions *awsretry.StandardOptions) {
+		standardOptions.MaxAttempts = s3MaxAttempts
+		standardOptions.MaxBackoff = s3MaxBackoff
+		for _, option := range options {
+			option(standardOptions)
+		}
+	})
+	return s3Retryer{Retryer: standard}
+}
+
+func (c *Client) s3HttpClient() *http.Client {
+	transport := c.s3HTTPTransport
+	if transport == nil {
+		// Disabling keep-alives and idle connections prevents stale DNS entries
+		// from pinning bucket operations to a routing view that is still converging.
+		transport = cleanhttp.DefaultTransport()
+	}
+
+	return &http.Client{Timeout: c.effectiveS3AttemptTimeout(), Transport: transport}
+}
+
+func (c *Client) effectiveS3AttemptTimeout() time.Duration {
+	if c.s3AttemptTimeout > 0 {
+		return c.s3AttemptTimeout
+	}
+	return DefaultS3AttemptTimeout
+}
+
+func (c *Client) currentTime() time.Time {
+	if c.s3Now != nil {
+		return c.s3Now()
+	}
+	return time.Now()
 }
 
 func (c *Client) createS3Client(ctx context.Context, zone string) (*s3.Client, *cwobjectv1.CreateAccessKeyFromJWTResponse, error) {
@@ -57,6 +129,11 @@ func (c *Client) createS3Client(ctx context.Context, zone string) (*s3.Client, *
 	}))
 	if err != nil {
 		return nil, nil, err
+	}
+
+	retryer := c.s3Retryer
+	if retryer == nil {
+		retryer = func() aws.Retryer { return newS3Retryer() }
 	}
 
 	httpClient := c.s3HttpClient()
@@ -69,6 +146,8 @@ func (c *Client) createS3Client(ctx context.Context, zone string) (*s3.Client, *
 		)),
 		HTTPClient:                 httpClient,
 		Region:                     zone, // must be non-empty and a valid DNS subdomain
+		RetryMode:                  aws.RetryModeStandard,
+		Retryer:                    retryer(),
 		RequestChecksumCalculation: aws.RequestChecksumCalculationWhenSupported,
 		ResponseChecksumValidation: aws.ResponseChecksumValidationWhenSupported,
 		UsePathStyle:               false,
@@ -77,9 +156,6 @@ func (c *Client) createS3Client(ctx context.Context, zone string) (*s3.Client, *
 }
 
 func (c *Client) S3Client(ctx context.Context, zone string) (*s3.Client, error) {
-	s3Mu.Lock()
-	defer s3Mu.Unlock()
-
 	// We use 'notempty' as the zone here because it doesn't actually matter what region is configured for cwobject.com
 	// it only matters that it's not empty & a valid DNS subdomain
 	s3Zone := zone
@@ -87,69 +163,152 @@ func (c *Client) S3Client(ctx context.Context, zone string) (*s3.Client, error) 
 		s3Zone = "notempty"
 	}
 
-	if s3AccessKeyInfo == nil || singletonS3Client == nil {
-		tflog.Info(ctx, "creating new s3 client because one does not exist")
-		client, keyInfo, err := c.createS3Client(ctx, s3Zone)
-		if err != nil {
+	for {
+		if err := ctx.Err(); err != nil {
 			return nil, err
 		}
+		now := c.currentTime()
 
-		// we need to ensure the access keys are valid before we overwrite the client - we've observed that
-		// it can take several seconds for access keys to propagate
-		if err := PollUntil("s3 access key validation", ctx, 1*time.Second, 1*time.Minute, func(ctx context.Context) (bool, error) {
-			_, err := client.ListBuckets(ctx, &s3.ListBucketsInput{})
-			// retry only on AccessDenied errors
-			if err != nil {
-				var apiErr smithy.APIError
-				if errors.As(err, &apiErr) && apiErr.ErrorCode() == errAccessDenied {
-					return false, nil
-				}
+		sharedS3ClientCache.mu.Lock()
+		identityMatches := sharedS3ClientCache.apiEndpoint == c.apiEndpoint &&
+			sharedS3ClientCache.endpoint == c.s3Endpoint &&
+			sharedS3ClientCache.token == c.token &&
+			sharedS3ClientCache.attemptTimeout == c.effectiveS3AttemptTimeout()
+		if sharedS3ClientCache.refresh != nil && !identityMatches {
+			refresh := sharedS3ClientCache.refresh
+			sharedS3ClientCache.mu.Unlock()
+			if _, err := waitForRefresh(ctx, refresh); err != nil && ctx.Err() != nil {
+				return nil, err
 			}
-
-			return err == nil, err
-		}); err != nil {
-			return nil, err
+			continue
+		}
+		if !identityMatches {
+			sharedS3ClientCache.client = nil
+			sharedS3ClientCache.accessKeyInfo = nil
+			sharedS3ClientCache.apiEndpoint = c.apiEndpoint
+			sharedS3ClientCache.endpoint = c.s3Endpoint
+			sharedS3ClientCache.token = c.token
+			sharedS3ClientCache.attemptTimeout = c.effectiveS3AttemptTimeout()
 		}
 
-		singletonS3Client = client
-		s3AccessKeyInfo = keyInfo
-		tflog.Info(ctx, "created new s3 client")
-		return client, nil
+		cachedClient := sharedS3ClientCache.client
+		cachedExpiry := accessKeyExpiry(sharedS3ClientCache.accessKeyInfo)
+		if cachedClient != nil && cachedExpiry.Sub(now) > 5*time.Minute {
+			sharedS3ClientCache.mu.Unlock()
+			tflog.Info(ctx, "fetched cached s3 client")
+			return cachedClient, nil
+		}
+
+		if sharedS3ClientCache.refresh != nil {
+			if cachedClient != nil && cachedExpiry.After(now) {
+				sharedS3ClientCache.mu.Unlock()
+				tflog.Info(ctx, "serving unexpired s3 client while credential refresh is in progress")
+				return cachedClient, nil
+			}
+			refresh := sharedS3ClientCache.refresh
+			sharedS3ClientCache.mu.Unlock()
+			client, err := waitForRefresh(ctx, refresh)
+			if err != nil {
+				return nil, err
+			}
+			return client, nil
+		}
+
+		refresh := &s3ClientRefresh{done: make(chan struct{})}
+		sharedS3ClientCache.refresh = refresh
+		sharedS3ClientCache.mu.Unlock()
+
+		if cachedClient == nil {
+			tflog.Info(ctx, "creating s3 client because one does not exist")
+		} else {
+			tflog.Info(ctx, "refreshing s3 client because keys expire within the next 5 minutes")
+		}
+
+		refreshCtx, cancelRefresh := context.WithTimeout(context.WithoutCancel(ctx), s3CredentialRefreshTimeout)
+		go c.refreshS3Client(refreshCtx, cancelRefresh, refresh, s3Zone)
+		return waitForRefresh(ctx, refresh)
+	}
+}
+
+func (c *Client) refreshS3Client(
+	ctx context.Context,
+	cancel context.CancelFunc,
+	refresh *s3ClientRefresh,
+	zone string,
+) {
+	defer cancel()
+
+	client, keyInfo, refreshErr := c.createS3Client(ctx, zone)
+	if refreshErr == nil {
+		refreshErr = validateS3Client(ctx, client)
 	}
 
-	// expiry is within 5 minutes from now (or already expired), refresh the client
-	if time.Until(s3AccessKeyInfo.Expiry.AsTime()) <= 5*time.Minute {
-		tflog.Info(ctx, "refreshing s3 client because keys expire within the next 5 minutes or have already expired")
-		client, keyInfo, err := c.createS3Client(ctx, s3Zone)
-		if err != nil {
-			return nil, err
-		}
-
-		// we need to ensure the access keys are valid before we overwrite the client - we've observed that
-		// it can take several seconds for access keys to propagate
-		if err := PollUntil("s3 access key validation", ctx, 1*time.Second, 1*time.Minute, func(ctx context.Context) (bool, error) {
-			_, err := client.ListBuckets(ctx, &s3.ListBucketsInput{})
-			// retry only on AccessDenied errors
-			if err != nil {
-				var apiErr smithy.APIError
-				if errors.As(err, &apiErr) && apiErr.ErrorCode() == errAccessDenied {
-					return false, nil
-				}
-			}
-			return err == nil, err
-		}); err != nil {
-			return nil, err
-		}
-
-		singletonS3Client = client
-		s3AccessKeyInfo = keyInfo
-		tflog.Info(ctx, "refreshed s3 client")
-		return client, nil
+	sharedS3ClientCache.mu.Lock()
+	if refreshErr == nil {
+		sharedS3ClientCache.client = client
+		sharedS3ClientCache.accessKeyInfo = keyInfo
 	}
+	fallbackClient := sharedS3ClientCache.client
+	fallbackExpiry := accessKeyExpiry(sharedS3ClientCache.accessKeyInfo)
+	fallbackUsable := fallbackClient != nil && fallbackExpiry.After(c.currentTime())
+	refresh.client = fallbackClient
+	if refreshErr != nil && !fallbackUsable {
+		refresh.err = refreshErr
+	}
+	sharedS3ClientCache.refresh = nil
+	close(refresh.done)
+	sharedS3ClientCache.mu.Unlock()
 
-	tflog.Info(ctx, "fetched cached s3 client")
-	// otherwise use the already cached client
-	return singletonS3Client, nil
+	if refreshErr != nil && fallbackUsable {
+		tflog.Warn(ctx, "s3 credential refresh failed; using unexpired cached client", map[string]interface{}{
+			"error": refreshErr.Error(),
+		})
+		return
+	}
+	if refreshErr == nil {
+		tflog.Info(ctx, "created or refreshed s3 client")
+	}
+}
+
+func accessKeyExpiry(keyInfo *cwobjectv1.CreateAccessKeyFromJWTResponse) time.Time {
+	if keyInfo == nil || keyInfo.GetExpiry() == nil {
+		return time.Time{}
+	}
+	return keyInfo.GetExpiry().AsTime()
+}
+
+func waitForRefresh(ctx context.Context, refresh *s3ClientRefresh) (*s3.Client, error) {
+	select {
+	case <-ctx.Done():
+		return nil, fmt.Errorf("waiting for s3 credential refresh: %w", ctx.Err())
+	case <-refresh.done:
+		return refresh.client, refresh.err
+	}
+}
+
+func validateS3Client(ctx context.Context, client *s3.Client) error {
+	return PollUntil("s3 access key validation", ctx, time.Second, time.Minute, func(ctx context.Context) (bool, error) {
+		_, err := client.ListBuckets(ctx, &s3.ListBucketsInput{})
+		if err != nil {
+			var apiErr smithy.APIError
+			if errors.As(err, &apiErr) && apiErr.ErrorCode() == errAccessDenied {
+				return false, nil
+			}
+		}
+		return err == nil, err
+	})
+}
+
+func resetS3ClientCache() {
+	sharedS3ClientCache.mu.Lock()
+	defer sharedS3ClientCache.mu.Unlock()
+	sharedS3ClientCache.client = nil
+	sharedS3ClientCache.accessKeyInfo = nil
+	sharedS3ClientCache.apiEndpoint = ""
+	sharedS3ClientCache.endpoint = ""
+	sharedS3ClientCache.token = ""
+	sharedS3ClientCache.attemptTimeout = 0
+	sharedS3ClientCache.refresh = nil
 }
 
 // PollUntil runs check(ctx) every interval until it returns (true, nil),

--- a/coreweave/s3_test.go
+++ b/coreweave/s3_test.go
@@ -4,16 +4,21 @@ import (
 	"context"
 	"crypto/ed25519"
 	"crypto/rand"
+	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
+	"errors"
 	"fmt"
+	"io"
 	"math/big"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
-	"reflect"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -21,7 +26,11 @@ import (
 	cwobjectv1 "buf.build/gen/go/coreweave/cwobject/protocolbuffers/go/cwobject/v1"
 	"connectrpc.com/connect"
 	"github.com/aws/aws-sdk-go-v2/aws"
-	retryablehttp "github.com/hashicorp/go-retryablehttp"
+	awsretry "github.com/aws/aws-sdk-go-v2/aws/retry"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/smithy-go"
+	smithyhttp "github.com/aws/smithy-go/transport/http"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 const (
@@ -254,41 +263,27 @@ endpoint_url = https://wrong.example.test
 				t.Fatalf("HTTP client type = %T, want *http.Client", options.HTTPClient)
 			}
 
-			transport, ok := httpClient.Transport.(*retryablehttp.RoundTripper)
+			transport, ok := httpClient.Transport.(*http.Transport)
 			if !ok {
-				t.Fatalf("HTTP transport type = %T, want *retryablehttp.RoundTripper", httpClient.Transport)
+				t.Fatalf("HTTP transport type = %T, want *http.Transport", httpClient.Transport)
 			}
-			if transport.Client.HTTPClient.Timeout != 30*time.Second {
+			if httpClient.Timeout != DefaultS3AttemptTimeout {
 				t.Errorf("HTTP client timeout = %s, want %s",
-					transport.Client.HTTPClient.Timeout, 30*time.Second)
+					httpClient.Timeout, DefaultS3AttemptTimeout)
 			}
-			if transport.Client.RetryMax != 10 {
-				t.Errorf("retry max = %d, want 10", transport.Client.RetryMax)
+			if options.Retryer == nil {
+				t.Fatal("S3 retryer is nil")
 			}
-			if transport.Client.RetryWaitMin != 200*time.Millisecond {
-				t.Errorf("retry wait min = %s, want %s", transport.Client.RetryWaitMin, 200*time.Millisecond)
-			}
-			if transport.Client.RetryWaitMax != 5*time.Second {
-				t.Errorf("retry wait max = %s, want %s", transport.Client.RetryWaitMax, 5*time.Second)
-			}
-			if reflect.ValueOf(transport.Client.Backoff).Pointer() != reflect.ValueOf(retryablehttp.DefaultBackoff).Pointer() {
-				t.Error("retry backoff is not retryablehttp.DefaultBackoff")
-			}
-			if reflect.ValueOf(transport.Client.CheckRetry).Pointer() != reflect.ValueOf(RetryPolicy).Pointer() {
-				t.Error("retry policy is not coreweave.RetryPolicy")
+			if got := options.Retryer.MaxAttempts(); got != s3MaxAttempts {
+				t.Errorf("S3 max attempts = %d, want %d", got, s3MaxAttempts)
 			}
 
-			innerTransport, ok := transport.Client.HTTPClient.Transport.(*http.Transport)
-			if !ok {
-				t.Fatalf("inner HTTP transport type = %T, want *http.Transport",
-					transport.Client.HTTPClient.Transport)
-			}
-			if !innerTransport.DisableKeepAlives {
+			if !transport.DisableKeepAlives {
 				t.Error("inner HTTP transport keep-alives enabled, want disabled")
 			}
-			if innerTransport.MaxIdleConnsPerHost != -1 {
+			if transport.MaxIdleConnsPerHost != -1 {
 				t.Errorf("inner HTTP transport max idle connections per host = %d, want -1",
-					innerTransport.MaxIdleConnsPerHost)
+					transport.MaxIdleConnsPerHost)
 			}
 
 			credentials, err := options.Credentials.Retrieve(t.Context())
@@ -300,5 +295,363 @@ endpoint_url = https://wrong.example.test
 					credentials.AccessKeyID, credentials.SecretAccessKey, testS3AccessKey, testS3SecretKey)
 			}
 		})
+	}
+}
+
+type zeroBackoff struct{}
+
+func (zeroBackoff) BackoffDelay(int, error) (time.Duration, error) {
+	return 0, nil
+}
+
+type countingRoundTripper struct {
+	count atomic.Int32
+}
+
+func (r *countingRoundTripper) RoundTrip(*http.Request) (*http.Response, error) {
+	r.count.Add(1)
+	return &http.Response{
+		StatusCode: http.StatusServiceUnavailable,
+		Status:     "503 Service Unavailable",
+		Header:     make(http.Header),
+		Body:       io.NopCloser(strings.NewReader("<Error><Code>ServiceUnavailable</Code></Error>")),
+	}, nil
+}
+
+func TestCreateS3Client_UsesOneBoundedRetryLayer(t *testing.T) {
+	isolateAWSEnvironment(t)
+
+	transport := &countingRoundTripper{}
+	client := &Client{
+		CWObjectClient:   &s3CWObjectClientStub{t: t},
+		s3Endpoint:       "https://objects.example.test",
+		s3AttemptTimeout: 7 * time.Second,
+		s3HTTPTransport:  transport,
+		s3Retryer: func() aws.Retryer {
+			return newS3Retryer(func(options *awsretry.StandardOptions) {
+				options.Backoff = zeroBackoff{}
+			})
+		},
+	}
+
+	s3Client, _, err := client.createS3Client(t.Context(), "US-TEST-01A")
+	if err != nil {
+		t.Fatalf("create S3 client: %v", err)
+	}
+
+	options := s3Client.Options()
+	httpClient, ok := options.HTTPClient.(*http.Client)
+	if !ok {
+		t.Fatalf("HTTP client type = %T, want *http.Client", options.HTTPClient)
+	}
+	if got := httpClient.Timeout; got != 7*time.Second {
+		t.Fatalf("HTTP client timeout = %s, want 7s", got)
+	}
+	if httpClient.Transport != transport {
+		t.Fatalf("HTTP transport = %T, want injected counting transport", httpClient.Transport)
+	}
+
+	_, err = s3Client.ListBuckets(t.Context(), &s3.ListBucketsInput{})
+	if err == nil {
+		t.Fatal("ListBuckets() error = nil, want exhausted retry error")
+	}
+	if got := transport.count.Load(); got != s3MaxAttempts {
+		t.Fatalf("transport sends = %d, want exactly %d", got, s3MaxAttempts)
+	}
+}
+
+type blockingS3CWObjectClientStub struct {
+	cwobjectv1connect.CWObjectClient
+	started chan struct{}
+	release chan struct{}
+	err     error
+	once    sync.Once
+	calls   atomic.Int32
+}
+
+type cancelAwareS3CWObjectClientStub struct {
+	cwobjectv1connect.CWObjectClient
+	started chan struct{}
+	release chan struct{}
+	once    sync.Once
+	calls   atomic.Int32
+}
+
+func (s *cancelAwareS3CWObjectClientStub) CreateAccessKeyFromJWT(
+	ctx context.Context,
+	_ *connect.Request[cwobjectv1.CreateAccessKeyFromJWTRequest],
+) (*connect.Response[cwobjectv1.CreateAccessKeyFromJWTResponse], error) {
+	s.calls.Add(1)
+	s.once.Do(func() { close(s.started) })
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-s.release:
+		return connect.NewResponse(&cwobjectv1.CreateAccessKeyFromJWTResponse{
+			AccessKeyId: testS3AccessKey,
+			SecretKey:   testS3SecretKey,
+			Expiry:      timestamppb.New(time.Now().Add(15 * time.Minute)),
+		}), nil
+	}
+}
+
+type successfulListBucketsRoundTripper struct{}
+
+func (successfulListBucketsRoundTripper) RoundTrip(request *http.Request) (*http.Response, error) {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Status:     "200 OK",
+		Header:     make(http.Header),
+		Body: io.NopCloser(strings.NewReader(
+			`<ListAllMyBucketsResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Buckets></Buckets></ListAllMyBucketsResult>`,
+		)),
+		Request: request,
+	}, nil
+}
+
+func (s *blockingS3CWObjectClientStub) CreateAccessKeyFromJWT(
+	context.Context,
+	*connect.Request[cwobjectv1.CreateAccessKeyFromJWTRequest],
+) (*connect.Response[cwobjectv1.CreateAccessKeyFromJWTResponse], error) {
+	s.calls.Add(1)
+	s.once.Do(func() { close(s.started) })
+	<-s.release
+	if s.err == nil {
+		s.err = errors.New("refresh failed")
+	}
+	return nil, s.err
+}
+
+func TestS3ClientWaitersShareRefreshFailure(t *testing.T) {
+	resetS3ClientCache()
+	t.Cleanup(resetS3ClientCache)
+
+	refreshErr := errors.New("refresh failed")
+	stub := &blockingS3CWObjectClientStub{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+		err:     refreshErr,
+	}
+	client := &Client{
+		CWObjectClient: stub,
+		apiEndpoint:    "https://api.example.test",
+		s3Endpoint:     "https://objects.example.test",
+		token:          "test-token",
+	}
+
+	type result struct {
+		client *s3.Client
+		err    error
+	}
+	results := make(chan result, 2)
+	for range 2 {
+		go func() {
+			got, err := client.S3Client(context.Background(), "US-TEST-01A")
+			results <- result{client: got, err: err}
+		}()
+	}
+
+	select {
+	case <-stub.started:
+	case <-time.After(time.Second):
+		t.Fatal("credential refresh did not start")
+	}
+
+	select {
+	case result := <-results:
+		t.Fatalf("S3Client() returned before the in-flight refresh completed: client=%v error=%v", result.client, result.err)
+	case <-time.After(25 * time.Millisecond):
+	}
+	if got := stub.calls.Load(); got != 1 {
+		t.Fatalf("CreateAccessKeyFromJWT calls before release = %d, want 1", got)
+	}
+
+	close(stub.release)
+	for range 2 {
+		select {
+		case result := <-results:
+			if result.client != nil {
+				t.Fatal("S3Client() returned a client after failed initial refresh")
+			}
+			if !errors.Is(result.err, refreshErr) {
+				t.Fatalf("S3Client() error = %v, want shared refresh error", result.err)
+			}
+		case <-time.After(time.Second):
+			t.Fatal("S3Client() did not return after refresh failure")
+		}
+	}
+	if got := stub.calls.Load(); got != 1 {
+		t.Fatalf("CreateAccessKeyFromJWT calls = %d, want 1", got)
+	}
+}
+
+func TestS3ClientCanceledLeaderDoesNotFailHealthyWaiter(t *testing.T) {
+	resetS3ClientCache()
+	t.Cleanup(resetS3ClientCache)
+
+	stub := &cancelAwareS3CWObjectClientStub{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	client := &Client{
+		CWObjectClient:  stub,
+		apiEndpoint:     "https://api.example.test",
+		s3Endpoint:      "https://objects.example.test",
+		s3HTTPTransport: successfulListBucketsRoundTripper{},
+		token:           "test-token",
+	}
+	type result struct {
+		client *s3.Client
+		err    error
+	}
+
+	leaderCtx, cancelLeader := context.WithCancel(t.Context())
+	leaderResult := make(chan result, 1)
+	go func() {
+		got, err := client.S3Client(leaderCtx, "US-TEST-01A")
+		leaderResult <- result{client: got, err: err}
+	}()
+	select {
+	case <-stub.started:
+	case <-time.After(time.Second):
+		t.Fatal("credential refresh did not start")
+	}
+
+	waiterResult := make(chan result, 1)
+	go func() {
+		got, err := client.S3Client(t.Context(), "US-TEST-01A")
+		waiterResult <- result{client: got, err: err}
+	}()
+	select {
+	case result := <-waiterResult:
+		t.Fatalf("healthy waiter returned before refresh completed: client=%v error=%v", result.client, result.err)
+	case <-time.After(25 * time.Millisecond):
+	}
+
+	cancelLeader()
+	select {
+	case result := <-leaderResult:
+		if !errors.Is(result.err, context.Canceled) {
+			t.Fatalf("canceled leader error = %v, want context canceled", result.err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("canceled leader did not return")
+	}
+
+	close(stub.release)
+	select {
+	case result := <-waiterResult:
+		if result.err != nil || result.client == nil {
+			t.Fatalf("healthy waiter result = (%v, %v), want client and nil error", result.client, result.err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("healthy waiter did not receive completed refresh")
+	}
+	if got := stub.calls.Load(); got != 1 {
+		t.Fatalf("CreateAccessKeyFromJWT calls = %d, want one shared refresh", got)
+	}
+}
+
+func TestS3ClientServesUnexpiredClientDuringRefresh(t *testing.T) {
+	resetS3ClientCache()
+	t.Cleanup(resetS3ClientCache)
+
+	now := time.Now()
+	cachedClient := s3.New(s3.Options{Region: "US-TEST-01A"})
+	sharedS3ClientCache.mu.Lock()
+	sharedS3ClientCache.client = cachedClient
+	sharedS3ClientCache.accessKeyInfo = &cwobjectv1.CreateAccessKeyFromJWTResponse{
+		Expiry: timestamppb.New(now.Add(time.Minute)),
+	}
+	sharedS3ClientCache.apiEndpoint = "https://api.example.test"
+	sharedS3ClientCache.endpoint = "https://objects.example.test"
+	sharedS3ClientCache.token = "test-token"
+	sharedS3ClientCache.attemptTimeout = DefaultS3AttemptTimeout
+	sharedS3ClientCache.mu.Unlock()
+
+	stub := &blockingS3CWObjectClientStub{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+		err:     errors.New("refresh failed"),
+	}
+	client := &Client{
+		CWObjectClient: stub,
+		apiEndpoint:    "https://api.example.test",
+		s3Endpoint:     "https://objects.example.test",
+		token:          "test-token",
+		s3Now:          func() time.Time { return now },
+	}
+
+	type result struct {
+		client *s3.Client
+		err    error
+	}
+	refreshResult := make(chan result, 1)
+	go func() {
+		got, err := client.S3Client(context.Background(), "US-TEST-01A")
+		refreshResult <- result{client: got, err: err}
+	}()
+
+	select {
+	case <-stub.started:
+	case <-time.After(time.Second):
+		t.Fatal("credential refresh did not start")
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
+	defer cancel()
+	got, err := client.S3Client(ctx, "US-TEST-01A")
+	if err != nil {
+		t.Fatalf("concurrent S3Client() error = %v", err)
+	}
+	if got != cachedClient {
+		t.Fatal("concurrent S3Client() did not return the unexpired cached client")
+	}
+
+	close(stub.release)
+	select {
+	case result := <-refreshResult:
+		if result.err != nil {
+			t.Fatalf("refreshing S3Client() error = %v", result.err)
+		}
+		if result.client != cachedClient {
+			t.Fatal("failed refresh did not fall back to the unexpired cached client")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("credential refresh did not finish")
+	}
+}
+
+func TestS3RetryerClassificationAndBackoffCap(t *testing.T) {
+	t.Parallel()
+
+	retryer := newS3Retryer()
+	certificateErr := &url.Error{
+		Op:  "Get",
+		URL: "https://objects.example.test",
+		Err: &tls.CertificateVerificationError{Err: errors.New("unknown authority")},
+	}
+	if retryer.IsErrorRetryable(certificateErr) {
+		t.Fatal("certificate verification error is retryable")
+	}
+	if retryer.IsErrorRetryable(&smithy.GenericAPIError{Code: "AccessDenied"}) {
+		t.Fatal("AccessDenied is retryable")
+	}
+	serverErr := &smithyhttp.ResponseError{
+		Response: &smithyhttp.Response{Response: &http.Response{StatusCode: http.StatusServiceUnavailable}},
+		Err:      errors.New("service unavailable"),
+	}
+	if !retryer.IsErrorRetryable(serverErr) {
+		t.Fatal("HTTP 503 is not retryable")
+	}
+
+	for attempt := 1; attempt <= 10; attempt++ {
+		delay, err := retryer.RetryDelay(attempt, serverErr)
+		if err != nil {
+			t.Fatalf("RetryDelay(%d) error = %v", attempt, err)
+		}
+		if delay > s3MaxBackoff {
+			t.Fatalf("RetryDelay(%d) = %s, exceeds cap %s", attempt, delay, s3MaxBackoff)
+		}
 	}
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,6 +29,6 @@ provider "coreweave" {
 ### Optional
 
 - `endpoint` (String) CoreWeave API Endpoint. This can also be set via the COREWEAVE_API_ENDPOINT environment variable, which takes precedence. Defaults to `https://api.coreweave.com/`
-- `http_timeout` (String) Timeout duration for the HTTP client to use. This can also be set via the COREWEAVE_HTTP_TIMEOUT environment variable, which takes precedence. If unset, defaults to 10 seconds
+- `http_timeout` (String) Timeout for each CoreWeave API and Object Storage S3 HTTP attempt. This can also be set via the COREWEAVE_HTTP_TIMEOUT environment variable, which takes precedence. When unset, CoreWeave API attempts default to 10 seconds and S3 attempts default to 30 seconds. Values near or below service latency can cause request timeouts.
 - `s3_endpoint` (String) CoreWeave S3 Endpoint, used for CoreWeave Object Storage. This can also be set via the COREWEAVE_S3_ENDPOINT environment variable, which takes precedence. Defaults to `https://cwobject.com`
 - `token` (String, Sensitive) CoreWeave API Token in the form `CW-SECRET-<secret>`. This can also be set via the COREWEAVE_API_TOKEN environment variable, which takes precedence.

--- a/docs/resources/object_storage_bucket.md
+++ b/docs/resources/object_storage_bucket.md
@@ -3,12 +3,12 @@
 page_title: "coreweave_object_storage_bucket Resource - coreweave"
 subcategory: ""
 description: |-
-  Buckets are the primary organizational containers for your data in CoreWeave AI Object Storage. Bucket names must be globally-unique and not begin with cw- or vip-, which are reserved for internal use. Learn more about creating buckets https://docs.coreweave.com/products/storage/object-storage/buckets/create-bucket.
+  Buckets are the primary organizational containers for your data in CoreWeave AI Object Storage. Bucket names must be globally-unique and not begin with cw- or vip-, which are reserved for internal use. Before creation, the provider verifies the complete list of buckets owned by the organization and fails without sending a create request if that inventory cannot be completed; an existing bucket with the requested name must be imported. Learn more about creating buckets https://docs.coreweave.com/products/storage/object-storage/buckets/create-bucket.
 ---
 
 # coreweave_object_storage_bucket (Resource)
 
-Buckets are the primary organizational containers for your data in CoreWeave AI Object Storage. Bucket names must be globally-unique and not begin with `cw-` or `vip-`, which are reserved for internal use. Learn more about [creating buckets](https://docs.coreweave.com/products/storage/object-storage/buckets/create-bucket).
+Buckets are the primary organizational containers for your data in CoreWeave AI Object Storage. Bucket names must be globally-unique and not begin with `cw-` or `vip-`, which are reserved for internal use. Before creation, the provider verifies the complete list of buckets owned by the organization and fails without sending a create request if that inventory cannot be completed; an existing bucket with the requested name must be imported. Learn more about [creating buckets](https://docs.coreweave.com/products/storage/object-storage/buckets/create-bucket).
 
 ## Example Usage
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -101,7 +101,7 @@ func (p *CoreweaveProvider) Schema(ctx context.Context, req provider.SchemaReque
 				Sensitive:           true,
 			},
 			"http_timeout": schema.StringAttribute{
-				MarkdownDescription: fmt.Sprintf("Timeout duration for the HTTP client to use. This can also be set via the %s environment variable, which takes precedence. If unset, defaults to 10 seconds", CoreweaveHTTPTimeoutEnvVar),
+				MarkdownDescription: fmt.Sprintf("Timeout for each CoreWeave API and Object Storage S3 HTTP attempt. This can also be set via the %s environment variable, which takes precedence. When unset, CoreWeave API attempts default to 10 seconds and S3 attempts default to 30 seconds. Values near or below service latency can cause request timeouts.", CoreweaveHTTPTimeoutEnvVar),
 				Optional:            true,
 				Validators: []validator.String{
 					durationValidator{},
@@ -134,13 +134,43 @@ func parseDuration(raw string) (*time.Duration, error) {
 	if err != nil {
 		// Try appending “s” to treat it as seconds
 		if parsed, err2 := time.ParseDuration(raw + "s"); err2 == nil {
+			if parsed <= 0 {
+				return nil, fmt.Errorf("duration must be greater than zero")
+			}
 			return &parsed, nil
 		}
 
 		return nil, err
 	}
+	if parsed <= 0 {
+		return nil, fmt.Errorf("duration must be greater than zero")
+	}
 
 	return &parsed, nil
+}
+
+func resolveHTTPTimeouts(ctx context.Context, configured types.String) (time.Duration, time.Duration) {
+	connectTimeout := DefaultHTTPTimeout
+	s3Timeout := coreweave.DefaultS3AttemptTimeout
+
+	if !configured.IsNull() && !configured.IsUnknown() && configured.ValueString() != "" {
+		if parsed, err := parseDuration(configured.ValueString()); err == nil {
+			connectTimeout = *parsed
+			s3Timeout = *parsed
+		}
+	}
+
+	if timeoutStr, ok := os.LookupEnv(CoreweaveHTTPTimeoutEnvVar); ok {
+		timeoutOverride, err := parseDuration(timeoutStr)
+		if err == nil {
+			connectTimeout = *timeoutOverride
+			s3Timeout = *timeoutOverride
+		} else {
+			tflog.Error(ctx, fmt.Sprintf("got invalid duration '%s' for %s, using configured/default timeouts", timeoutStr, CoreweaveHTTPTimeoutEnvVar))
+		}
+	}
+
+	return connectTimeout, s3Timeout
 }
 
 // Builds a CW client using the provided model, including any defaults or environment variables.
@@ -152,14 +182,7 @@ func BuildClient(ctx context.Context, model CoreweaveProviderModel, tfVersion, p
 	endpoint := model.Endpoint.ValueString()
 	s3Endpoint := model.S3Endpoint.ValueString()
 	token := model.Token.ValueString()
-	httpTimeout := model.HTTPTimeout.ValueString()
-	timeout := DefaultHTTPTimeout
-
-	// An error should not be able to happen in this case, as we specify a validator on the StringAttribute on the provider schema
-	// but for posterity we check for the error anyway
-	if userSpecified, err := parseDuration(httpTimeout); err == nil {
-		timeout = *userSpecified
-	}
+	timeout, s3Timeout := resolveHTTPTimeouts(ctx, model.HTTPTimeout)
 
 	if tokenFromEnv, ok := os.LookupEnv(CoreweaveApiTokenEnvVar); ok {
 		token = tokenFromEnv
@@ -170,15 +193,6 @@ func BuildClient(ctx context.Context, model CoreweaveProviderModel, tfVersion, p
 	if s3EndpointFrmEnv, ok := os.LookupEnv(CoreWeaveS3EndpointEnvVar); ok {
 		s3Endpoint = s3EndpointFrmEnv
 	}
-	if timeoutStr, ok := os.LookupEnv(CoreweaveHTTPTimeoutEnvVar); ok {
-		timeoutOverride, err := parseDuration(timeoutStr)
-		if err == nil {
-			timeout = *timeoutOverride
-		} else {
-			tflog.Error(ctx, fmt.Sprintf("got invalid duration '%s' for %s, using default timeout %v", timeoutStr, CoreweaveHTTPTimeoutEnvVar, DefaultHTTPTimeout))
-		}
-	}
-
 	if token == "" {
 		return nil, errors.New("token is required for coreweave client instantiation")
 	}
@@ -202,7 +216,16 @@ func BuildClient(ctx context.Context, model CoreweaveProviderModel, tfVersion, p
 		},
 	)
 
-	return coreweave.NewClient(endpoint, s3Endpoint, timeout, token, userAgent, headerInterceptor, coreweave.TFLogInterceptor()), nil
+	return coreweave.NewClientWithOptions(
+		endpoint,
+		s3Endpoint,
+		timeout,
+		token,
+		userAgent,
+		coreweave.ClientOptions{S3AttemptTimeout: s3Timeout},
+		headerInterceptor,
+		coreweave.TFLogInterceptor(),
+	), nil
 }
 
 func (p *CoreweaveProvider) Resources(ctx context.Context) []func() resource.Resource {

--- a/internal/provider/provider_timeout_test.go
+++ b/internal/provider/provider_timeout_test.go
@@ -1,0 +1,96 @@
+package provider
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestResolveHTTPTimeouts(t *testing.T) {
+	original, wasSet := os.LookupEnv(CoreweaveHTTPTimeoutEnvVar)
+	if err := os.Unsetenv(CoreweaveHTTPTimeoutEnvVar); err != nil {
+		t.Fatalf("unset %s: %v", CoreweaveHTTPTimeoutEnvVar, err)
+	}
+	t.Cleanup(func() {
+		if wasSet {
+			_ = os.Setenv(CoreweaveHTTPTimeoutEnvVar, original)
+			return
+		}
+		_ = os.Unsetenv(CoreweaveHTTPTimeoutEnvVar)
+	})
+
+	tests := []struct {
+		name        string
+		configured  types.String
+		environment *string
+		wantConnect time.Duration
+		wantS3      time.Duration
+	}{
+		{
+			name:        "unset preserves thirty second S3 attempt timeout",
+			configured:  types.StringNull(),
+			wantConnect: DefaultHTTPTimeout,
+			wantS3:      30 * time.Second,
+		},
+		{
+			name:        "provider value applies unchanged to both clients",
+			configured:  types.StringValue("17s"),
+			wantConnect: 17 * time.Second,
+			wantS3:      17 * time.Second,
+		},
+		{
+			name:        "environment value takes precedence unchanged",
+			configured:  types.StringValue("17s"),
+			environment: stringPointer("23s"),
+			wantConnect: 23 * time.Second,
+			wantS3:      23 * time.Second,
+		},
+		{
+			name:        "zero provider value is rejected instead of removing the bound",
+			configured:  types.StringValue("0s"),
+			wantConnect: DefaultHTTPTimeout,
+			wantS3:      30 * time.Second,
+		},
+		{
+			name:        "negative environment value is rejected instead of removing the bound",
+			configured:  types.StringValue("17s"),
+			environment: stringPointer("-1s"),
+			wantConnect: 17 * time.Second,
+			wantS3:      17 * time.Second,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.environment == nil {
+				if err := os.Unsetenv(CoreweaveHTTPTimeoutEnvVar); err != nil {
+					t.Fatalf("unset %s: %v", CoreweaveHTTPTimeoutEnvVar, err)
+				}
+			} else {
+				t.Setenv(CoreweaveHTTPTimeoutEnvVar, *tt.environment)
+			}
+
+			connectTimeout, s3Timeout := resolveHTTPTimeouts(context.Background(), tt.configured)
+			if connectTimeout != tt.wantConnect || s3Timeout != tt.wantS3 {
+				t.Fatalf("resolveHTTPTimeouts() = (%s, %s), want (%s, %s)", connectTimeout, s3Timeout, tt.wantConnect, tt.wantS3)
+			}
+		})
+	}
+}
+
+func TestParseDurationRejectsNonPositiveValues(t *testing.T) {
+	for _, raw := range []string{"0", "0s", "-1", "-1s"} {
+		t.Run(raw, func(t *testing.T) {
+			if _, err := parseDuration(raw); err == nil {
+				t.Fatalf("parseDuration(%q) error = nil, want non-positive duration error", raw)
+			}
+		})
+	}
+}
+
+func stringPointer(value string) *string {
+	return &value
+}

--- a/internal/provider/validators.go
+++ b/internal/provider/validators.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/url"
-	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -16,12 +15,12 @@ type durationValidator struct{}
 
 // Description is a short summary for “terraform plan/tfdocs” output.
 func (v durationValidator) Description(ctx context.Context) string {
-	return "Must be a valid Go duration (e.g. \"100ms\", \"5s\", \"1h30m\"). If an integer is passed, assumed as seconds (e.g. \"100\" -> \"100s\")"
+	return "Must be a positive Go duration (e.g. \"100ms\", \"5s\", \"1h30m\"). If an integer is passed, assumed as seconds (e.g. \"100\" -> \"100s\")"
 }
 
 // MarkdownDescription is the same, but rendered in Markdown in docs.
 func (v durationValidator) MarkdownDescription(ctx context.Context) string {
-	return "Must be a valid Go duration (e.g. \"100ms\", \"5s\", \"1h30m\"). If an integer is passed, assumed as seconds (e.g. \"100\" -> \"100s\")"
+	return "Must be a positive Go duration (e.g. \"100ms\", \"5s\", \"1h30m\"). If an integer is passed, assumed as seconds (e.g. \"100\" -> \"100s\")"
 }
 
 // ValidateString is called during plan/apply. If the value is known & non-null,
@@ -38,18 +37,13 @@ func (v durationValidator) ValidateString(
 	}
 
 	raw := req.ConfigValue.ValueString()
-	if _, err := time.ParseDuration(raw); err != nil {
-		// Try appending “s” to treat it as seconds
-		if _, err2 := time.ParseDuration(raw + "s"); err2 == nil {
-			return
-		}
-
+	if _, err := parseDuration(raw); err != nil {
 		// AddAttributeError takes: (path, summary, detail)
 		resp.Diagnostics.AddAttributeError(
 			path.Root(req.Path.String()),
-			"Invalid duration format",
+			"Invalid HTTP timeout",
 			// The user saw e.g. "5xs" or "abc"; show what they passed and a hint.
-			`Expected a valid Go duration (for example: "5s", "250ms", or "1h"), but got: "`+raw+`".`,
+			`Expected a positive Go duration (for example: "5s", "250ms", or "1h"), but got: "`+raw+`".`,
 		)
 	}
 }


### PR DESCRIPTION
## Summary

- replace nested S3 transport retries with one AWS SDK retry layer capped at three attempts and use a single-send `CreateBucket`
- fail closed on incomplete owned-bucket inventory, reconcile ambiguous create responses only after exact ownership and zone proof, and persist bucket identity before bounded readiness/tag convergence
- share credential refresh safely across concurrent operations, including when the initiating caller is canceled, and apply positive `http_timeout` values consistently to CoreWeave API and S3 attempts
- add deterministic coverage for pagination, retry classification, one-shot mutation behavior, response-loss reconciliation, state retention, concurrency, and timeout handling

## Validation

- `go test ./... -count=1`
- `go test -race ./coreweave ./coreweave/object_storage ./internal/provider -count=1`
- `golangci-lint run`
- `make generate`
- repeated timeout and credential-refresh regression tests
- live Object Storage acceptance coverage for bucket lifecycle, tag updates/removal, replacement across names and zones, import/destroy, versioning, and lifecycle configuration using an internal organization

The live reproduction observed an immediate `HeadBucket` 400 during post-create routing convergence. The new readiness phase handles that known propagation response within the shared five-minute bound. An HTTP-attempt timeout while the Terraform operation context remains live is treated as ambiguous and reconciled without resending the mutation. Cancellation of the Terraform operation during the `CreateBucket` round trip remains unreconciled because follow-up ownership and zone checks cannot safely run on a dead operation context.

Configured `http_timeout` values now apply to both CoreWeave API and Object Storage S3 attempts; zero and negative values are rejected.

[CLDAPI-1063](https://coreweave.atlassian.net/browse/CLDAPI-1063)


[CLDAPI-1063]: https://coreweave.atlassian.net/browse/CLDAPI-1063?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ