### PR TITLE
docs(object_storage): add readable destination policy to inventory example

### DIFF
--- a/docs/resources/object_storage_bucket_inventory.md
+++ b/docs/resources/object_storage_bucket_inventory.md
@@ -13,6 +13,8 @@ Manages a Coreweave AI Object Storage bucket inventory configuration. [Learn mor
 ## Example Usage
 
 ```terraform
+data "coreweave_caller_identity" "current" {}
+
 resource "coreweave_object_storage_bucket" "source" {
   name = "inventory-source-example"
   zone = "US-EAST-04A"
@@ -21,6 +23,61 @@ resource "coreweave_object_storage_bucket" "source" {
 resource "coreweave_object_storage_bucket" "destination" {
   name = "inventory-destination-example"
   zone = "US-EAST-04A"
+}
+
+# After a bucket policy exists, CoreWeave AI Object Storage implicitly denies
+# any principal or action the policy does not allow. Grant the inventory
+# service write access, and grant the Terraform caller access to list, read,
+# and manage report objects.
+resource "coreweave_object_storage_bucket_policy" "destination" {
+  bucket = coreweave_object_storage_bucket.destination.name
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowServiceAccountWriteReportsToDestination"
+        Effect = "Allow"
+        Principal = {
+          CW = "arn:aws:iam::static:role/static/inventory"
+        }
+        Action = [
+          "s3:PutObject",
+          "s3:AbortMultipartUpload",
+        ]
+        Resource = [
+          "arn:aws:s3:::${coreweave_object_storage_bucket.destination.name}/*",
+        ]
+      },
+      {
+        Sid    = "AllowOwnerListDestination"
+        Effect = "Allow"
+        Principal = {
+          CW = "arn:aws:iam::${data.coreweave_caller_identity.current.organization_id}:coreweave/${data.coreweave_caller_identity.current.principal_id}"
+        }
+        Action = [
+          "s3:ListBucket",
+        ]
+        Resource = [
+          "arn:aws:s3:::${coreweave_object_storage_bucket.destination.name}",
+        ]
+      },
+      {
+        Sid    = "AllowOwnerManageDestinationObjects"
+        Effect = "Allow"
+        Principal = {
+          CW = "arn:aws:iam::${data.coreweave_caller_identity.current.organization_id}:coreweave/${data.coreweave_caller_identity.current.principal_id}"
+        }
+        Action = [
+          "s3:GetObject",
+          "s3:PutObject",
+          "s3:DeleteObject",
+        ]
+        Resource = [
+          "arn:aws:s3:::${coreweave_object_storage_bucket.destination.name}/*",
+        ]
+      },
+    ]
+  })
 }
 
 resource "coreweave_object_storage_bucket_inventory" "default" {
@@ -48,6 +105,10 @@ resource "coreweave_object_storage_bucket_inventory" "default" {
       prefix     = "inventory-reports/"
     }
   }
+
+  # Create the destination bucket policy first. PutBucketInventoryConfiguration
+  # is rejected if the inventory service cannot PutObject to the destination.
+  depends_on = [coreweave_object_storage_bucket_policy.destination]
 }
 ```
 

--- a/examples/resources/coreweave_object_storage_bucket_inventory/resource.tf
+++ b/examples/resources/coreweave_object_storage_bucket_inventory/resource.tf
@@ -1,3 +1,5 @@
+data "coreweave_caller_identity" "current" {}
+
 resource "coreweave_object_storage_bucket" "source" {
   name = "inventory-source-example"
   zone = "US-EAST-04A"
@@ -6,6 +8,61 @@ resource "coreweave_object_storage_bucket" "source" {
 resource "coreweave_object_storage_bucket" "destination" {
   name = "inventory-destination-example"
   zone = "US-EAST-04A"
+}
+
+# After a bucket policy exists, CoreWeave AI Object Storage implicitly denies
+# any principal or action the policy does not allow. Grant the inventory
+# service write access, and grant the Terraform caller access to list, read,
+# and manage report objects.
+resource "coreweave_object_storage_bucket_policy" "destination" {
+  bucket = coreweave_object_storage_bucket.destination.name
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowServiceAccountWriteReportsToDestination"
+        Effect = "Allow"
+        Principal = {
+          CW = "arn:aws:iam::static:role/static/inventory"
+        }
+        Action = [
+          "s3:PutObject",
+          "s3:AbortMultipartUpload",
+        ]
+        Resource = [
+          "arn:aws:s3:::${coreweave_object_storage_bucket.destination.name}/*",
+        ]
+      },
+      {
+        Sid    = "AllowOwnerListDestination"
+        Effect = "Allow"
+        Principal = {
+          CW = "arn:aws:iam::${data.coreweave_caller_identity.current.organization_id}:coreweave/${data.coreweave_caller_identity.current.principal_id}"
+        }
+        Action = [
+          "s3:ListBucket",
+        ]
+        Resource = [
+          "arn:aws:s3:::${coreweave_object_storage_bucket.destination.name}",
+        ]
+      },
+      {
+        Sid    = "AllowOwnerManageDestinationObjects"
+        Effect = "Allow"
+        Principal = {
+          CW = "arn:aws:iam::${data.coreweave_caller_identity.current.organization_id}:coreweave/${data.coreweave_caller_identity.current.principal_id}"
+        }
+        Action = [
+          "s3:GetObject",
+          "s3:PutObject",
+          "s3:DeleteObject",
+        ]
+        Resource = [
+          "arn:aws:s3:::${coreweave_object_storage_bucket.destination.name}/*",
+        ]
+      },
+    ]
+  })
 }
 
 resource "coreweave_object_storage_bucket_inventory" "default" {
@@ -33,4 +90,8 @@ resource "coreweave_object_storage_bucket_inventory" "default" {
       prefix     = "inventory-reports/"
     }
   }
+
+  # Create the destination bucket policy first. PutBucketInventoryConfiguration
+  # is rejected if the inventory service cannot PutObject to the destination.
+  depends_on = [coreweave_object_storage_bucket_policy.destination]
 }


### PR DESCRIPTION
## Summary
- The inventory example now attaches a destination bucket policy that grants the CoreWeave inventory service `s3:PutObject` and `s3:AbortMultipartUpload`, and grants the Terraform caller `s3:ListBucket`, `s3:GetObject`, `s3:PutObject`, and `s3:DeleteObject`.
- Owner principals come from `data.coreweave_caller_identity.current`, so the example is apply-able without `[ORG-ID]` / `[USER-UID]` placeholders.
- `depends_on` creates the policy before the inventory configuration, because `PutBucketInventoryConfiguration` rejects the config if the service cannot write.
- Regenerated `docs/resources/object_storage_bucket_inventory.md` with `make generate`.

This replaces closed [#418](https://github.com/coreweave/terraform-provider-coreweave/pull/418), which implemented a service-only grant. That grant is correct for the inventory writer, but CAIOS treats a present bucket policy as implicit-deny for anyone else, so copy-pasters could not read the reports.

Resolves [DOCS-2996](https://coreweave.atlassian.net/browse/DOCS-2996).

## Test plan
- [x] `make generate` and confirm only the inventory example and generated resource doc changed
- [ ] Preview the example in the generated `docs/resources/object_storage_bucket_inventory.md`
- [ ] After merge and a provider release, confirm TFDocsBot syncs `public-docs/platform/terraform/resources/object_storage_bucket_inventory.mdx`

## Sources and decision log

### Factual claims
- Inventory principal `arn:aws:iam::static:role/static/inventory` and actions `s3:PutObject` + `s3:AbortMultipartUpload` match the published [configure guide](https://docs.coreweave.com/products/storage/object-storage/buckets/inventory-reporting/configure#set-bucket-access-policies) and StoreWeave `inventory.ServiceName` / `GetServiceOrg()` (`CloudId: "static"`).
- Owner statements (`AllowOwnerListDestination`, `AllowOwnerManageDestinationObjects`) match that same destination policy example.
- A present bucket policy is implicit-deny for unmatched principals/actions: [About policies](https://docs.coreweave.com/products/storage/object-storage/auth-access/policies#policy-evaluation).
- `PutBucketInventoryConfiguration` probes destination `s3:PutObject` at apply time ([`buckets.go`](https://github.com/coreweave/storage/blob/main/images/storeweave/internal/api/buckets.go)).
- `organization_id` / `principal_id` come from `data.coreweave_caller_identity.current` (`uid` from `/v1beta1/auth/whoami`).

### Wording and structure
- Sid names reuse the configure guide so both examples read as the same policy.
- `jsonencode` matches the existing bucket-policy resource example.
- Comments explain implicit-deny and the apply-time `depends_on` requirement.

### Intentionally omitted
- Source-bucket `s3:PutInventoryConfiguration` policy. The Terraform caller is assumed to already have that via org policy.
- `cw:PrincipalOrgID` on the inventory principal. That principal is a specific service account, not a wildcard.
- IP conditions on the inventory `Allow`. Inventory requests carry no source IP.

### Related
- Jira: DOCS-2996 (scope updated in ticket comment)
- Closed PR: #418
- Docs: coreweave/docs#3464, DOCS-2451, DOCS-2988

Made with [Cursor](https://cursor.com)

[DOCS-2996]: https://coreweave.atlassian.net/browse/DOCS-2996?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ