### PR TITLE
fix(object_storage): retry post-create InvalidRegion updates

### DIFF
--- a/coreweave/object_storage/bucket_create.go
+++ b/coreweave/object_storage/bucket_create.go
@@ -2,11 +2,8 @@ package objectstorage
 
 import (
 	"context"
-	cryptorand "crypto/rand"
-	"crypto/tls"
 	"errors"
 	"fmt"
-	"math/big"
 	"net"
 	standardhttp "net/http"
 	"net/url"
@@ -18,18 +15,13 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/aws/smithy-go"
-	smithyhttp "github.com/aws/smithy-go/transport/http"
-	"github.com/coreweave/terraform-provider-coreweave/coreweave"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 const (
-	bucketPreflightPageSize  int32 = 10000
-	bucketPreflightMaxPages        = 10000
-	ambiguousCreateTimeout         = time.Minute
-	postCreateTimeout              = 5 * time.Minute
-	postCreateInitialBackoff       = 500 * time.Millisecond
-	postCreateMaxBackoff           = 5 * time.Second
+	bucketPreflightPageSize int32 = 10000
+	bucketPreflightMaxPages       = 10000
+	ambiguousCreateTimeout        = time.Minute
 )
 
 type bucketCreateAPI interface {
@@ -181,7 +173,7 @@ func reconcileAmbiguousCreate(
 	ctx, cancel := context.WithTimeout(parentCtx, ambiguousCreateTimeout)
 	defer cancel()
 
-	return runS3Phase(ctx, "ambiguous bucket create", bucket, zone, options, func(ctx context.Context) (bool, error) {
+	return runS3Phase(ctx, s3PhaseMetadata{phase: "ambiguous bucket create", bucket: bucket, zone: zone}, options, func(ctx context.Context) (bool, error) {
 		owned, err := bucketNameOwned(ctx, client, bucket)
 		if err != nil || !owned {
 			return false, err
@@ -199,82 +191,7 @@ func reconcileAmbiguousCreate(
 			return false, fmt.Errorf("owned bucket %q is in zone %q, want %q", bucket, actualZone, zone)
 		}
 		return true, nil
-	}, isPostCreateRetryableS3Error)
-}
-
-type s3PhaseOptions struct {
-	now   func() time.Time
-	delay func(attempt int) time.Duration
-	wait  func(context.Context, time.Duration) error
-}
-
-func (options s3PhaseOptions) withDefaults() s3PhaseOptions {
-	if options.now == nil {
-		options.now = time.Now
-	}
-	if options.delay == nil {
-		options.delay = postCreateBackoff
-	}
-	if options.wait == nil {
-		options.wait = waitForS3Backoff
-	}
-	return options
-}
-
-type s3PhaseError struct {
-	phase    string
-	attempts int
-	elapsed  time.Duration
-	err      error
-}
-
-func (e *s3PhaseError) Error() string {
-	return fmt.Sprintf("%s failed after %d attempt(s) in %s: %v", e.phase, e.attempts, e.elapsed.Round(time.Millisecond), e.err)
-}
-
-func (e *s3PhaseError) Unwrap() error {
-	return e.err
-}
-
-func runS3Phase(
-	ctx context.Context,
-	phase, bucket, zone string,
-	options s3PhaseOptions,
-	attempt func(context.Context) (bool, error),
-	retryable func(error) bool,
-) error {
-	options = options.withDefaults()
-	started := options.now()
-
-	for attemptNumber := 1; ; attemptNumber++ {
-		if err := ctx.Err(); err != nil {
-			return &s3PhaseError{phase: phase, attempts: attemptNumber - 1, elapsed: options.now().Sub(started), err: err}
-		}
-
-		done, err := attempt(ctx)
-		if err == nil && done {
-			return nil
-		}
-		if err != nil && !retryable(err) {
-			return &s3PhaseError{phase: phase, attempts: attemptNumber, elapsed: options.now().Sub(started), err: err}
-		}
-
-		delay := options.delay(attemptNumber)
-		errorClass, errorCode := s3ErrorMetadata(err)
-		tflog.Debug(ctx, "waiting for S3 operation convergence", map[string]interface{}{
-			"attempt":     attemptNumber,
-			"bucket":      bucket,
-			"elapsed":     options.now().Sub(started).String(),
-			"error_class": errorClass,
-			"error_code":  errorCode,
-			"next_delay":  delay.String(),
-			"phase":       phase,
-			"zone":        zone,
-		})
-		if waitErr := options.wait(ctx, delay); waitErr != nil {
-			return &s3PhaseError{phase: phase, attempts: attemptNumber, elapsed: options.now().Sub(started), err: waitErr}
-		}
-	}
+	}, isBucketPropagationRetryableS3Error)
 }
 
 func reconcileBucketAfterCreate(
@@ -285,10 +202,10 @@ func reconcileBucketAfterCreate(
 	applyTags bool,
 	options s3PhaseOptions,
 ) error {
-	ctx, cancel := context.WithTimeout(parentCtx, postCreateTimeout)
+	ctx, cancel := bucketPropagationContext(parentCtx)
 	defer cancel()
 
-	if err := runS3Phase(ctx, "bucket readiness", bucket, zone, options, func(ctx context.Context) (bool, error) {
+	if err := runS3Phase(ctx, s3PhaseMetadata{phase: "bucket readiness", bucket: bucket, zone: zone}, options, func(ctx context.Context) (bool, error) {
 		_, err := client.HeadBucket(ctx, &s3.HeadBucketInput{Bucket: aws.String(bucket)})
 		return err == nil, err
 	}, isBucketReadinessRetryableS3Error); err != nil {
@@ -303,16 +220,16 @@ func reconcileBucketAfterCreate(
 		Bucket:  aws.String(bucket),
 		Tagging: &s3types.Tagging{TagSet: expectedTags},
 	}
-	if err := runS3Phase(ctx, "bucket tag application", bucket, zone, options, func(ctx context.Context) (bool, error) {
+	if err := runS3Phase(ctx, s3PhaseMetadata{phase: "bucket tag application", bucket: bucket, zone: zone}, options, func(ctx context.Context) (bool, error) {
 		_, err := client.PutBucketTagging(ctx, tagInput)
 		return err == nil, err
-	}, isPostCreateRetryableS3Error); err != nil {
+	}, isBucketPropagationRetryableS3Error); err != nil {
 		return err
 	}
 
 	expected := append([]s3types.Tag(nil), expectedTags...)
 	slices.SortFunc(expected, cmpTag)
-	return runS3Phase(ctx, "bucket tag readback", bucket, zone, options, func(ctx context.Context) (bool, error) {
+	return runS3Phase(ctx, s3PhaseMetadata{phase: "bucket tag readback", bucket: bucket, zone: zone}, options, func(ctx context.Context) (bool, error) {
 		output, err := client.GetBucketTagging(ctx, &s3.GetBucketTaggingInput{Bucket: aws.String(bucket)})
 		if err != nil {
 			return false, err
@@ -323,7 +240,7 @@ func reconcileBucketAfterCreate(
 		actual := append([]s3types.Tag(nil), output.TagSet...)
 		slices.SortFunc(actual, cmpTag)
 		return slices.EqualFunc(expected, actual, eqTag), nil
-	}, isPostCreateRetryableS3Error)
+	}, isBucketPropagationRetryableS3Error)
 }
 
 func deleteBucketWithRetry(
@@ -332,41 +249,16 @@ func deleteBucketWithRetry(
 	bucket, zone string,
 	options s3PhaseOptions,
 ) error {
-	ctx, cancel := context.WithTimeout(parentCtx, postCreateTimeout)
+	ctx, cancel := bucketPropagationContext(parentCtx)
 	defer cancel()
 
-	return runS3Phase(ctx, "bucket deletion request", bucket, zone, options, func(ctx context.Context) (bool, error) {
+	return runS3Phase(ctx, s3PhaseMetadata{phase: "bucket deletion request", bucket: bucket, zone: zone}, options, func(ctx context.Context) (bool, error) {
 		_, err := client.DeleteBucket(ctx, &s3.DeleteBucketInput{Bucket: aws.String(bucket)})
 		if err == nil || isBucketNotFoundError(err) {
 			return true, nil
 		}
 		return false, err
-	}, isPostCreateRetryableS3Error)
-}
-
-func postCreateBackoff(attempt int) time.Duration {
-	shift := min(max(attempt-1, 0), 4)
-	delay := postCreateInitialBackoff << shift
-	if delay > postCreateMaxBackoff {
-		delay = postCreateMaxBackoff
-	}
-	half := delay / 2
-	jitter, err := cryptorand.Int(cryptorand.Reader, big.NewInt(int64(half)+1))
-	if err != nil {
-		return delay
-	}
-	return half + time.Duration(jitter.Int64())
-}
-
-func waitForS3Backoff(ctx context.Context, delay time.Duration) error {
-	timer := time.NewTimer(delay)
-	defer timer.Stop()
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	case <-timer.C:
-		return nil
-	}
+	}, isBucketPropagationRetryableS3Error)
 }
 
 func isAmbiguousCreateError(ctx context.Context, err error) bool {
@@ -400,78 +292,8 @@ func isAmbiguousCreateError(ctx context.Context, err error) bool {
 	return errors.As(err, &netErr)
 }
 
-func isPostCreateRetryableS3Error(err error) bool {
-	if err == nil || errors.Is(err, context.Canceled) || isPermanentTransportError(err) {
-		return false
-	}
-
-	var apiErr smithy.APIError
-	hasAPIError := errors.As(err, &apiErr)
-	if hasAPIError && isPermanentBucketAPIError(apiErr.ErrorCode()) {
-		return false
-	}
-
-	if status, ok := s3HTTPStatus(err); ok && isTransientS3HTTPStatus(status, true) {
-		return true
-	}
-	if hasAPIError {
-		return isTransientBucketAPIError(apiErr.ErrorCode(), true)
-	}
-	if errors.Is(err, context.DeadlineExceeded) {
-		return true
-	}
-
-	var urlErr *url.Error
-	if errors.As(err, &urlErr) {
-		return true
-	}
-	var netErr net.Error
-	return errors.As(err, &netErr)
-}
-
-func isPermanentBucketAPIError(code string) bool {
-	switch code {
-	case "AccessDenied", "AuthorizationHeaderMalformed", "InvalidAccessKeyId",
-		"InvalidArgument", "InvalidBucketName", "InvalidRequest", "InvalidToken",
-		"SignatureDoesNotMatch":
-		return true
-	default:
-		return false
-	}
-}
-
-func isTransientBucketAPIError(code string, includePropagation bool) bool {
-	if includePropagation {
-		switch code {
-		case errInvalidRegion, ErrNoSuchBucket, errNotFound, errNoSuchTagSet:
-			return true
-		}
-	}
-
-	switch code {
-	case "BadGateway", "GatewayTimeout", "InternalError", "InternalServerError",
-		"RequestTimeout", "RequestTimeoutException", "ServiceUnavailable", "SlowDown",
-		"TooManyRequests":
-		return true
-	default:
-		return false
-	}
-}
-
-func isTransientS3HTTPStatus(status int, includeNotFound bool) bool {
-	if includeNotFound && status == standardhttp.StatusNotFound {
-		return true
-	}
-	return status == standardhttp.StatusRequestTimeout ||
-		status == standardhttp.StatusTooManyRequests ||
-		status == standardhttp.StatusInternalServerError ||
-		status == standardhttp.StatusBadGateway ||
-		status == standardhttp.StatusServiceUnavailable ||
-		status == standardhttp.StatusGatewayTimeout
-}
-
 func isBucketReadinessRetryableS3Error(err error) bool {
-	if isPostCreateRetryableS3Error(err) {
+	if isBucketPropagationRetryableS3Error(err) {
 		return true
 	}
 
@@ -485,38 +307,4 @@ func isBucketReadinessRetryableS3Error(err error) bool {
 		apiErr.ErrorCode() == "BadRequest" &&
 		hasStatus &&
 		status == standardhttp.StatusBadRequest
-}
-
-func isPermanentTransportError(err error) bool {
-	return coreweave.IsPermanentRequestError(err)
-}
-
-func s3HTTPStatus(err error) (int, bool) {
-	var responseErr *smithyhttp.ResponseError
-	if !errors.As(err, &responseErr) || responseErr.Response == nil {
-		return 0, false
-	}
-	return responseErr.Response.StatusCode, true
-}
-
-func s3ErrorMetadata(err error) (class, code string) {
-	if err == nil {
-		return "not_converged", ""
-	}
-	var apiErr smithy.APIError
-	if errors.As(err, &apiErr) {
-		return "api", apiErr.ErrorCode()
-	}
-	if status, ok := s3HTTPStatus(err); ok {
-		return "http", fmt.Sprintf("%d", status)
-	}
-	var certificateErr *tls.CertificateVerificationError
-	if errors.As(err, &certificateErr) {
-		return "tls_certificate", ""
-	}
-	var urlErr *url.Error
-	if errors.As(err, &urlErr) {
-		return "network", ""
-	}
-	return "unknown", ""
 }

--- a/coreweave/object_storage/bucket_create.go
+++ b/coreweave/object_storage/bucket_create.go
@@ -229,7 +229,7 @@ func reconcileBucketAfterCreate(
 
 	expected := append([]s3types.Tag(nil), expectedTags...)
 	slices.SortFunc(expected, cmpTag)
-	return runS3Phase(ctx, s3PhaseMetadata{phase: "bucket tag readback", bucket: bucket, zone: zone}, options, func(ctx context.Context) (bool, error) {
+	return runBucketReadbackPhase(ctx, s3PhaseMetadata{phase: "bucket tag readback", bucket: bucket, zone: zone}, options, func(ctx context.Context) (bool, error) {
 		output, err := client.GetBucketTagging(ctx, &s3.GetBucketTaggingInput{Bucket: aws.String(bucket)})
 		if err != nil {
 			return false, err
@@ -240,7 +240,7 @@ func reconcileBucketAfterCreate(
 		actual := append([]s3types.Tag(nil), output.TagSet...)
 		slices.SortFunc(actual, cmpTag)
 		return slices.EqualFunc(expected, actual, eqTag), nil
-	}, isBucketPropagationRetryableS3Error)
+	})
 }
 
 func deleteBucketWithRetry(

--- a/coreweave/object_storage/resource_bucket.go
+++ b/coreweave/object_storage/resource_bucket.go
@@ -122,6 +122,17 @@ func handleS3Error(
 	diags *diag.Diagnostics,
 	bucketName string,
 ) {
+	// Convergence phases wrap SDK errors with retry metadata. Report that
+	// context before inspecting nested Smithy errors so it is not discarded.
+	var phaseErr *s3PhaseError
+	if errors.As(err, &phaseErr) {
+		diags.AddError(
+			fmt.Sprintf("S3 %s failed on bucket %q", phaseErr.phase, bucketName),
+			phaseErr.Error(),
+		)
+		return
+	}
+
 	// 1) OperationError ⇒ report service, operation, inner error
 	var opErr *smithy.OperationError
 	if errors.As(err, &opErr) {

--- a/coreweave/object_storage/resource_bucket_convergence_boundary_unit_test.go
+++ b/coreweave/object_storage/resource_bucket_convergence_boundary_unit_test.go
@@ -20,7 +20,7 @@ func TestBucketVersioningCreateRetainsStateWhenReadbackTimesOut(t *testing.T) {
 		s3ClientForConvergence: func(context.Context) (bucketVersioningAPI, error) {
 			return client, nil
 		},
-		bucketPropagationOptions: s3PhaseOptionsTimingOutOnWait(2),
+		bucketPropagationOptions: s3PhaseOptionsTimingOutOnSecondWait(),
 	}
 	model := BucketVersioningResourceModel{
 		Bucket: types.StringValue("versioning-state-retention-test"),
@@ -56,7 +56,7 @@ func TestBucketPolicyUpdateRetainsStateWhenReadbackTimesOut(t *testing.T) {
 		s3ClientForConvergence: func(context.Context) (bucketPolicyAPI, error) {
 			return client, nil
 		},
-		bucketPropagationOptions: s3PhaseOptionsTimingOutOnWait(2),
+		bucketPropagationOptions: s3PhaseOptionsTimingOutOnSecondWait(),
 	}
 	model := BucketPolicyResourceModel{
 		Bucket: types.StringValue("policy-update-state-retention-test"),
@@ -89,7 +89,7 @@ func TestBucketVersioningUpdateRetainsStateWhenReadbackTimesOut(t *testing.T) {
 		s3ClientForConvergence: func(context.Context) (bucketVersioningAPI, error) {
 			return client, nil
 		},
-		bucketPropagationOptions: s3PhaseOptionsTimingOutOnWait(2),
+		bucketPropagationOptions: s3PhaseOptionsTimingOutOnSecondWait(),
 	}
 	model := BucketVersioningResourceModel{
 		Bucket: types.StringValue("versioning-update-state-retention-test"),
@@ -124,7 +124,7 @@ func TestBucketLifecycleCreateRetainsStateWhenReadbackTimesOut(t *testing.T) {
 		s3ClientForConvergence: func(context.Context) (bucketLifecycleConfigurationClient, error) {
 			return client, nil
 		},
-		bucketPropagationOptions: s3PhaseOptionsTimingOutOnWait(2),
+		bucketPropagationOptions: s3PhaseOptionsTimingOutOnSecondWait(),
 	}
 	model := BucketLifecycleResourceModel{
 		Bucket: types.StringValue("lifecycle-state-retention-test"),
@@ -166,7 +166,7 @@ func TestBucketLifecycleUpdateRetainsStateWhenReadbackTimesOut(t *testing.T) {
 		s3ClientForConvergence: func(context.Context) (bucketLifecycleConfigurationClient, error) {
 			return client, nil
 		},
-		bucketPropagationOptions: s3PhaseOptionsTimingOutOnWait(2),
+		bucketPropagationOptions: s3PhaseOptionsTimingOutOnSecondWait(),
 	}
 	model := BucketLifecycleResourceModel{
 		Bucket: types.StringValue("lifecycle-update-state-retention-test"),
@@ -208,7 +208,7 @@ func TestBucketInventoryCreateRetainsStateWhenReadbackTimesOut(t *testing.T) {
 		s3ClientForConvergence: func(context.Context) (bucketInventoryConfigurationClient, error) {
 			return client, nil
 		},
-		bucketPropagationOptions: s3PhaseOptionsTimingOutOnWait(2),
+		bucketPropagationOptions: s3PhaseOptionsTimingOutOnSecondWait(),
 	}
 	model := *fullInventoryModel()
 
@@ -238,7 +238,7 @@ func TestBucketInventoryUpdateRetainsStateWhenReadbackTimesOut(t *testing.T) {
 		s3ClientForConvergence: func(context.Context) (bucketInventoryConfigurationClient, error) {
 			return client, nil
 		},
-		bucketPropagationOptions: s3PhaseOptionsTimingOutOnWait(2),
+		bucketPropagationOptions: s3PhaseOptionsTimingOutOnSecondWait(),
 	}
 	model := *fullInventoryModel()
 	model.Enabled = types.BoolValue(false)

--- a/coreweave/object_storage/resource_bucket_convergence_boundary_unit_test.go
+++ b/coreweave/object_storage/resource_bucket_convergence_boundary_unit_test.go
@@ -95,7 +95,7 @@ func TestBucketLifecycleCreateRetainsStateWhenReadbackTimesOut(t *testing.T) {
 	client.put.errors = []error{&smithy.GenericAPIError{Code: errInvalidRegion}, nil}
 	client.get.errors = []error{&smithy.GenericAPIError{Code: errInvalidRegion}}
 	resourceUnderTest := &BucketLifecycleResource{
-		s3ClientForConvergence:   func(context.Context) (bucketLifecycleConfigurationClient, error) { return client, nil },
+		s3ClientForConvergence:   func(context.Context) (bucketLifecycleConfigurationAPI, error) { return client, nil },
 		bucketPropagationOptions: s3PhaseOptionsTimingOutOnSecondWait(),
 	}
 	model := BucketLifecycleResourceModel{
@@ -123,7 +123,7 @@ func TestBucketLifecycleUpdateRetainsStateWhenReadbackTimesOut(t *testing.T) {
 	client.put.errors = []error{&smithy.GenericAPIError{Code: errInvalidRegion}, nil}
 	client.get.errors = []error{&smithy.GenericAPIError{Code: errInvalidRegion}}
 	resourceUnderTest := &BucketLifecycleResource{
-		s3ClientForConvergence:   func(context.Context) (bucketLifecycleConfigurationClient, error) { return client, nil },
+		s3ClientForConvergence:   func(context.Context) (bucketLifecycleConfigurationAPI, error) { return client, nil },
 		bucketPropagationOptions: s3PhaseOptionsTimingOutOnSecondWait(),
 	}
 	model := BucketLifecycleResourceModel{
@@ -151,7 +151,7 @@ func TestBucketInventoryCreateRetainsStateWhenReadbackTimesOut(t *testing.T) {
 	client.put.errors = []error{&smithy.GenericAPIError{Code: errInvalidRegion}, nil}
 	client.get.errors = []error{&smithy.GenericAPIError{Code: errInvalidRegion}}
 	resourceUnderTest := &BucketInventoryResource{
-		s3ClientForConvergence:   func(context.Context) (bucketInventoryConfigurationClient, error) { return client, nil },
+		s3ClientForConvergence:   func(context.Context) (bucketInventoryConfigurationAPI, error) { return client, nil },
 		bucketPropagationOptions: s3PhaseOptionsTimingOutOnSecondWait(),
 	}
 	model := *fullInventoryModel()
@@ -167,7 +167,7 @@ func TestBucketInventoryUpdateRetainsStateWhenReadbackTimesOut(t *testing.T) {
 	client.put.errors = []error{&smithy.GenericAPIError{Code: errInvalidRegion}, nil}
 	client.get.errors = []error{&smithy.GenericAPIError{Code: errInvalidRegion}}
 	resourceUnderTest := &BucketInventoryResource{
-		s3ClientForConvergence:   func(context.Context) (bucketInventoryConfigurationClient, error) { return client, nil },
+		s3ClientForConvergence:   func(context.Context) (bucketInventoryConfigurationAPI, error) { return client, nil },
 		bucketPropagationOptions: s3PhaseOptionsTimingOutOnSecondWait(),
 	}
 	model := *fullInventoryModel()

--- a/coreweave/object_storage/resource_bucket_convergence_boundary_unit_test.go
+++ b/coreweave/object_storage/resource_bucket_convergence_boundary_unit_test.go
@@ -2,24 +2,39 @@ package objectstorage
 
 import (
 	"context"
-	"reflect"
 	"testing"
 
 	"github.com/aws/smithy-go"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
+func TestBucketPolicyCreateRetainsStateWhenReadbackTimesOut(t *testing.T) {
+	t.Parallel()
+
+	client := &scriptedBucketPolicyClient{}
+	client.put.errors = []error{&smithy.GenericAPIError{Code: errInvalidRegion}, nil}
+	client.get.errors = []error{&smithy.GenericAPIError{Code: errInvalidRegion}}
+	resourceUnderTest := &BucketPolicyResource{
+		s3ClientForConvergence:   func(context.Context) (bucketPolicyAPI, error) { return client, nil },
+		bucketPropagationOptions: s3PhaseOptionsTimingOutOnSecondWait(),
+	}
+	model := BucketPolicyResourceModel{
+		Bucket: types.StringValue("policy-state-retention-test"),
+		Policy: types.StringValue(`{"Version":"2012-10-17","Statement":[]}`),
+	}
+
+	response := runCreateWithModel(t, resourceUnderTest, model)
+	assertReadbackTimeoutRetainsPlan(t, response.State, response.Diagnostics.HasError(), model, &client.put, &client.get)
+}
+
 func TestBucketVersioningCreateRetainsStateWhenReadbackTimesOut(t *testing.T) {
 	t.Parallel()
 
-	client := &scriptedBucketVersioningClient{
-		putErrors: []error{&smithy.GenericAPIError{Code: errInvalidRegion}, nil},
-		getErrors: []error{&smithy.GenericAPIError{Code: errInvalidRegion}},
-	}
+	client := &scriptedBucketVersioningClient{}
+	client.put.errors = []error{&smithy.GenericAPIError{Code: errInvalidRegion}, nil}
+	client.get.errors = []error{&smithy.GenericAPIError{Code: errInvalidRegion}}
 	resourceUnderTest := &BucketVersioningResource{
-		s3ClientForConvergence: func(context.Context) (bucketVersioningAPI, error) {
-			return client, nil
-		},
+		s3ClientForConvergence:   func(context.Context) (bucketVersioningAPI, error) { return client, nil },
 		bucketPropagationOptions: s3PhaseOptionsTimingOutOnSecondWait(),
 	}
 	model := BucketVersioningResourceModel{
@@ -30,65 +45,36 @@ func TestBucketVersioningCreateRetainsStateWhenReadbackTimesOut(t *testing.T) {
 	}
 
 	response := runCreateWithModel(t, resourceUnderTest, model)
-	assertWriteRetriedAndRetainedState(t, response.Diagnostics.HasError(), len(client.putInputs), len(client.getInputs), client.putContexts, client.getContexts)
-	if client.putInputs[0] != client.putInputs[1] {
-		t.Fatal("PutBucketVersioning rebuilt its retry input")
-	}
-
-	var retained BucketVersioningResourceModel
-	if diagnostics := response.State.Get(t.Context(), &retained); diagnostics.HasError() {
-		t.Fatalf("read retained state: %v", diagnostics)
-	}
-	if !reflect.DeepEqual(retained, model) {
-		t.Fatalf("retained state = %#v, want %#v", retained, model)
-	}
+	assertReadbackTimeoutRetainsPlan(t, response.State, response.Diagnostics.HasError(), model, &client.put, &client.get)
 }
 
 func TestBucketPolicyUpdateRetainsStateWhenReadbackTimesOut(t *testing.T) {
 	t.Parallel()
 
-	const policy = `{"Version":"2012-10-17","Statement":[]}`
-	client := &scriptedBucketPolicyClient{
-		putErrors: []error{&smithy.GenericAPIError{Code: errInvalidRegion}, nil},
-		getErrors: []error{&smithy.GenericAPIError{Code: errInvalidRegion}},
-	}
+	client := &scriptedBucketPolicyClient{}
+	client.put.errors = []error{&smithy.GenericAPIError{Code: errInvalidRegion}, nil}
+	client.get.errors = []error{&smithy.GenericAPIError{Code: errInvalidRegion}}
 	resourceUnderTest := &BucketPolicyResource{
-		s3ClientForConvergence: func(context.Context) (bucketPolicyAPI, error) {
-			return client, nil
-		},
+		s3ClientForConvergence:   func(context.Context) (bucketPolicyAPI, error) { return client, nil },
 		bucketPropagationOptions: s3PhaseOptionsTimingOutOnSecondWait(),
 	}
 	model := BucketPolicyResourceModel{
 		Bucket: types.StringValue("policy-update-state-retention-test"),
-		Policy: types.StringValue(policy),
+		Policy: types.StringValue(`{"Version":"2012-10-17","Statement":[]}`),
 	}
 
 	response := runUpdateWithModel(t, resourceUnderTest, model)
-	assertWriteRetriedAndRetainedState(t, response.Diagnostics.HasError(), len(client.putInputs), len(client.getInputs), client.putContexts, client.getContexts)
-	if client.putInputs[0] != client.putInputs[1] {
-		t.Fatal("PutBucketPolicy rebuilt its retry input")
-	}
-
-	var retained BucketPolicyResourceModel
-	if diagnostics := response.State.Get(t.Context(), &retained); diagnostics.HasError() {
-		t.Fatalf("read retained state: %v", diagnostics)
-	}
-	if !reflect.DeepEqual(retained, model) {
-		t.Fatalf("retained state = %#v, want %#v", retained, model)
-	}
+	assertReadbackTimeoutRetainsPlan(t, response.State, response.Diagnostics.HasError(), model, &client.put, &client.get)
 }
 
 func TestBucketVersioningUpdateRetainsStateWhenReadbackTimesOut(t *testing.T) {
 	t.Parallel()
 
-	client := &scriptedBucketVersioningClient{
-		putErrors: []error{&smithy.GenericAPIError{Code: errInvalidRegion}, nil},
-		getErrors: []error{&smithy.GenericAPIError{Code: errInvalidRegion}},
-	}
+	client := &scriptedBucketVersioningClient{}
+	client.put.errors = []error{&smithy.GenericAPIError{Code: errInvalidRegion}, nil}
+	client.get.errors = []error{&smithy.GenericAPIError{Code: errInvalidRegion}}
 	resourceUnderTest := &BucketVersioningResource{
-		s3ClientForConvergence: func(context.Context) (bucketVersioningAPI, error) {
-			return client, nil
-		},
+		s3ClientForConvergence:   func(context.Context) (bucketVersioningAPI, error) { return client, nil },
 		bucketPropagationOptions: s3PhaseOptionsTimingOutOnSecondWait(),
 	}
 	model := BucketVersioningResourceModel{
@@ -99,31 +85,17 @@ func TestBucketVersioningUpdateRetainsStateWhenReadbackTimesOut(t *testing.T) {
 	}
 
 	response := runUpdateWithModel(t, resourceUnderTest, model)
-	assertWriteRetriedAndRetainedState(t, response.Diagnostics.HasError(), len(client.putInputs), len(client.getInputs), client.putContexts, client.getContexts)
-	if client.putInputs[0] != client.putInputs[1] {
-		t.Fatal("PutBucketVersioning rebuilt its retry input")
-	}
-
-	var retained BucketVersioningResourceModel
-	if diagnostics := response.State.Get(t.Context(), &retained); diagnostics.HasError() {
-		t.Fatalf("read retained state: %v", diagnostics)
-	}
-	if !reflect.DeepEqual(retained, model) {
-		t.Fatalf("retained state = %#v, want %#v", retained, model)
-	}
+	assertReadbackTimeoutRetainsPlan(t, response.State, response.Diagnostics.HasError(), model, &client.put, &client.get)
 }
 
 func TestBucketLifecycleCreateRetainsStateWhenReadbackTimesOut(t *testing.T) {
 	t.Parallel()
 
-	client := &scriptedLifecycleConfigurationClient{
-		putErrors: []error{&smithy.GenericAPIError{Code: errInvalidRegion}, nil},
-		getErrors: []error{&smithy.GenericAPIError{Code: errInvalidRegion}},
-	}
+	client := &scriptedLifecycleConfigurationClient{}
+	client.put.errors = []error{&smithy.GenericAPIError{Code: errInvalidRegion}, nil}
+	client.get.errors = []error{&smithy.GenericAPIError{Code: errInvalidRegion}}
 	resourceUnderTest := &BucketLifecycleResource{
-		s3ClientForConvergence: func(context.Context) (bucketLifecycleConfigurationClient, error) {
-			return client, nil
-		},
+		s3ClientForConvergence:   func(context.Context) (bucketLifecycleConfigurationClient, error) { return client, nil },
 		bucketPropagationOptions: s3PhaseOptionsTimingOutOnSecondWait(),
 	}
 	model := BucketLifecycleResourceModel{
@@ -141,31 +113,17 @@ func TestBucketLifecycleCreateRetainsStateWhenReadbackTimesOut(t *testing.T) {
 	}
 
 	response := runCreateWithModel(t, resourceUnderTest, model)
-	assertWriteRetriedAndRetainedState(t, response.Diagnostics.HasError(), len(client.putInputs), len(client.getInputs), client.putContexts, client.getContexts)
-	if client.putInputs[0] != client.putInputs[1] {
-		t.Fatal("PutBucketLifecycleConfiguration rebuilt its retry input")
-	}
-
-	var retained BucketLifecycleResourceModel
-	if diagnostics := response.State.Get(t.Context(), &retained); diagnostics.HasError() {
-		t.Fatalf("read retained state: %v", diagnostics)
-	}
-	if !reflect.DeepEqual(retained, model) {
-		t.Fatalf("retained state = %#v, want lifecycle plan", retained)
-	}
+	assertReadbackTimeoutRetainsPlan(t, response.State, response.Diagnostics.HasError(), model, &client.put, &client.get)
 }
 
 func TestBucketLifecycleUpdateRetainsStateWhenReadbackTimesOut(t *testing.T) {
 	t.Parallel()
 
-	client := &scriptedLifecycleConfigurationClient{
-		putErrors: []error{&smithy.GenericAPIError{Code: errInvalidRegion}, nil},
-		getErrors: []error{&smithy.GenericAPIError{Code: errInvalidRegion}},
-	}
+	client := &scriptedLifecycleConfigurationClient{}
+	client.put.errors = []error{&smithy.GenericAPIError{Code: errInvalidRegion}, nil}
+	client.get.errors = []error{&smithy.GenericAPIError{Code: errInvalidRegion}}
 	resourceUnderTest := &BucketLifecycleResource{
-		s3ClientForConvergence: func(context.Context) (bucketLifecycleConfigurationClient, error) {
-			return client, nil
-		},
+		s3ClientForConvergence:   func(context.Context) (bucketLifecycleConfigurationClient, error) { return client, nil },
 		bucketPropagationOptions: s3PhaseOptionsTimingOutOnSecondWait(),
 	}
 	model := BucketLifecycleResourceModel{
@@ -183,77 +141,38 @@ func TestBucketLifecycleUpdateRetainsStateWhenReadbackTimesOut(t *testing.T) {
 	}
 
 	response := runUpdateWithModel(t, resourceUnderTest, model)
-	assertWriteRetriedAndRetainedState(t, response.Diagnostics.HasError(), len(client.putInputs), len(client.getInputs), client.putContexts, client.getContexts)
-	if client.putInputs[0] != client.putInputs[1] {
-		t.Fatal("PutBucketLifecycleConfiguration rebuilt its retry input")
-	}
-
-	var retained BucketLifecycleResourceModel
-	if diagnostics := response.State.Get(t.Context(), &retained); diagnostics.HasError() {
-		t.Fatalf("read retained state: %v", diagnostics)
-	}
-	if !reflect.DeepEqual(retained, model) {
-		t.Fatalf("retained state = %#v, want %#v", retained, model)
-	}
+	assertReadbackTimeoutRetainsPlan(t, response.State, response.Diagnostics.HasError(), model, &client.put, &client.get)
 }
 
 func TestBucketInventoryCreateRetainsStateWhenReadbackTimesOut(t *testing.T) {
 	t.Parallel()
 
-	client := &scriptedInventoryConfigurationClient{
-		putErrors: []error{&smithy.GenericAPIError{Code: errInvalidRegion}, nil},
-		getErrors: []error{&smithy.GenericAPIError{Code: errInvalidRegion}},
-	}
+	client := &scriptedInventoryConfigurationClient{}
+	client.put.errors = []error{&smithy.GenericAPIError{Code: errInvalidRegion}, nil}
+	client.get.errors = []error{&smithy.GenericAPIError{Code: errInvalidRegion}}
 	resourceUnderTest := &BucketInventoryResource{
-		s3ClientForConvergence: func(context.Context) (bucketInventoryConfigurationClient, error) {
-			return client, nil
-		},
+		s3ClientForConvergence:   func(context.Context) (bucketInventoryConfigurationClient, error) { return client, nil },
 		bucketPropagationOptions: s3PhaseOptionsTimingOutOnSecondWait(),
 	}
 	model := *fullInventoryModel()
 
 	response := runCreateWithModel(t, resourceUnderTest, model)
-	assertWriteRetriedAndRetainedState(t, response.Diagnostics.HasError(), len(client.putInputs), len(client.getInputs), client.putContexts, client.getContexts)
-	if client.putInputs[0] != client.putInputs[1] {
-		t.Fatal("PutBucketInventoryConfiguration rebuilt its retry input")
-	}
-
-	var retained BucketInventoryResourceModel
-	if diagnostics := response.State.Get(t.Context(), &retained); diagnostics.HasError() {
-		t.Fatalf("read retained state: %v", diagnostics)
-	}
-	if !reflect.DeepEqual(retained, model) {
-		t.Fatalf("retained state = %#v, want inventory plan", retained)
-	}
+	assertReadbackTimeoutRetainsPlan(t, response.State, response.Diagnostics.HasError(), model, &client.put, &client.get)
 }
 
 func TestBucketInventoryUpdateRetainsStateWhenReadbackTimesOut(t *testing.T) {
 	t.Parallel()
 
-	client := &scriptedInventoryConfigurationClient{
-		putErrors: []error{&smithy.GenericAPIError{Code: errInvalidRegion}, nil},
-		getErrors: []error{&smithy.GenericAPIError{Code: errInvalidRegion}},
-	}
+	client := &scriptedInventoryConfigurationClient{}
+	client.put.errors = []error{&smithy.GenericAPIError{Code: errInvalidRegion}, nil}
+	client.get.errors = []error{&smithy.GenericAPIError{Code: errInvalidRegion}}
 	resourceUnderTest := &BucketInventoryResource{
-		s3ClientForConvergence: func(context.Context) (bucketInventoryConfigurationClient, error) {
-			return client, nil
-		},
+		s3ClientForConvergence:   func(context.Context) (bucketInventoryConfigurationClient, error) { return client, nil },
 		bucketPropagationOptions: s3PhaseOptionsTimingOutOnSecondWait(),
 	}
 	model := *fullInventoryModel()
 	model.Enabled = types.BoolValue(false)
 
 	response := runUpdateWithModel(t, resourceUnderTest, model)
-	assertWriteRetriedAndRetainedState(t, response.Diagnostics.HasError(), len(client.putInputs), len(client.getInputs), client.putContexts, client.getContexts)
-	if client.putInputs[0] != client.putInputs[1] {
-		t.Fatal("PutBucketInventoryConfiguration rebuilt its retry input")
-	}
-
-	var retained BucketInventoryResourceModel
-	if diagnostics := response.State.Get(t.Context(), &retained); diagnostics.HasError() {
-		t.Fatalf("read retained state: %v", diagnostics)
-	}
-	if !reflect.DeepEqual(retained, model) {
-		t.Fatalf("retained state = %#v, want %#v", retained, model)
-	}
+	assertReadbackTimeoutRetainsPlan(t, response.State, response.Diagnostics.HasError(), model, &client.put, &client.get)
 }

--- a/coreweave/object_storage/resource_bucket_convergence_boundary_unit_test.go
+++ b/coreweave/object_storage/resource_bucket_convergence_boundary_unit_test.go
@@ -1,0 +1,259 @@
+package objectstorage
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/aws/smithy-go"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestBucketVersioningCreateRetainsStateWhenReadbackTimesOut(t *testing.T) {
+	t.Parallel()
+
+	client := &scriptedBucketVersioningClient{
+		putErrors: []error{&smithy.GenericAPIError{Code: errInvalidRegion}, nil},
+		getErrors: []error{&smithy.GenericAPIError{Code: errInvalidRegion}},
+	}
+	resourceUnderTest := &BucketVersioningResource{
+		s3ClientForConvergence: func(context.Context) (bucketVersioningAPI, error) {
+			return client, nil
+		},
+		bucketPropagationOptions: s3PhaseOptionsTimingOutOnWait(2),
+	}
+	model := BucketVersioningResourceModel{
+		Bucket: types.StringValue("versioning-state-retention-test"),
+		VersioningConfiguration: VersioningConfigurationModel{
+			Status: types.StringValue("Enabled"),
+		},
+	}
+
+	response := runCreateWithModel(t, resourceUnderTest, model)
+	assertWriteRetriedAndRetainedState(t, response.Diagnostics.HasError(), len(client.putInputs), len(client.getInputs), client.putContexts, client.getContexts)
+	if client.putInputs[0] != client.putInputs[1] {
+		t.Fatal("PutBucketVersioning rebuilt its retry input")
+	}
+
+	var retained BucketVersioningResourceModel
+	if diagnostics := response.State.Get(t.Context(), &retained); diagnostics.HasError() {
+		t.Fatalf("read retained state: %v", diagnostics)
+	}
+	if !reflect.DeepEqual(retained, model) {
+		t.Fatalf("retained state = %#v, want %#v", retained, model)
+	}
+}
+
+func TestBucketPolicyUpdateRetainsStateWhenReadbackTimesOut(t *testing.T) {
+	t.Parallel()
+
+	const policy = `{"Version":"2012-10-17","Statement":[]}`
+	client := &scriptedBucketPolicyClient{
+		putErrors: []error{&smithy.GenericAPIError{Code: errInvalidRegion}, nil},
+		getErrors: []error{&smithy.GenericAPIError{Code: errInvalidRegion}},
+	}
+	resourceUnderTest := &BucketPolicyResource{
+		s3ClientForConvergence: func(context.Context) (bucketPolicyAPI, error) {
+			return client, nil
+		},
+		bucketPropagationOptions: s3PhaseOptionsTimingOutOnWait(2),
+	}
+	model := BucketPolicyResourceModel{
+		Bucket: types.StringValue("policy-update-state-retention-test"),
+		Policy: types.StringValue(policy),
+	}
+
+	response := runUpdateWithModel(t, resourceUnderTest, model)
+	assertWriteRetriedAndRetainedState(t, response.Diagnostics.HasError(), len(client.putInputs), len(client.getInputs), client.putContexts, client.getContexts)
+	if client.putInputs[0] != client.putInputs[1] {
+		t.Fatal("PutBucketPolicy rebuilt its retry input")
+	}
+
+	var retained BucketPolicyResourceModel
+	if diagnostics := response.State.Get(t.Context(), &retained); diagnostics.HasError() {
+		t.Fatalf("read retained state: %v", diagnostics)
+	}
+	if !reflect.DeepEqual(retained, model) {
+		t.Fatalf("retained state = %#v, want %#v", retained, model)
+	}
+}
+
+func TestBucketVersioningUpdateRetainsStateWhenReadbackTimesOut(t *testing.T) {
+	t.Parallel()
+
+	client := &scriptedBucketVersioningClient{
+		putErrors: []error{&smithy.GenericAPIError{Code: errInvalidRegion}, nil},
+		getErrors: []error{&smithy.GenericAPIError{Code: errInvalidRegion}},
+	}
+	resourceUnderTest := &BucketVersioningResource{
+		s3ClientForConvergence: func(context.Context) (bucketVersioningAPI, error) {
+			return client, nil
+		},
+		bucketPropagationOptions: s3PhaseOptionsTimingOutOnWait(2),
+	}
+	model := BucketVersioningResourceModel{
+		Bucket: types.StringValue("versioning-update-state-retention-test"),
+		VersioningConfiguration: VersioningConfigurationModel{
+			Status: types.StringValue("Suspended"),
+		},
+	}
+
+	response := runUpdateWithModel(t, resourceUnderTest, model)
+	assertWriteRetriedAndRetainedState(t, response.Diagnostics.HasError(), len(client.putInputs), len(client.getInputs), client.putContexts, client.getContexts)
+	if client.putInputs[0] != client.putInputs[1] {
+		t.Fatal("PutBucketVersioning rebuilt its retry input")
+	}
+
+	var retained BucketVersioningResourceModel
+	if diagnostics := response.State.Get(t.Context(), &retained); diagnostics.HasError() {
+		t.Fatalf("read retained state: %v", diagnostics)
+	}
+	if !reflect.DeepEqual(retained, model) {
+		t.Fatalf("retained state = %#v, want %#v", retained, model)
+	}
+}
+
+func TestBucketLifecycleCreateRetainsStateWhenReadbackTimesOut(t *testing.T) {
+	t.Parallel()
+
+	client := &scriptedLifecycleConfigurationClient{
+		putErrors: []error{&smithy.GenericAPIError{Code: errInvalidRegion}, nil},
+		getErrors: []error{&smithy.GenericAPIError{Code: errInvalidRegion}},
+	}
+	resourceUnderTest := &BucketLifecycleResource{
+		s3ClientForConvergence: func(context.Context) (bucketLifecycleConfigurationClient, error) {
+			return client, nil
+		},
+		bucketPropagationOptions: s3PhaseOptionsTimingOutOnWait(2),
+	}
+	model := BucketLifecycleResourceModel{
+		Bucket: types.StringValue("lifecycle-state-retention-test"),
+		Rule: []LifecycleRuleModel{{
+			ID:     types.StringValue("expire-logs"),
+			Prefix: types.StringNull(),
+			Status: types.StringValue("Enabled"),
+			Expiration: &ExpirationModel{
+				Date:                      types.StringNull(),
+				Days:                      types.Int32Value(30),
+				ExpiredObjectDeleteMarker: types.BoolNull(),
+			},
+		}},
+	}
+
+	response := runCreateWithModel(t, resourceUnderTest, model)
+	assertWriteRetriedAndRetainedState(t, response.Diagnostics.HasError(), len(client.putInputs), len(client.getInputs), client.putContexts, client.getContexts)
+	if client.putInputs[0] != client.putInputs[1] {
+		t.Fatal("PutBucketLifecycleConfiguration rebuilt its retry input")
+	}
+
+	var retained BucketLifecycleResourceModel
+	if diagnostics := response.State.Get(t.Context(), &retained); diagnostics.HasError() {
+		t.Fatalf("read retained state: %v", diagnostics)
+	}
+	if !reflect.DeepEqual(retained, model) {
+		t.Fatalf("retained state = %#v, want lifecycle plan", retained)
+	}
+}
+
+func TestBucketLifecycleUpdateRetainsStateWhenReadbackTimesOut(t *testing.T) {
+	t.Parallel()
+
+	client := &scriptedLifecycleConfigurationClient{
+		putErrors: []error{&smithy.GenericAPIError{Code: errInvalidRegion}, nil},
+		getErrors: []error{&smithy.GenericAPIError{Code: errInvalidRegion}},
+	}
+	resourceUnderTest := &BucketLifecycleResource{
+		s3ClientForConvergence: func(context.Context) (bucketLifecycleConfigurationClient, error) {
+			return client, nil
+		},
+		bucketPropagationOptions: s3PhaseOptionsTimingOutOnWait(2),
+	}
+	model := BucketLifecycleResourceModel{
+		Bucket: types.StringValue("lifecycle-update-state-retention-test"),
+		Rule: []LifecycleRuleModel{{
+			ID:     types.StringValue("expire-updated-logs"),
+			Prefix: types.StringNull(),
+			Status: types.StringValue("Enabled"),
+			Expiration: &ExpirationModel{
+				Date:                      types.StringNull(),
+				Days:                      types.Int32Value(60),
+				ExpiredObjectDeleteMarker: types.BoolNull(),
+			},
+		}},
+	}
+
+	response := runUpdateWithModel(t, resourceUnderTest, model)
+	assertWriteRetriedAndRetainedState(t, response.Diagnostics.HasError(), len(client.putInputs), len(client.getInputs), client.putContexts, client.getContexts)
+	if client.putInputs[0] != client.putInputs[1] {
+		t.Fatal("PutBucketLifecycleConfiguration rebuilt its retry input")
+	}
+
+	var retained BucketLifecycleResourceModel
+	if diagnostics := response.State.Get(t.Context(), &retained); diagnostics.HasError() {
+		t.Fatalf("read retained state: %v", diagnostics)
+	}
+	if !reflect.DeepEqual(retained, model) {
+		t.Fatalf("retained state = %#v, want %#v", retained, model)
+	}
+}
+
+func TestBucketInventoryCreateRetainsStateWhenReadbackTimesOut(t *testing.T) {
+	t.Parallel()
+
+	client := &scriptedInventoryConfigurationClient{
+		putErrors: []error{&smithy.GenericAPIError{Code: errInvalidRegion}, nil},
+		getErrors: []error{&smithy.GenericAPIError{Code: errInvalidRegion}},
+	}
+	resourceUnderTest := &BucketInventoryResource{
+		s3ClientForConvergence: func(context.Context) (bucketInventoryConfigurationClient, error) {
+			return client, nil
+		},
+		bucketPropagationOptions: s3PhaseOptionsTimingOutOnWait(2),
+	}
+	model := *fullInventoryModel()
+
+	response := runCreateWithModel(t, resourceUnderTest, model)
+	assertWriteRetriedAndRetainedState(t, response.Diagnostics.HasError(), len(client.putInputs), len(client.getInputs), client.putContexts, client.getContexts)
+	if client.putInputs[0] != client.putInputs[1] {
+		t.Fatal("PutBucketInventoryConfiguration rebuilt its retry input")
+	}
+
+	var retained BucketInventoryResourceModel
+	if diagnostics := response.State.Get(t.Context(), &retained); diagnostics.HasError() {
+		t.Fatalf("read retained state: %v", diagnostics)
+	}
+	if !reflect.DeepEqual(retained, model) {
+		t.Fatalf("retained state = %#v, want inventory plan", retained)
+	}
+}
+
+func TestBucketInventoryUpdateRetainsStateWhenReadbackTimesOut(t *testing.T) {
+	t.Parallel()
+
+	client := &scriptedInventoryConfigurationClient{
+		putErrors: []error{&smithy.GenericAPIError{Code: errInvalidRegion}, nil},
+		getErrors: []error{&smithy.GenericAPIError{Code: errInvalidRegion}},
+	}
+	resourceUnderTest := &BucketInventoryResource{
+		s3ClientForConvergence: func(context.Context) (bucketInventoryConfigurationClient, error) {
+			return client, nil
+		},
+		bucketPropagationOptions: s3PhaseOptionsTimingOutOnWait(2),
+	}
+	model := *fullInventoryModel()
+	model.Enabled = types.BoolValue(false)
+
+	response := runUpdateWithModel(t, resourceUnderTest, model)
+	assertWriteRetriedAndRetainedState(t, response.Diagnostics.HasError(), len(client.putInputs), len(client.getInputs), client.putContexts, client.getContexts)
+	if client.putInputs[0] != client.putInputs[1] {
+		t.Fatal("PutBucketInventoryConfiguration rebuilt its retry input")
+	}
+
+	var retained BucketInventoryResourceModel
+	if diagnostics := response.State.Get(t.Context(), &retained); diagnostics.HasError() {
+		t.Fatalf("read retained state: %v", diagnostics)
+	}
+	if !reflect.DeepEqual(retained, model) {
+		t.Fatalf("retained state = %#v, want %#v", retained, model)
+	}
+}

--- a/coreweave/object_storage/resource_bucket_convergence_test_helpers_test.go
+++ b/coreweave/object_storage/resource_bucket_convergence_test_helpers_test.go
@@ -1,0 +1,72 @@
+package objectstorage
+
+import (
+	"context"
+	"testing"
+
+	fwresource "github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+)
+
+type createResource interface {
+	Schema(context.Context, fwresource.SchemaRequest, *fwresource.SchemaResponse)
+	Create(context.Context, fwresource.CreateRequest, *fwresource.CreateResponse)
+}
+
+type updateResource interface {
+	Schema(context.Context, fwresource.SchemaRequest, *fwresource.SchemaResponse)
+	Update(context.Context, fwresource.UpdateRequest, *fwresource.UpdateResponse)
+}
+
+func runCreateWithModel(t *testing.T, resourceUnderTest createResource, model any) *fwresource.CreateResponse {
+	t.Helper()
+
+	var schemaResponse fwresource.SchemaResponse
+	resourceUnderTest.Schema(t.Context(), fwresource.SchemaRequest{}, &schemaResponse)
+	if schemaResponse.Diagnostics.HasError() {
+		t.Fatalf("resource schema diagnostics: %v", schemaResponse.Diagnostics)
+	}
+	plan := tfsdk.Plan{Schema: schemaResponse.Schema}
+	if diagnostics := plan.Set(t.Context(), model); diagnostics.HasError() {
+		t.Fatalf("set test plan: %v", diagnostics)
+	}
+	response := &fwresource.CreateResponse{State: tfsdk.State{Schema: schemaResponse.Schema}}
+	resourceUnderTest.Create(t.Context(), fwresource.CreateRequest{Plan: plan}, response)
+	return response
+}
+
+func runUpdateWithModel(t *testing.T, resourceUnderTest updateResource, model any) *fwresource.UpdateResponse {
+	t.Helper()
+
+	var schemaResponse fwresource.SchemaResponse
+	resourceUnderTest.Schema(t.Context(), fwresource.SchemaRequest{}, &schemaResponse)
+	if schemaResponse.Diagnostics.HasError() {
+		t.Fatalf("resource schema diagnostics: %v", schemaResponse.Diagnostics)
+	}
+	plan := tfsdk.Plan{Schema: schemaResponse.Schema}
+	if diagnostics := plan.Set(t.Context(), model); diagnostics.HasError() {
+		t.Fatalf("set test plan: %v", diagnostics)
+	}
+	response := &fwresource.UpdateResponse{State: tfsdk.State{Schema: schemaResponse.Schema}}
+	resourceUnderTest.Update(t.Context(), fwresource.UpdateRequest{Plan: plan}, response)
+	return response
+}
+
+func assertWriteRetriedAndRetainedState(
+	t *testing.T,
+	hasDiagnosticsError bool,
+	putCalls, getCalls int,
+	putContexts, getContexts []context.Context,
+) {
+	t.Helper()
+
+	if !hasDiagnosticsError {
+		t.Fatal("write diagnostics contain no error, want readback timeout")
+	}
+	if putCalls != 2 || getCalls != 1 {
+		t.Fatalf("S3 calls: Put=%d Get=%d, want 2 and 1", putCalls, getCalls)
+	}
+	if len(putContexts) != 2 || len(getContexts) != 1 || putContexts[0] != putContexts[1] || putContexts[1] != getContexts[0] {
+		t.Fatal("mutation and readback did not share one propagation context")
+	}
+}

--- a/coreweave/object_storage/resource_bucket_convergence_test_helpers_test.go
+++ b/coreweave/object_storage/resource_bucket_convergence_test_helpers_test.go
@@ -2,11 +2,33 @@ package objectstorage
 
 import (
 	"context"
+	"reflect"
 	"testing"
+	"time"
 
 	fwresource "github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 )
+
+type scriptedS3Call[Input, Output any] struct {
+	errors   []error
+	outputs  []*Output
+	inputs   []*Input
+	contexts []context.Context
+}
+
+func (c *scriptedS3Call[Input, Output]) call(ctx context.Context, input *Input) (*Output, error) {
+	index := len(c.inputs)
+	c.inputs = append(c.inputs, input)
+	c.contexts = append(c.contexts, ctx)
+	if index < len(c.errors) && c.errors[index] != nil {
+		return nil, c.errors[index]
+	}
+	if index < len(c.outputs) && c.outputs[index] != nil {
+		return c.outputs[index], nil
+	}
+	return new(Output), nil
+}
 
 type createResource interface {
 	Schema(context.Context, fwresource.SchemaRequest, *fwresource.SchemaResponse)
@@ -52,21 +74,49 @@ func runUpdateWithModel(t *testing.T, resourceUnderTest updateResource, model an
 	return response
 }
 
-func assertWriteRetriedAndRetainedState(
+func assertReadbackTimeoutRetainsPlan[Model, PutInput, PutOutput, GetInput, GetOutput any](
 	t *testing.T,
+	state tfsdk.State,
 	hasDiagnosticsError bool,
-	putCalls, getCalls int,
-	putContexts, getContexts []context.Context,
+	want Model,
+	put *scriptedS3Call[PutInput, PutOutput],
+	get *scriptedS3Call[GetInput, GetOutput],
 ) {
 	t.Helper()
 
 	if !hasDiagnosticsError {
 		t.Fatal("write diagnostics contain no error, want readback timeout")
 	}
-	if putCalls != 2 || getCalls != 1 {
-		t.Fatalf("S3 calls: Put=%d Get=%d, want 2 and 1", putCalls, getCalls)
+	if len(put.inputs) != 2 || len(get.inputs) != 1 {
+		t.Fatalf("S3 calls: Put=%d Get=%d, want 2 and 1", len(put.inputs), len(get.inputs))
 	}
-	if len(putContexts) != 2 || len(getContexts) != 1 || putContexts[0] != putContexts[1] || putContexts[1] != getContexts[0] {
+	if put.inputs[0] != put.inputs[1] {
+		t.Fatal("mutation rebuilt its retry input")
+	}
+	if len(put.contexts) != 2 || len(get.contexts) != 1 || put.contexts[0] != put.contexts[1] || put.contexts[1] != get.contexts[0] {
 		t.Fatal("mutation and readback did not share one propagation context")
+	}
+
+	var got Model
+	if diagnostics := state.Get(t.Context(), &got); diagnostics.HasError() {
+		t.Fatalf("read retained state: %v", diagnostics)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("retained state = %#v, want %#v", got, want)
+	}
+}
+
+func s3PhaseOptionsTimingOutOnSecondWait() s3PhaseOptions {
+	waits := 0
+	return s3PhaseOptions{
+		now:   time.Now,
+		delay: func(int) time.Duration { return 0 },
+		wait: func(context.Context, time.Duration) error {
+			waits++
+			if waits >= 2 {
+				return context.DeadlineExceeded
+			}
+			return nil
+		},
 	}
 }

--- a/coreweave/object_storage/resource_bucket_create_unit_test.go
+++ b/coreweave/object_storage/resource_bucket_create_unit_test.go
@@ -405,7 +405,9 @@ func TestReconcileBucketAfterCreate(t *testing.T) {
 			nil,
 		},
 		getTagOutputs: []*s3.GetBucketTaggingOutput{
+			{TagSet: expectedTags},
 			{TagSet: []s3types.Tag{{Key: aws.String("env"), Value: aws.String("stale")}}},
+			{TagSet: expectedTags},
 			{TagSet: expectedTags},
 		},
 	}
@@ -423,11 +425,11 @@ func TestReconcileBucketAfterCreate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("reconcileBucketAfterCreate() error = %v", err)
 	}
-	if client.headCalls != 4 || client.putTagCalls != 2 || client.getTagCalls != 2 {
-		t.Fatalf("calls: Head=%d PutTags=%d GetTags=%d, want 4, 2, 2", client.headCalls, client.putTagCalls, client.getTagCalls)
+	if client.headCalls != 4 || client.putTagCalls != 2 || client.getTagCalls != 4 {
+		t.Fatalf("calls: Head=%d PutTags=%d GetTags=%d, want 4, 2, 4", client.headCalls, client.putTagCalls, client.getTagCalls)
 	}
-	if waits != 5 {
-		t.Fatalf("backoff waits = %d, want 5", waits)
+	if waits != 7 {
+		t.Fatalf("backoff waits = %d, want 7", waits)
 	}
 }
 

--- a/coreweave/object_storage/resource_bucket_create_unit_test.go
+++ b/coreweave/object_storage/resource_bucket_create_unit_test.go
@@ -357,7 +357,7 @@ func TestCreateBucketSafely(t *testing.T) {
 			client,
 			"target",
 			"US-EAST-04A",
-			immediatePhaseOptions(&waits),
+			immediateS3PhaseOptions(&waits),
 		); err != nil {
 			t.Fatalf("createBucketSafelyWithOptions() error = %v", err)
 		}
@@ -389,17 +389,6 @@ func TestCreateBucketSafely(t *testing.T) {
 	})
 }
 
-func immediatePhaseOptions(waits *int) s3PhaseOptions {
-	return s3PhaseOptions{
-		now:   time.Now,
-		delay: func(int) time.Duration { return 0 },
-		wait: func(ctx context.Context, _ time.Duration) error {
-			*waits++
-			return ctx.Err()
-		},
-	}
-}
-
 func TestReconcileBucketAfterCreate(t *testing.T) {
 	t.Parallel()
 
@@ -429,7 +418,7 @@ func TestReconcileBucketAfterCreate(t *testing.T) {
 		"US-EAST-04A",
 		expectedTags,
 		true,
-		immediatePhaseOptions(&waits),
+		immediateS3PhaseOptions(&waits),
 	)
 	if err != nil {
 		t.Fatalf("reconcileBucketAfterCreate() error = %v", err)
@@ -457,7 +446,7 @@ func TestReconcileBucketAfterCreateDoesNotRetryUnrelated400(t *testing.T) {
 		"US-EAST-04A",
 		nil,
 		false,
-		immediatePhaseOptions(&waits),
+		immediateS3PhaseOptions(&waits),
 	)
 	if err == nil {
 		t.Fatal("reconcileBucketAfterCreate() error = nil, want permanent failure")
@@ -480,7 +469,7 @@ func TestDeleteBucketWithRetryHandlesLocationPropagation(t *testing.T) {
 		client,
 		"target",
 		"US-EAST-04A",
-		immediatePhaseOptions(&waits),
+		immediateS3PhaseOptions(&waits),
 	); err != nil {
 		t.Fatalf("deleteBucketWithRetry() error = %v", err)
 	}
@@ -626,7 +615,7 @@ func TestCreateBucketSafelyReconcilesHTTPAttemptTimeout(t *testing.T) {
 		client,
 		bucketName,
 		zone,
-		immediatePhaseOptions(&waits),
+		immediateS3PhaseOptions(&waits),
 	); err != nil {
 		t.Fatalf("createBucketSafelyWithOptions() error = %v", err)
 	}

--- a/coreweave/object_storage/resource_bucket_create_unit_test.go
+++ b/coreweave/object_storage/resource_bucket_create_unit_test.go
@@ -489,7 +489,7 @@ func TestDeleteBucketWithRetryHandlesLocationPropagation(t *testing.T) {
 	}
 }
 
-func TestIsPostCreateRetryableS3Error(t *testing.T) {
+func TestIsBucketPropagationRetryableS3Error(t *testing.T) {
 	t.Parallel()
 
 	tlsErr := &url.Error{
@@ -519,8 +519,8 @@ func TestIsPostCreateRetryableS3Error(t *testing.T) {
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			if got := isPostCreateRetryableS3Error(tt.err); got != tt.want {
-				t.Fatalf("isPostCreateRetryableS3Error() = %t, want %t", got, tt.want)
+			if got := isBucketPropagationRetryableS3Error(tt.err); got != tt.want {
+				t.Fatalf("isBucketPropagationRetryableS3Error() = %t, want %t", got, tt.want)
 			}
 		})
 	}

--- a/coreweave/object_storage/resource_bucket_inventory.go
+++ b/coreweave/object_storage/resource_bucket_inventory.go
@@ -67,7 +67,9 @@ func NewBucketInventoryResource() resource.Resource {
 
 // BucketInventoryResource is the resource implementation.
 type BucketInventoryResource struct {
-	client *coreweave.Client
+	client                   *coreweave.Client
+	s3ClientForConvergence   func(context.Context) (bucketInventoryConfigurationClient, error)
+	bucketPropagationOptions s3PhaseOptions
 }
 
 // BucketInventoryResourceModel maps resource schema data.
@@ -387,6 +389,13 @@ func waitForInventoryConfig(
 	return out, err
 }
 
+func (r *BucketInventoryResource) convergenceClient(ctx context.Context) (bucketInventoryConfigurationClient, error) {
+	if r.s3ClientForConvergence != nil {
+		return r.s3ClientForConvergence(ctx)
+	}
+	return r.client.S3Client(ctx, "")
+}
+
 func (r *BucketInventoryResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var data BucketInventoryResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
@@ -394,7 +403,7 @@ func (r *BucketInventoryResource) Create(ctx context.Context, req resource.Creat
 		return
 	}
 
-	s3c, err := r.client.S3Client(ctx, "")
+	s3c, err := r.convergenceClient(ctx)
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to create S3 client", err.Error())
 		return
@@ -425,7 +434,7 @@ func (r *BucketInventoryResource) Create(ctx context.Context, req resource.Creat
 	}
 	propagationCtx, cancel := bucketPropagationContext(ctx)
 	defer cancel()
-	if err := putBucketInventoryConfig(propagationCtx, s3c, data.Bucket.ValueString(), putInput, s3PhaseOptions{}); err != nil {
+	if err := putBucketInventoryConfig(propagationCtx, s3c, data.Bucket.ValueString(), putInput, r.bucketPropagationOptions); err != nil {
 		handleS3Error(err, &resp.Diagnostics, data.Bucket.ValueString())
 		return
 	}
@@ -439,7 +448,7 @@ func (r *BucketInventoryResource) Create(ctx context.Context, req resource.Creat
 
 	// Inventory configuration is eventually consistent, so poll the GET API
 	// until it reflects what we just wrote before reading it back into state.
-	result, err := waitForInventoryConfig(propagationCtx, s3c, data.Bucket.ValueString(), data.Name.ValueString(), *invConfig, s3PhaseOptions{})
+	result, err := waitForInventoryConfig(propagationCtx, s3c, data.Bucket.ValueString(), data.Name.ValueString(), *invConfig, r.bucketPropagationOptions)
 	if err != nil {
 		handleS3Error(err, &resp.Diagnostics, data.Bucket.ValueString())
 		return
@@ -564,7 +573,7 @@ func (r *BucketInventoryResource) Update(ctx context.Context, req resource.Updat
 		return
 	}
 
-	s3c, err := r.client.S3Client(ctx, "")
+	s3c, err := r.convergenceClient(ctx)
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to create S3 client", err.Error())
 		return
@@ -586,7 +595,7 @@ func (r *BucketInventoryResource) Update(ctx context.Context, req resource.Updat
 	}
 	propagationCtx, cancel := bucketPropagationContext(ctx)
 	defer cancel()
-	if err := putBucketInventoryConfig(propagationCtx, s3c, data.Bucket.ValueString(), putInput, s3PhaseOptions{}); err != nil {
+	if err := putBucketInventoryConfig(propagationCtx, s3c, data.Bucket.ValueString(), putInput, r.bucketPropagationOptions); err != nil {
 		handleS3Error(err, &resp.Diagnostics, data.Bucket.ValueString())
 		return
 	}
@@ -600,7 +609,7 @@ func (r *BucketInventoryResource) Update(ctx context.Context, req resource.Updat
 
 	// Inventory configuration is eventually consistent, so poll the GET API
 	// until it reflects the update before reading it back into state.
-	result, err := waitForInventoryConfig(propagationCtx, s3c, data.Bucket.ValueString(), data.Name.ValueString(), *invConfig, s3PhaseOptions{})
+	result, err := waitForInventoryConfig(propagationCtx, s3c, data.Bucket.ValueString(), data.Name.ValueString(), *invConfig, r.bucketPropagationOptions)
 	if err != nil {
 		handleS3Error(err, &resp.Diagnostics, data.Bucket.ValueString())
 		return

--- a/coreweave/object_storage/resource_bucket_inventory.go
+++ b/coreweave/object_storage/resource_bucket_inventory.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"slices"
 	"strings"
-	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
@@ -44,6 +43,11 @@ const (
 	// inventory configuration does not exist for the given bucket + id.
 	ErrNoSuchInventoryConfiguration string = "NoSuchInventoryConfiguration"
 )
+
+type bucketInventoryConfigurationClient interface {
+	PutBucketInventoryConfiguration(context.Context, *s3.PutBucketInventoryConfigurationInput, ...func(*s3.Options)) (*s3.PutBucketInventoryConfigurationOutput, error)
+	GetBucketInventoryConfiguration(context.Context, *s3.GetBucketInventoryConfigurationInput, ...func(*s3.Options)) (*s3.GetBucketInventoryConfigurationOutput, error)
+}
 
 // enumStrings converts an AWS SDK string-enum's Values() slice into the []string
 // form the OneOf validator expects, so the accepted values track the SDK enum
@@ -332,29 +336,54 @@ func eqInventoryConfiguration(a, b s3types.InventoryConfiguration) bool {
 	return slices.Equal(toSorted(a.OptionalFields), toSorted(b.OptionalFields))
 }
 
-func waitForInventoryConfig(parentCtx context.Context, client *s3.Client, bucket, id string, expected s3types.InventoryConfiguration) (*s3.GetBucketInventoryConfigurationOutput, error) {
+func putBucketInventoryConfig(
+	ctx context.Context,
+	client bucketInventoryConfigurationClient,
+	bucket string,
+	input *s3.PutBucketInventoryConfigurationInput,
+	options s3PhaseOptions,
+) error {
+	return runBucketMutationPhase(
+		ctx,
+		s3PhaseMetadata{phase: "bucket inventory configuration write", bucket: bucket},
+		options,
+		func(ctx context.Context) error {
+			_, err := client.PutBucketInventoryConfiguration(ctx, input)
+			return err
+		},
+	)
+}
+
+func waitForInventoryConfig(
+	ctx context.Context,
+	client bucketInventoryConfigurationClient,
+	bucket, id string,
+	expected s3types.InventoryConfiguration,
+	options s3PhaseOptions,
+) (*s3.GetBucketInventoryConfigurationOutput, error) {
+	input := &s3.GetBucketInventoryConfigurationInput{
+		Bucket: aws.String(bucket),
+		Id:     aws.String(id),
+	}
 	var out *s3.GetBucketInventoryConfigurationOutput
-	err := coreweave.PollUntil("bucket inventory configuration", parentCtx, 5*time.Second, 5*time.Minute, func(ctx context.Context) (bool, error) {
-		result, err := client.GetBucketInventoryConfiguration(ctx, &s3.GetBucketInventoryConfigurationInput{
-			Bucket: aws.String(bucket),
-			Id:     aws.String(id),
-		})
-		if err != nil {
-			out = nil
-			// A freshly-written config can 404 until it propagates; isTransientS3Error
-			// treats 404 (and 5xx/429/408) as retryable so we keep polling.
-			if isTransientS3Error(err) {
+	err := runBucketReadbackPhase(
+		ctx,
+		s3PhaseMetadata{phase: "bucket inventory configuration readback", bucket: bucket},
+		options,
+		func(ctx context.Context) (bool, error) {
+			result, err := client.GetBucketInventoryConfiguration(ctx, input)
+			if err != nil {
+				out = nil
+				return false, err
+			}
+			out = result
+
+			if result == nil || result.InventoryConfiguration == nil {
 				return false, nil
 			}
-			return false, err
-		}
-		out = result
-
-		if result.InventoryConfiguration == nil {
-			return false, nil
-		}
-		return eqInventoryConfiguration(expected, *result.InventoryConfiguration), nil
-	})
+			return eqInventoryConfiguration(expected, *result.InventoryConfiguration), nil
+		},
+	)
 	return out, err
 }
 
@@ -389,12 +418,14 @@ func (r *BucketInventoryResource) Create(ctx context.Context, req resource.Creat
 		"id":        data.Name.ValueString(),
 	})
 
-	_, err = s3c.PutBucketInventoryConfiguration(ctx, &s3.PutBucketInventoryConfigurationInput{
+	putInput := &s3.PutBucketInventoryConfigurationInput{
 		Bucket:                 aws.String(data.Bucket.ValueString()),
 		Id:                     aws.String(data.Name.ValueString()),
 		InventoryConfiguration: invConfig,
-	})
-	if err != nil {
+	}
+	propagationCtx, cancel := bucketPropagationContext(ctx)
+	defer cancel()
+	if err := putBucketInventoryConfig(propagationCtx, s3c, data.Bucket.ValueString(), putInput, s3PhaseOptions{}); err != nil {
 		handleS3Error(err, &resp.Diagnostics, data.Bucket.ValueString())
 		return
 	}
@@ -408,7 +439,7 @@ func (r *BucketInventoryResource) Create(ctx context.Context, req resource.Creat
 
 	// Inventory configuration is eventually consistent, so poll the GET API
 	// until it reflects what we just wrote before reading it back into state.
-	result, err := waitForInventoryConfig(ctx, s3c, data.Bucket.ValueString(), data.Name.ValueString(), *invConfig)
+	result, err := waitForInventoryConfig(propagationCtx, s3c, data.Bucket.ValueString(), data.Name.ValueString(), *invConfig, s3PhaseOptions{})
 	if err != nil {
 		handleS3Error(err, &resp.Diagnostics, data.Bucket.ValueString())
 		return
@@ -548,12 +579,14 @@ func (r *BucketInventoryResource) Update(ctx context.Context, req resource.Updat
 
 	// PutBucketInventoryConfiguration is an upsert, so update is the same write
 	// path as create, keyed by bucket + id.
-	_, err = s3c.PutBucketInventoryConfiguration(ctx, &s3.PutBucketInventoryConfigurationInput{
+	putInput := &s3.PutBucketInventoryConfigurationInput{
 		Bucket:                 aws.String(data.Bucket.ValueString()),
 		Id:                     aws.String(data.Name.ValueString()),
 		InventoryConfiguration: invConfig,
-	})
-	if err != nil {
+	}
+	propagationCtx, cancel := bucketPropagationContext(ctx)
+	defer cancel()
+	if err := putBucketInventoryConfig(propagationCtx, s3c, data.Bucket.ValueString(), putInput, s3PhaseOptions{}); err != nil {
 		handleS3Error(err, &resp.Diagnostics, data.Bucket.ValueString())
 		return
 	}
@@ -567,7 +600,7 @@ func (r *BucketInventoryResource) Update(ctx context.Context, req resource.Updat
 
 	// Inventory configuration is eventually consistent, so poll the GET API
 	// until it reflects the update before reading it back into state.
-	result, err := waitForInventoryConfig(ctx, s3c, data.Bucket.ValueString(), data.Name.ValueString(), *invConfig)
+	result, err := waitForInventoryConfig(propagationCtx, s3c, data.Bucket.ValueString(), data.Name.ValueString(), *invConfig, s3PhaseOptions{})
 	if err != nil {
 		handleS3Error(err, &resp.Diagnostics, data.Bucket.ValueString())
 		return

--- a/coreweave/object_storage/resource_bucket_inventory.go
+++ b/coreweave/object_storage/resource_bucket_inventory.go
@@ -44,7 +44,7 @@ const (
 	ErrNoSuchInventoryConfiguration string = "NoSuchInventoryConfiguration"
 )
 
-type bucketInventoryConfigurationClient interface {
+type bucketInventoryConfigurationAPI interface {
 	PutBucketInventoryConfiguration(context.Context, *s3.PutBucketInventoryConfigurationInput, ...func(*s3.Options)) (*s3.PutBucketInventoryConfigurationOutput, error)
 	GetBucketInventoryConfiguration(context.Context, *s3.GetBucketInventoryConfigurationInput, ...func(*s3.Options)) (*s3.GetBucketInventoryConfigurationOutput, error)
 }
@@ -68,7 +68,7 @@ func NewBucketInventoryResource() resource.Resource {
 // BucketInventoryResource is the resource implementation.
 type BucketInventoryResource struct {
 	client                   *coreweave.Client
-	s3ClientForConvergence   func(context.Context) (bucketInventoryConfigurationClient, error)
+	s3ClientForConvergence   func(context.Context) (bucketInventoryConfigurationAPI, error)
 	bucketPropagationOptions s3PhaseOptions
 }
 
@@ -340,14 +340,14 @@ func eqInventoryConfiguration(a, b s3types.InventoryConfiguration) bool {
 
 func putBucketInventoryConfig(
 	ctx context.Context,
-	client bucketInventoryConfigurationClient,
+	client bucketInventoryConfigurationAPI,
 	bucket string,
 	input *s3.PutBucketInventoryConfigurationInput,
 	options s3PhaseOptions,
 ) error {
 	return runBucketMutationPhase(
 		ctx,
-		s3PhaseMetadata{phase: "bucket inventory configuration write", bucket: bucket},
+		s3PhaseMetadata{phase: "bucket inventory configuration application", bucket: bucket},
 		options,
 		func(ctx context.Context) error {
 			_, err := client.PutBucketInventoryConfiguration(ctx, input)
@@ -358,7 +358,7 @@ func putBucketInventoryConfig(
 
 func waitForInventoryConfig(
 	ctx context.Context,
-	client bucketInventoryConfigurationClient,
+	client bucketInventoryConfigurationAPI,
 	bucket, id string,
 	expected s3types.InventoryConfiguration,
 	options s3PhaseOptions,
@@ -389,7 +389,7 @@ func waitForInventoryConfig(
 	return out, err
 }
 
-func (r *BucketInventoryResource) convergenceClient(ctx context.Context) (bucketInventoryConfigurationClient, error) {
+func (r *BucketInventoryResource) convergenceClient(ctx context.Context) (bucketInventoryConfigurationAPI, error) {
 	if r.s3ClientForConvergence != nil {
 		return r.s3ClientForConvergence(ctx)
 	}

--- a/coreweave/object_storage/resource_bucket_lifecycle_configuration.go
+++ b/coreweave/object_storage/resource_bucket_lifecycle_configuration.go
@@ -41,7 +41,7 @@ const (
 	ErrNoSuchLifecycleConfiguration string = "NoSuchLifecycleConfiguration"
 )
 
-type bucketLifecycleConfigurationClient interface {
+type bucketLifecycleConfigurationAPI interface {
 	PutBucketLifecycleConfiguration(context.Context, *s3.PutBucketLifecycleConfigurationInput, ...func(*s3.Options)) (*s3.PutBucketLifecycleConfigurationOutput, error)
 	GetBucketLifecycleConfiguration(context.Context, *s3.GetBucketLifecycleConfigurationInput, ...func(*s3.Options)) (*s3.GetBucketLifecycleConfigurationOutput, error)
 }
@@ -54,7 +54,7 @@ func NewBucketLifecycleResource() resource.Resource {
 // BucketLifecycleResource is the resource implementation.
 type BucketLifecycleResource struct {
 	client                   *coreweave.Client
-	s3ClientForConvergence   func(context.Context) (bucketLifecycleConfigurationClient, error)
+	s3ClientForConvergence   func(context.Context) (bucketLifecycleConfigurationAPI, error)
 	bucketPropagationOptions s3PhaseOptions
 }
 
@@ -580,14 +580,14 @@ func eqLifecycleRule(a, b s3types.LifecycleRule) bool { //nolint:gocyclo
 
 func putBucketLifecycleConfig(
 	ctx context.Context,
-	client bucketLifecycleConfigurationClient,
+	client bucketLifecycleConfigurationAPI,
 	bucket string,
 	input *s3.PutBucketLifecycleConfigurationInput,
 	options s3PhaseOptions,
 ) error {
 	return runBucketMutationPhase(
 		ctx,
-		s3PhaseMetadata{phase: "bucket lifecycle configuration write", bucket: bucket},
+		s3PhaseMetadata{phase: "bucket lifecycle configuration application", bucket: bucket},
 		options,
 		func(ctx context.Context) error {
 			_, err := client.PutBucketLifecycleConfiguration(ctx, input)
@@ -598,7 +598,7 @@ func putBucketLifecycleConfig(
 
 func waitForLifecycleConfig(
 	ctx context.Context,
-	client bucketLifecycleConfigurationClient,
+	client bucketLifecycleConfigurationAPI,
 	bucket string,
 	expected s3types.BucketLifecycleConfiguration,
 	options s3PhaseOptions,
@@ -631,7 +631,7 @@ func waitForLifecycleConfig(
 	return out, err
 }
 
-func (r *BucketLifecycleResource) convergenceClient(ctx context.Context) (bucketLifecycleConfigurationClient, error) {
+func (r *BucketLifecycleResource) convergenceClient(ctx context.Context) (bucketLifecycleConfigurationAPI, error) {
 	if r.s3ClientForConvergence != nil {
 		return r.s3ClientForConvergence(ctx)
 	}

--- a/coreweave/object_storage/resource_bucket_lifecycle_configuration.go
+++ b/coreweave/object_storage/resource_bucket_lifecycle_configuration.go
@@ -41,6 +41,11 @@ const (
 	ErrNoSuchLifecycleConfiguration string = "NoSuchLifecycleConfiguration"
 )
 
+type bucketLifecycleConfigurationClient interface {
+	PutBucketLifecycleConfiguration(context.Context, *s3.PutBucketLifecycleConfigurationInput, ...func(*s3.Options)) (*s3.PutBucketLifecycleConfigurationOutput, error)
+	GetBucketLifecycleConfiguration(context.Context, *s3.GetBucketLifecycleConfigurationInput, ...func(*s3.Options)) (*s3.GetBucketLifecycleConfigurationOutput, error)
+}
+
 // NewBucketLifecycleResource returns a new resource instance.
 func NewBucketLifecycleResource() resource.Resource {
 	return &BucketLifecycleResource{}
@@ -571,26 +576,56 @@ func eqLifecycleRule(a, b s3types.LifecycleRule) bool { //nolint:gocyclo
 	return true
 }
 
-func waitForLifecycleConfig(parentCtx context.Context, client *s3.Client, bucket string, expected s3types.BucketLifecycleConfiguration) (*s3.GetBucketLifecycleConfigurationOutput, error) {
+func putBucketLifecycleConfig(
+	ctx context.Context,
+	client bucketLifecycleConfigurationClient,
+	bucket string,
+	input *s3.PutBucketLifecycleConfigurationInput,
+	options s3PhaseOptions,
+) error {
+	return runBucketMutationPhase(
+		ctx,
+		s3PhaseMetadata{phase: "bucket lifecycle configuration write", bucket: bucket},
+		options,
+		func(ctx context.Context) error {
+			_, err := client.PutBucketLifecycleConfiguration(ctx, input)
+			return err
+		},
+	)
+}
+
+func waitForLifecycleConfig(
+	ctx context.Context,
+	client bucketLifecycleConfigurationClient,
+	bucket string,
+	expected s3types.BucketLifecycleConfiguration,
+	options s3PhaseOptions,
+) (*s3.GetBucketLifecycleConfigurationOutput, error) {
 	// make a sorted copy of expected rules
 	exp := slices.SortedFunc(slices.Values(expected.Rules), cmpLifecycleRule)
+	input := &s3.GetBucketLifecycleConfigurationInput{Bucket: aws.String(bucket)}
 
 	var out *s3.GetBucketLifecycleConfigurationOutput
-	err := coreweave.PollUntil("bucket lifecycle configuration", parentCtx, 5*time.Second, 5*time.Minute, func(ctx context.Context) (bool, error) {
-		result, err := client.GetBucketLifecycleConfiguration(ctx, &s3.GetBucketLifecycleConfigurationInput{Bucket: aws.String(bucket)})
-		if err != nil {
-			out = nil
-			if isTransientS3Error(err) {
+	err := runBucketReadbackPhase(
+		ctx,
+		s3PhaseMetadata{phase: "bucket lifecycle configuration readback", bucket: bucket},
+		options,
+		func(ctx context.Context) (bool, error) {
+			result, err := client.GetBucketLifecycleConfiguration(ctx, input)
+			if err != nil {
+				out = nil
+				return false, err
+			}
+			out = result
+			if result == nil {
 				return false, nil
 			}
-			return false, err
-		}
-		out = result
 
-		// Make sorted a copy of the slice to sort for comparison, to avoid mutating the returned slice by reference.
-		rules := slices.SortedFunc(slices.Values(result.Rules), cmpLifecycleRule)
-		return slices.EqualFunc(exp, rules, eqLifecycleRule), nil
-	})
+			// Make sorted a copy of the slice to sort for comparison, to avoid mutating the returned slice by reference.
+			rules := slices.SortedFunc(slices.Values(result.Rules), cmpLifecycleRule)
+			return slices.EqualFunc(exp, rules, eqLifecycleRule), nil
+		},
+	)
 	return out, err
 }
 
@@ -617,11 +652,13 @@ func (r *BucketLifecycleResource) Create(ctx context.Context, req resource.Creat
 	lifecycleConfig := &s3types.BucketLifecycleConfiguration{
 		Rules: rules,
 	}
-	_, err = s3c.PutBucketLifecycleConfiguration(ctx, &s3.PutBucketLifecycleConfigurationInput{
+	putInput := &s3.PutBucketLifecycleConfigurationInput{
 		Bucket:                 aws.String(data.Bucket.ValueString()),
 		LifecycleConfiguration: lifecycleConfig,
-	})
-	if err != nil {
+	}
+	propagationCtx, cancel := bucketPropagationContext(ctx)
+	defer cancel()
+	if err := putBucketLifecycleConfig(propagationCtx, s3c, data.Bucket.ValueString(), putInput, s3PhaseOptions{}); err != nil {
 		handleS3Error(err, &resp.Diagnostics, data.Bucket.ValueString())
 		return
 	}
@@ -633,7 +670,7 @@ func (r *BucketLifecycleResource) Create(ctx context.Context, req resource.Creat
 	}
 
 	// wait for lifecycle config  to be read back from s3 API since it is not guaranteed to propagate immediately
-	if result, err := waitForLifecycleConfig(ctx, s3c, data.Bucket.ValueString(), *lifecycleConfig); err != nil {
+	if result, err := waitForLifecycleConfig(propagationCtx, s3c, data.Bucket.ValueString(), *lifecycleConfig, s3PhaseOptions{}); err != nil {
 		handleS3Error(err, &resp.Diagnostics, data.Bucket.ValueString())
 		return
 	} else {
@@ -820,11 +857,13 @@ func (r *BucketLifecycleResource) Update(ctx context.Context, req resource.Updat
 	lifecycleConfig := &s3types.BucketLifecycleConfiguration{
 		Rules: rules,
 	}
-	_, err = s3c.PutBucketLifecycleConfiguration(ctx, &s3.PutBucketLifecycleConfigurationInput{
+	putInput := &s3.PutBucketLifecycleConfigurationInput{
 		Bucket:                 aws.String(data.Bucket.ValueString()),
 		LifecycleConfiguration: lifecycleConfig,
-	})
-	if err != nil {
+	}
+	propagationCtx, cancel := bucketPropagationContext(ctx)
+	defer cancel()
+	if err := putBucketLifecycleConfig(propagationCtx, s3c, data.Bucket.ValueString(), putInput, s3PhaseOptions{}); err != nil {
 		handleS3Error(err, &resp.Diagnostics, data.Bucket.ValueString())
 		return
 	}
@@ -836,7 +875,7 @@ func (r *BucketLifecycleResource) Update(ctx context.Context, req resource.Updat
 	}
 
 	// wait for lifecycle config  to be read back from s3 API since it is not guaranteed to propagate immediately
-	if result, err := waitForLifecycleConfig(ctx, s3c, data.Bucket.ValueString(), *lifecycleConfig); err != nil {
+	if result, err := waitForLifecycleConfig(propagationCtx, s3c, data.Bucket.ValueString(), *lifecycleConfig, s3PhaseOptions{}); err != nil {
 		handleS3Error(err, &resp.Diagnostics, data.Bucket.ValueString())
 		return
 	} else {

--- a/coreweave/object_storage/resource_bucket_lifecycle_configuration.go
+++ b/coreweave/object_storage/resource_bucket_lifecycle_configuration.go
@@ -53,7 +53,9 @@ func NewBucketLifecycleResource() resource.Resource {
 
 // BucketLifecycleResource is the resource implementation.
 type BucketLifecycleResource struct {
-	client *coreweave.Client
+	client                   *coreweave.Client
+	s3ClientForConvergence   func(context.Context) (bucketLifecycleConfigurationClient, error)
+	bucketPropagationOptions s3PhaseOptions
 }
 
 // BucketLifecycleResourceModel maps resource schema data.
@@ -629,6 +631,13 @@ func waitForLifecycleConfig(
 	return out, err
 }
 
+func (r *BucketLifecycleResource) convergenceClient(ctx context.Context) (bucketLifecycleConfigurationClient, error) {
+	if r.s3ClientForConvergence != nil {
+		return r.s3ClientForConvergence(ctx)
+	}
+	return r.client.S3Client(ctx, "")
+}
+
 func (r *BucketLifecycleResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var data BucketLifecycleResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
@@ -636,7 +645,7 @@ func (r *BucketLifecycleResource) Create(ctx context.Context, req resource.Creat
 		return
 	}
 
-	s3c, err := r.client.S3Client(ctx, "")
+	s3c, err := r.convergenceClient(ctx)
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to create S3 client", err.Error())
 		return
@@ -658,7 +667,7 @@ func (r *BucketLifecycleResource) Create(ctx context.Context, req resource.Creat
 	}
 	propagationCtx, cancel := bucketPropagationContext(ctx)
 	defer cancel()
-	if err := putBucketLifecycleConfig(propagationCtx, s3c, data.Bucket.ValueString(), putInput, s3PhaseOptions{}); err != nil {
+	if err := putBucketLifecycleConfig(propagationCtx, s3c, data.Bucket.ValueString(), putInput, r.bucketPropagationOptions); err != nil {
 		handleS3Error(err, &resp.Diagnostics, data.Bucket.ValueString())
 		return
 	}
@@ -670,7 +679,7 @@ func (r *BucketLifecycleResource) Create(ctx context.Context, req resource.Creat
 	}
 
 	// wait for lifecycle config  to be read back from s3 API since it is not guaranteed to propagate immediately
-	if result, err := waitForLifecycleConfig(propagationCtx, s3c, data.Bucket.ValueString(), *lifecycleConfig, s3PhaseOptions{}); err != nil {
+	if result, err := waitForLifecycleConfig(propagationCtx, s3c, data.Bucket.ValueString(), *lifecycleConfig, r.bucketPropagationOptions); err != nil {
 		handleS3Error(err, &resp.Diagnostics, data.Bucket.ValueString())
 		return
 	} else {
@@ -847,7 +856,7 @@ func (r *BucketLifecycleResource) Update(ctx context.Context, req resource.Updat
 		return
 	}
 
-	s3c, err := r.client.S3Client(ctx, "")
+	s3c, err := r.convergenceClient(ctx)
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to create S3 client", err.Error())
 		return
@@ -863,7 +872,7 @@ func (r *BucketLifecycleResource) Update(ctx context.Context, req resource.Updat
 	}
 	propagationCtx, cancel := bucketPropagationContext(ctx)
 	defer cancel()
-	if err := putBucketLifecycleConfig(propagationCtx, s3c, data.Bucket.ValueString(), putInput, s3PhaseOptions{}); err != nil {
+	if err := putBucketLifecycleConfig(propagationCtx, s3c, data.Bucket.ValueString(), putInput, r.bucketPropagationOptions); err != nil {
 		handleS3Error(err, &resp.Diagnostics, data.Bucket.ValueString())
 		return
 	}
@@ -875,7 +884,7 @@ func (r *BucketLifecycleResource) Update(ctx context.Context, req resource.Updat
 	}
 
 	// wait for lifecycle config  to be read back from s3 API since it is not guaranteed to propagate immediately
-	if result, err := waitForLifecycleConfig(propagationCtx, s3c, data.Bucket.ValueString(), *lifecycleConfig, s3PhaseOptions{}); err != nil {
+	if result, err := waitForLifecycleConfig(propagationCtx, s3c, data.Bucket.ValueString(), *lifecycleConfig, r.bucketPropagationOptions); err != nil {
 		handleS3Error(err, &resp.Diagnostics, data.Bucket.ValueString())
 		return
 	} else {

--- a/coreweave/object_storage/resource_bucket_lifecycle_inventory_convergence_unit_test.go
+++ b/coreweave/object_storage/resource_bucket_lifecycle_inventory_convergence_unit_test.go
@@ -11,19 +11,22 @@ import (
 )
 
 type scriptedLifecycleConfigurationClient struct {
-	putErrors  []error
-	putInputs  []*s3.PutBucketLifecycleConfigurationInput
-	getErrors  []error
-	getOutputs []*s3.GetBucketLifecycleConfigurationOutput
-	getInputs  []*s3.GetBucketLifecycleConfigurationInput
+	putErrors   []error
+	putInputs   []*s3.PutBucketLifecycleConfigurationInput
+	getErrors   []error
+	getOutputs  []*s3.GetBucketLifecycleConfigurationOutput
+	getInputs   []*s3.GetBucketLifecycleConfigurationInput
+	putContexts []context.Context
+	getContexts []context.Context
 }
 
 func (c *scriptedLifecycleConfigurationClient) PutBucketLifecycleConfiguration(
-	_ context.Context,
+	ctx context.Context,
 	input *s3.PutBucketLifecycleConfigurationInput,
 	_ ...func(*s3.Options),
 ) (*s3.PutBucketLifecycleConfigurationOutput, error) {
 	c.putInputs = append(c.putInputs, input)
+	c.putContexts = append(c.putContexts, ctx)
 	index := len(c.putInputs) - 1
 	if index < len(c.putErrors) && c.putErrors[index] != nil {
 		return nil, c.putErrors[index]
@@ -32,11 +35,12 @@ func (c *scriptedLifecycleConfigurationClient) PutBucketLifecycleConfiguration(
 }
 
 func (c *scriptedLifecycleConfigurationClient) GetBucketLifecycleConfiguration(
-	_ context.Context,
+	ctx context.Context,
 	input *s3.GetBucketLifecycleConfigurationInput,
 	_ ...func(*s3.Options),
 ) (*s3.GetBucketLifecycleConfigurationOutput, error) {
 	c.getInputs = append(c.getInputs, input)
+	c.getContexts = append(c.getContexts, ctx)
 	index := len(c.getInputs) - 1
 	if index < len(c.getErrors) && c.getErrors[index] != nil {
 		return nil, c.getErrors[index]
@@ -48,19 +52,22 @@ func (c *scriptedLifecycleConfigurationClient) GetBucketLifecycleConfiguration(
 }
 
 type scriptedInventoryConfigurationClient struct {
-	putErrors  []error
-	putInputs  []*s3.PutBucketInventoryConfigurationInput
-	getErrors  []error
-	getOutputs []*s3.GetBucketInventoryConfigurationOutput
-	getInputs  []*s3.GetBucketInventoryConfigurationInput
+	putErrors   []error
+	putInputs   []*s3.PutBucketInventoryConfigurationInput
+	getErrors   []error
+	getOutputs  []*s3.GetBucketInventoryConfigurationOutput
+	getInputs   []*s3.GetBucketInventoryConfigurationInput
+	putContexts []context.Context
+	getContexts []context.Context
 }
 
 func (c *scriptedInventoryConfigurationClient) PutBucketInventoryConfiguration(
-	_ context.Context,
+	ctx context.Context,
 	input *s3.PutBucketInventoryConfigurationInput,
 	_ ...func(*s3.Options),
 ) (*s3.PutBucketInventoryConfigurationOutput, error) {
 	c.putInputs = append(c.putInputs, input)
+	c.putContexts = append(c.putContexts, ctx)
 	index := len(c.putInputs) - 1
 	if index < len(c.putErrors) && c.putErrors[index] != nil {
 		return nil, c.putErrors[index]
@@ -69,11 +76,12 @@ func (c *scriptedInventoryConfigurationClient) PutBucketInventoryConfiguration(
 }
 
 func (c *scriptedInventoryConfigurationClient) GetBucketInventoryConfiguration(
-	_ context.Context,
+	ctx context.Context,
 	input *s3.GetBucketInventoryConfigurationInput,
 	_ ...func(*s3.Options),
 ) (*s3.GetBucketInventoryConfigurationOutput, error) {
 	c.getInputs = append(c.getInputs, input)
+	c.getContexts = append(c.getContexts, ctx)
 	index := len(c.getInputs) - 1
 	if index < len(c.getErrors) && c.getErrors[index] != nil {
 		return nil, c.getErrors[index]
@@ -101,10 +109,11 @@ func TestBucketLifecycleConfigConvergenceRetriesInvalidRegion(t *testing.T) {
 		getOutputs: []*s3.GetBucketLifecycleConfigurationOutput{
 			nil,
 			{Rules: expected.Rules},
+			{Rules: expected.Rules},
 		},
 	}
 	waits := 0
-	options := immediatePhaseOptions(&waits)
+	options := immediateS3PhaseOptions(&waits)
 
 	if err := putBucketLifecycleConfig(t.Context(), client, "source-bucket", putInput, options); err != nil {
 		t.Fatalf("putBucketLifecycleConfig() error = %v", err)
@@ -119,11 +128,11 @@ func TestBucketLifecycleConfigConvergenceRetriesInvalidRegion(t *testing.T) {
 	if len(client.putInputs) != 2 || client.putInputs[0] != putInput || client.putInputs[1] != putInput {
 		t.Fatalf("Put inputs = %#v, want the same input pointer on both attempts", client.putInputs)
 	}
-	if len(client.getInputs) != 2 || client.getInputs[0] != client.getInputs[1] {
-		t.Fatalf("Get inputs = %#v, want the same input pointer on both attempts", client.getInputs)
+	if len(client.getInputs) != 3 || client.getInputs[0] != client.getInputs[1] || client.getInputs[1] != client.getInputs[2] {
+		t.Fatalf("Get inputs = %#v, want the same input pointer on all attempts", client.getInputs)
 	}
-	if waits != 2 {
-		t.Fatalf("backoff waits = %d, want 2", waits)
+	if waits != 3 {
+		t.Fatalf("backoff waits = %d, want 3", waits)
 	}
 }
 
@@ -146,10 +155,11 @@ func TestBucketInventoryConfigConvergenceRetriesInvalidRegion(t *testing.T) {
 		getOutputs: []*s3.GetBucketInventoryConfigurationOutput{
 			nil,
 			{InventoryConfiguration: &expected},
+			{InventoryConfiguration: &expected},
 		},
 	}
 	waits := 0
-	options := immediatePhaseOptions(&waits)
+	options := immediateS3PhaseOptions(&waits)
 
 	if err := putBucketInventoryConfig(t.Context(), client, "source-bucket", putInput, options); err != nil {
 		t.Fatalf("putBucketInventoryConfig() error = %v", err)
@@ -164,11 +174,11 @@ func TestBucketInventoryConfigConvergenceRetriesInvalidRegion(t *testing.T) {
 	if len(client.putInputs) != 2 || client.putInputs[0] != putInput || client.putInputs[1] != putInput {
 		t.Fatalf("Put inputs = %#v, want the same input pointer on both attempts", client.putInputs)
 	}
-	if len(client.getInputs) != 2 || client.getInputs[0] != client.getInputs[1] {
-		t.Fatalf("Get inputs = %#v, want the same input pointer on both attempts", client.getInputs)
+	if len(client.getInputs) != 3 || client.getInputs[0] != client.getInputs[1] || client.getInputs[1] != client.getInputs[2] {
+		t.Fatalf("Get inputs = %#v, want the same input pointer on all attempts", client.getInputs)
 	}
-	if waits != 2 {
-		t.Fatalf("backoff waits = %d, want 2", waits)
+	if waits != 3 {
+		t.Fatalf("backoff waits = %d, want 3", waits)
 	}
 }
 
@@ -187,7 +197,7 @@ func TestBucketConfigurationConvergenceDoesNotRetryPermanentErrors(t *testing.T)
 			client,
 			"invalid",
 			&s3.PutBucketLifecycleConfigurationInput{Bucket: aws.String("invalid")},
-			immediatePhaseOptions(&waits),
+			immediateS3PhaseOptions(&waits),
 		)
 		if err == nil {
 			t.Fatal("putBucketLifecycleConfig() error = nil, want permanent failure")
@@ -210,7 +220,7 @@ func TestBucketConfigurationConvergenceDoesNotRetryPermanentErrors(t *testing.T)
 			"source-bucket",
 			"daily",
 			s3types.InventoryConfiguration{},
-			immediatePhaseOptions(&waits),
+			immediateS3PhaseOptions(&waits),
 		)
 		if err == nil {
 			t.Fatal("waitForInventoryConfig() error = nil, want permanent failure")

--- a/coreweave/object_storage/resource_bucket_lifecycle_inventory_convergence_unit_test.go
+++ b/coreweave/object_storage/resource_bucket_lifecycle_inventory_convergence_unit_test.go
@@ -11,13 +11,8 @@ import (
 )
 
 type scriptedLifecycleConfigurationClient struct {
-	putErrors   []error
-	putInputs   []*s3.PutBucketLifecycleConfigurationInput
-	getErrors   []error
-	getOutputs  []*s3.GetBucketLifecycleConfigurationOutput
-	getInputs   []*s3.GetBucketLifecycleConfigurationInput
-	putContexts []context.Context
-	getContexts []context.Context
+	put scriptedS3Call[s3.PutBucketLifecycleConfigurationInput, s3.PutBucketLifecycleConfigurationOutput]
+	get scriptedS3Call[s3.GetBucketLifecycleConfigurationInput, s3.GetBucketLifecycleConfigurationOutput]
 }
 
 func (c *scriptedLifecycleConfigurationClient) PutBucketLifecycleConfiguration(
@@ -25,13 +20,7 @@ func (c *scriptedLifecycleConfigurationClient) PutBucketLifecycleConfiguration(
 	input *s3.PutBucketLifecycleConfigurationInput,
 	_ ...func(*s3.Options),
 ) (*s3.PutBucketLifecycleConfigurationOutput, error) {
-	c.putInputs = append(c.putInputs, input)
-	c.putContexts = append(c.putContexts, ctx)
-	index := len(c.putInputs) - 1
-	if index < len(c.putErrors) && c.putErrors[index] != nil {
-		return nil, c.putErrors[index]
-	}
-	return &s3.PutBucketLifecycleConfigurationOutput{}, nil
+	return c.put.call(ctx, input)
 }
 
 func (c *scriptedLifecycleConfigurationClient) GetBucketLifecycleConfiguration(
@@ -39,26 +28,12 @@ func (c *scriptedLifecycleConfigurationClient) GetBucketLifecycleConfiguration(
 	input *s3.GetBucketLifecycleConfigurationInput,
 	_ ...func(*s3.Options),
 ) (*s3.GetBucketLifecycleConfigurationOutput, error) {
-	c.getInputs = append(c.getInputs, input)
-	c.getContexts = append(c.getContexts, ctx)
-	index := len(c.getInputs) - 1
-	if index < len(c.getErrors) && c.getErrors[index] != nil {
-		return nil, c.getErrors[index]
-	}
-	if index < len(c.getOutputs) {
-		return c.getOutputs[index], nil
-	}
-	return &s3.GetBucketLifecycleConfigurationOutput{}, nil
+	return c.get.call(ctx, input)
 }
 
 type scriptedInventoryConfigurationClient struct {
-	putErrors   []error
-	putInputs   []*s3.PutBucketInventoryConfigurationInput
-	getErrors   []error
-	getOutputs  []*s3.GetBucketInventoryConfigurationOutput
-	getInputs   []*s3.GetBucketInventoryConfigurationInput
-	putContexts []context.Context
-	getContexts []context.Context
+	put scriptedS3Call[s3.PutBucketInventoryConfigurationInput, s3.PutBucketInventoryConfigurationOutput]
+	get scriptedS3Call[s3.GetBucketInventoryConfigurationInput, s3.GetBucketInventoryConfigurationOutput]
 }
 
 func (c *scriptedInventoryConfigurationClient) PutBucketInventoryConfiguration(
@@ -66,13 +41,7 @@ func (c *scriptedInventoryConfigurationClient) PutBucketInventoryConfiguration(
 	input *s3.PutBucketInventoryConfigurationInput,
 	_ ...func(*s3.Options),
 ) (*s3.PutBucketInventoryConfigurationOutput, error) {
-	c.putInputs = append(c.putInputs, input)
-	c.putContexts = append(c.putContexts, ctx)
-	index := len(c.putInputs) - 1
-	if index < len(c.putErrors) && c.putErrors[index] != nil {
-		return nil, c.putErrors[index]
-	}
-	return &s3.PutBucketInventoryConfigurationOutput{}, nil
+	return c.put.call(ctx, input)
 }
 
 func (c *scriptedInventoryConfigurationClient) GetBucketInventoryConfiguration(
@@ -80,16 +49,7 @@ func (c *scriptedInventoryConfigurationClient) GetBucketInventoryConfiguration(
 	input *s3.GetBucketInventoryConfigurationInput,
 	_ ...func(*s3.Options),
 ) (*s3.GetBucketInventoryConfigurationOutput, error) {
-	c.getInputs = append(c.getInputs, input)
-	c.getContexts = append(c.getContexts, ctx)
-	index := len(c.getInputs) - 1
-	if index < len(c.getErrors) && c.getErrors[index] != nil {
-		return nil, c.getErrors[index]
-	}
-	if index < len(c.getOutputs) {
-		return c.getOutputs[index], nil
-	}
-	return &s3.GetBucketInventoryConfigurationOutput{}, nil
+	return c.get.call(ctx, input)
 }
 
 func TestBucketLifecycleConfigConvergenceRetriesInvalidRegion(t *testing.T) {
@@ -103,14 +63,13 @@ func TestBucketLifecycleConfigConvergenceRetriesInvalidRegion(t *testing.T) {
 		Bucket:                 aws.String("source-bucket"),
 		LifecycleConfiguration: &expected,
 	}
-	client := &scriptedLifecycleConfigurationClient{
-		putErrors: []error{&smithy.GenericAPIError{Code: errInvalidRegion}, nil},
-		getErrors: []error{&smithy.GenericAPIError{Code: errInvalidRegion}, nil},
-		getOutputs: []*s3.GetBucketLifecycleConfigurationOutput{
-			nil,
-			{Rules: expected.Rules},
-			{Rules: expected.Rules},
-		},
+	client := &scriptedLifecycleConfigurationClient{}
+	client.put.errors = []error{&smithy.GenericAPIError{Code: errInvalidRegion}, nil}
+	client.get.errors = []error{&smithy.GenericAPIError{Code: errInvalidRegion}, nil}
+	client.get.outputs = []*s3.GetBucketLifecycleConfigurationOutput{
+		nil,
+		{Rules: expected.Rules},
+		{Rules: expected.Rules},
 	}
 	waits := 0
 	options := immediateS3PhaseOptions(&waits)
@@ -125,11 +84,11 @@ func TestBucketLifecycleConfigConvergenceRetriesInvalidRegion(t *testing.T) {
 	if result == nil || len(result.Rules) != 1 {
 		t.Fatalf("waitForLifecycleConfig() result = %#v, want expected rule", result)
 	}
-	if len(client.putInputs) != 2 || client.putInputs[0] != putInput || client.putInputs[1] != putInput {
-		t.Fatalf("Put inputs = %#v, want the same input pointer on both attempts", client.putInputs)
+	if len(client.put.inputs) != 2 || client.put.inputs[0] != putInput || client.put.inputs[1] != putInput {
+		t.Fatalf("Put inputs = %#v, want the same input pointer on both attempts", client.put.inputs)
 	}
-	if len(client.getInputs) != 3 || client.getInputs[0] != client.getInputs[1] || client.getInputs[1] != client.getInputs[2] {
-		t.Fatalf("Get inputs = %#v, want the same input pointer on all attempts", client.getInputs)
+	if len(client.get.inputs) != 3 || client.get.inputs[0] != client.get.inputs[1] || client.get.inputs[1] != client.get.inputs[2] {
+		t.Fatalf("Get inputs = %#v, want the same input pointer on all attempts", client.get.inputs)
 	}
 	if waits != 3 {
 		t.Fatalf("backoff waits = %d, want 3", waits)
@@ -149,14 +108,13 @@ func TestBucketInventoryConfigConvergenceRetriesInvalidRegion(t *testing.T) {
 		Id:                     expected.Id,
 		InventoryConfiguration: &expected,
 	}
-	client := &scriptedInventoryConfigurationClient{
-		putErrors: []error{&smithy.GenericAPIError{Code: errInvalidRegion}, nil},
-		getErrors: []error{&smithy.GenericAPIError{Code: errInvalidRegion}, nil},
-		getOutputs: []*s3.GetBucketInventoryConfigurationOutput{
-			nil,
-			{InventoryConfiguration: &expected},
-			{InventoryConfiguration: &expected},
-		},
+	client := &scriptedInventoryConfigurationClient{}
+	client.put.errors = []error{&smithy.GenericAPIError{Code: errInvalidRegion}, nil}
+	client.get.errors = []error{&smithy.GenericAPIError{Code: errInvalidRegion}, nil}
+	client.get.outputs = []*s3.GetBucketInventoryConfigurationOutput{
+		nil,
+		{InventoryConfiguration: &expected},
+		{InventoryConfiguration: &expected},
 	}
 	waits := 0
 	options := immediateS3PhaseOptions(&waits)
@@ -171,62 +129,13 @@ func TestBucketInventoryConfigConvergenceRetriesInvalidRegion(t *testing.T) {
 	if result == nil || result.InventoryConfiguration == nil {
 		t.Fatalf("waitForInventoryConfig() result = %#v, want expected configuration", result)
 	}
-	if len(client.putInputs) != 2 || client.putInputs[0] != putInput || client.putInputs[1] != putInput {
-		t.Fatalf("Put inputs = %#v, want the same input pointer on both attempts", client.putInputs)
+	if len(client.put.inputs) != 2 || client.put.inputs[0] != putInput || client.put.inputs[1] != putInput {
+		t.Fatalf("Put inputs = %#v, want the same input pointer on both attempts", client.put.inputs)
 	}
-	if len(client.getInputs) != 3 || client.getInputs[0] != client.getInputs[1] || client.getInputs[1] != client.getInputs[2] {
-		t.Fatalf("Get inputs = %#v, want the same input pointer on all attempts", client.getInputs)
+	if len(client.get.inputs) != 3 || client.get.inputs[0] != client.get.inputs[1] || client.get.inputs[1] != client.get.inputs[2] {
+		t.Fatalf("Get inputs = %#v, want the same input pointer on all attempts", client.get.inputs)
 	}
 	if waits != 3 {
 		t.Fatalf("backoff waits = %d, want 3", waits)
 	}
-}
-
-func TestBucketConfigurationConvergenceDoesNotRetryPermanentErrors(t *testing.T) {
-	t.Parallel()
-
-	t.Run("lifecycle write", func(t *testing.T) {
-		t.Parallel()
-		client := &scriptedLifecycleConfigurationClient{putErrors: []error{
-			&smithy.GenericAPIError{Code: "InvalidBucketName"},
-			nil,
-		}}
-		waits := 0
-		err := putBucketLifecycleConfig(
-			t.Context(),
-			client,
-			"invalid",
-			&s3.PutBucketLifecycleConfigurationInput{Bucket: aws.String("invalid")},
-			immediateS3PhaseOptions(&waits),
-		)
-		if err == nil {
-			t.Fatal("putBucketLifecycleConfig() error = nil, want permanent failure")
-		}
-		if len(client.putInputs) != 1 || waits != 0 {
-			t.Fatalf("Put calls = %d, waits = %d, want 1 and 0", len(client.putInputs), waits)
-		}
-	})
-
-	t.Run("inventory readback", func(t *testing.T) {
-		t.Parallel()
-		client := &scriptedInventoryConfigurationClient{getErrors: []error{
-			&smithy.GenericAPIError{Code: "AccessDenied"},
-			nil,
-		}}
-		waits := 0
-		_, err := waitForInventoryConfig(
-			t.Context(),
-			client,
-			"source-bucket",
-			"daily",
-			s3types.InventoryConfiguration{},
-			immediateS3PhaseOptions(&waits),
-		)
-		if err == nil {
-			t.Fatal("waitForInventoryConfig() error = nil, want permanent failure")
-		}
-		if len(client.getInputs) != 1 || waits != 0 {
-			t.Fatalf("Get calls = %d, waits = %d, want 1 and 0", len(client.getInputs), waits)
-		}
-	})
 }

--- a/coreweave/object_storage/resource_bucket_lifecycle_inventory_convergence_unit_test.go
+++ b/coreweave/object_storage/resource_bucket_lifecycle_inventory_convergence_unit_test.go
@@ -1,0 +1,222 @@
+package objectstorage
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/aws/smithy-go"
+)
+
+type scriptedLifecycleConfigurationClient struct {
+	putErrors  []error
+	putInputs  []*s3.PutBucketLifecycleConfigurationInput
+	getErrors  []error
+	getOutputs []*s3.GetBucketLifecycleConfigurationOutput
+	getInputs  []*s3.GetBucketLifecycleConfigurationInput
+}
+
+func (c *scriptedLifecycleConfigurationClient) PutBucketLifecycleConfiguration(
+	_ context.Context,
+	input *s3.PutBucketLifecycleConfigurationInput,
+	_ ...func(*s3.Options),
+) (*s3.PutBucketLifecycleConfigurationOutput, error) {
+	c.putInputs = append(c.putInputs, input)
+	index := len(c.putInputs) - 1
+	if index < len(c.putErrors) && c.putErrors[index] != nil {
+		return nil, c.putErrors[index]
+	}
+	return &s3.PutBucketLifecycleConfigurationOutput{}, nil
+}
+
+func (c *scriptedLifecycleConfigurationClient) GetBucketLifecycleConfiguration(
+	_ context.Context,
+	input *s3.GetBucketLifecycleConfigurationInput,
+	_ ...func(*s3.Options),
+) (*s3.GetBucketLifecycleConfigurationOutput, error) {
+	c.getInputs = append(c.getInputs, input)
+	index := len(c.getInputs) - 1
+	if index < len(c.getErrors) && c.getErrors[index] != nil {
+		return nil, c.getErrors[index]
+	}
+	if index < len(c.getOutputs) {
+		return c.getOutputs[index], nil
+	}
+	return &s3.GetBucketLifecycleConfigurationOutput{}, nil
+}
+
+type scriptedInventoryConfigurationClient struct {
+	putErrors  []error
+	putInputs  []*s3.PutBucketInventoryConfigurationInput
+	getErrors  []error
+	getOutputs []*s3.GetBucketInventoryConfigurationOutput
+	getInputs  []*s3.GetBucketInventoryConfigurationInput
+}
+
+func (c *scriptedInventoryConfigurationClient) PutBucketInventoryConfiguration(
+	_ context.Context,
+	input *s3.PutBucketInventoryConfigurationInput,
+	_ ...func(*s3.Options),
+) (*s3.PutBucketInventoryConfigurationOutput, error) {
+	c.putInputs = append(c.putInputs, input)
+	index := len(c.putInputs) - 1
+	if index < len(c.putErrors) && c.putErrors[index] != nil {
+		return nil, c.putErrors[index]
+	}
+	return &s3.PutBucketInventoryConfigurationOutput{}, nil
+}
+
+func (c *scriptedInventoryConfigurationClient) GetBucketInventoryConfiguration(
+	_ context.Context,
+	input *s3.GetBucketInventoryConfigurationInput,
+	_ ...func(*s3.Options),
+) (*s3.GetBucketInventoryConfigurationOutput, error) {
+	c.getInputs = append(c.getInputs, input)
+	index := len(c.getInputs) - 1
+	if index < len(c.getErrors) && c.getErrors[index] != nil {
+		return nil, c.getErrors[index]
+	}
+	if index < len(c.getOutputs) {
+		return c.getOutputs[index], nil
+	}
+	return &s3.GetBucketInventoryConfigurationOutput{}, nil
+}
+
+func TestBucketLifecycleConfigConvergenceRetriesInvalidRegion(t *testing.T) {
+	t.Parallel()
+
+	expected := s3types.BucketLifecycleConfiguration{Rules: []s3types.LifecycleRule{{
+		ID:     aws.String("expire-logs"),
+		Status: s3types.ExpirationStatusEnabled,
+	}}}
+	putInput := &s3.PutBucketLifecycleConfigurationInput{
+		Bucket:                 aws.String("source-bucket"),
+		LifecycleConfiguration: &expected,
+	}
+	client := &scriptedLifecycleConfigurationClient{
+		putErrors: []error{&smithy.GenericAPIError{Code: errInvalidRegion}, nil},
+		getErrors: []error{&smithy.GenericAPIError{Code: errInvalidRegion}, nil},
+		getOutputs: []*s3.GetBucketLifecycleConfigurationOutput{
+			nil,
+			{Rules: expected.Rules},
+		},
+	}
+	waits := 0
+	options := immediatePhaseOptions(&waits)
+
+	if err := putBucketLifecycleConfig(t.Context(), client, "source-bucket", putInput, options); err != nil {
+		t.Fatalf("putBucketLifecycleConfig() error = %v", err)
+	}
+	result, err := waitForLifecycleConfig(t.Context(), client, "source-bucket", expected, options)
+	if err != nil {
+		t.Fatalf("waitForLifecycleConfig() error = %v", err)
+	}
+	if result == nil || len(result.Rules) != 1 {
+		t.Fatalf("waitForLifecycleConfig() result = %#v, want expected rule", result)
+	}
+	if len(client.putInputs) != 2 || client.putInputs[0] != putInput || client.putInputs[1] != putInput {
+		t.Fatalf("Put inputs = %#v, want the same input pointer on both attempts", client.putInputs)
+	}
+	if len(client.getInputs) != 2 || client.getInputs[0] != client.getInputs[1] {
+		t.Fatalf("Get inputs = %#v, want the same input pointer on both attempts", client.getInputs)
+	}
+	if waits != 2 {
+		t.Fatalf("backoff waits = %d, want 2", waits)
+	}
+}
+
+func TestBucketInventoryConfigConvergenceRetriesInvalidRegion(t *testing.T) {
+	t.Parallel()
+
+	expected := s3types.InventoryConfiguration{
+		Id:                     aws.String("daily"),
+		IsEnabled:              aws.Bool(true),
+		IncludedObjectVersions: s3types.InventoryIncludedObjectVersionsAll,
+	}
+	putInput := &s3.PutBucketInventoryConfigurationInput{
+		Bucket:                 aws.String("source-bucket"),
+		Id:                     expected.Id,
+		InventoryConfiguration: &expected,
+	}
+	client := &scriptedInventoryConfigurationClient{
+		putErrors: []error{&smithy.GenericAPIError{Code: errInvalidRegion}, nil},
+		getErrors: []error{&smithy.GenericAPIError{Code: errInvalidRegion}, nil},
+		getOutputs: []*s3.GetBucketInventoryConfigurationOutput{
+			nil,
+			{InventoryConfiguration: &expected},
+		},
+	}
+	waits := 0
+	options := immediatePhaseOptions(&waits)
+
+	if err := putBucketInventoryConfig(t.Context(), client, "source-bucket", putInput, options); err != nil {
+		t.Fatalf("putBucketInventoryConfig() error = %v", err)
+	}
+	result, err := waitForInventoryConfig(t.Context(), client, "source-bucket", "daily", expected, options)
+	if err != nil {
+		t.Fatalf("waitForInventoryConfig() error = %v", err)
+	}
+	if result == nil || result.InventoryConfiguration == nil {
+		t.Fatalf("waitForInventoryConfig() result = %#v, want expected configuration", result)
+	}
+	if len(client.putInputs) != 2 || client.putInputs[0] != putInput || client.putInputs[1] != putInput {
+		t.Fatalf("Put inputs = %#v, want the same input pointer on both attempts", client.putInputs)
+	}
+	if len(client.getInputs) != 2 || client.getInputs[0] != client.getInputs[1] {
+		t.Fatalf("Get inputs = %#v, want the same input pointer on both attempts", client.getInputs)
+	}
+	if waits != 2 {
+		t.Fatalf("backoff waits = %d, want 2", waits)
+	}
+}
+
+func TestBucketConfigurationConvergenceDoesNotRetryPermanentErrors(t *testing.T) {
+	t.Parallel()
+
+	t.Run("lifecycle write", func(t *testing.T) {
+		t.Parallel()
+		client := &scriptedLifecycleConfigurationClient{putErrors: []error{
+			&smithy.GenericAPIError{Code: "InvalidBucketName"},
+			nil,
+		}}
+		waits := 0
+		err := putBucketLifecycleConfig(
+			t.Context(),
+			client,
+			"invalid",
+			&s3.PutBucketLifecycleConfigurationInput{Bucket: aws.String("invalid")},
+			immediatePhaseOptions(&waits),
+		)
+		if err == nil {
+			t.Fatal("putBucketLifecycleConfig() error = nil, want permanent failure")
+		}
+		if len(client.putInputs) != 1 || waits != 0 {
+			t.Fatalf("Put calls = %d, waits = %d, want 1 and 0", len(client.putInputs), waits)
+		}
+	})
+
+	t.Run("inventory readback", func(t *testing.T) {
+		t.Parallel()
+		client := &scriptedInventoryConfigurationClient{getErrors: []error{
+			&smithy.GenericAPIError{Code: "AccessDenied"},
+			nil,
+		}}
+		waits := 0
+		_, err := waitForInventoryConfig(
+			t.Context(),
+			client,
+			"source-bucket",
+			"daily",
+			s3types.InventoryConfiguration{},
+			immediatePhaseOptions(&waits),
+		)
+		if err == nil {
+			t.Fatal("waitForInventoryConfig() error = nil, want permanent failure")
+		}
+		if len(client.getInputs) != 1 || waits != 0 {
+			t.Fatalf("Get calls = %d, waits = %d, want 1 and 0", len(client.getInputs), waits)
+		}
+	})
+}

--- a/coreweave/object_storage/resource_bucket_policy.go
+++ b/coreweave/object_storage/resource_bucket_policy.go
@@ -22,8 +22,8 @@ import (
 
 // Ensure provider defined types fully satisfy framework interfaces.
 var (
-	_ resource.Resource                = &BucketVersioningResource{}
-	_ resource.ResourceWithImportState = &BucketVersioningResource{}
+	_ resource.Resource                = &BucketPolicyResource{}
+	_ resource.ResourceWithImportState = &BucketPolicyResource{}
 )
 
 const (

--- a/coreweave/object_storage/resource_bucket_policy.go
+++ b/coreweave/object_storage/resource_bucket_policy.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
-	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
@@ -36,12 +35,19 @@ func NewBucketPolicyResource() resource.Resource {
 }
 
 type BucketPolicyResource struct {
-	client *coreweave.Client
+	client                   *coreweave.Client
+	s3ClientForConvergence   func(context.Context) (bucketPolicyAPI, error)
+	bucketPropagationOptions s3PhaseOptions
 }
 
 type BucketPolicyResourceModel struct {
 	Bucket types.String `tfsdk:"bucket"`
 	Policy types.String `tfsdk:"policy"`
+}
+
+type bucketPolicyAPI interface {
+	PutBucketPolicy(context.Context, *s3.PutBucketPolicyInput, ...func(*s3.Options)) (*s3.PutBucketPolicyOutput, error)
+	GetBucketPolicy(context.Context, *s3.GetBucketPolicyInput, ...func(*s3.Options)) (*s3.GetBucketPolicyOutput, error)
 }
 
 func (b *BucketPolicyResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
@@ -79,22 +85,45 @@ func (b *BucketPolicyResource) Schema(ctx context.Context, req resource.SchemaRe
 	}
 }
 
-func waitForBucketPolicy(parentCtx context.Context, client *s3.Client, bucket string, expected string) error {
+func putBucketPolicy(
+	ctx context.Context,
+	client bucketPolicyAPI,
+	bucket string,
+	input *s3.PutBucketPolicyInput,
+	options s3PhaseOptions,
+) error {
+	return runBucketMutationPhase(ctx, s3PhaseMetadata{
+		phase:  "bucket policy application",
+		bucket: bucket,
+	}, options, func(ctx context.Context) error {
+		_, err := client.PutBucketPolicy(ctx, input)
+		return err
+	})
+}
+
+func waitForBucketPolicy(
+	ctx context.Context,
+	client bucketPolicyAPI,
+	bucket string,
+	expected string,
+	options s3PhaseOptions,
+) error {
 	var expectedPolicy PolicyDocument
 	if err := json.Unmarshal([]byte(expected), &expectedPolicy); err != nil {
 		return err
 	}
+	input := &s3.GetBucketPolicyInput{Bucket: aws.String(bucket)}
 
-	return coreweave.PollUntil("bucket versioning configuration", parentCtx, 5*time.Second, 5*time.Minute, func(ctx context.Context) (bool, error) {
-		out, err := client.GetBucketPolicy(ctx, &s3.GetBucketPolicyInput{Bucket: aws.String(bucket)})
+	return runBucketReadbackPhase(ctx, s3PhaseMetadata{
+		phase:  "bucket policy readback",
+		bucket: bucket,
+	}, options, func(ctx context.Context) (bool, error) {
+		out, err := client.GetBucketPolicy(ctx, input)
 		if err != nil {
-			if isTransientS3Error(err) {
-				return false, nil
-			}
 			return false, err
 		}
 
-		if out.Policy == nil {
+		if out == nil || out.Policy == nil {
 			if expected == "" {
 				return true, nil
 			}
@@ -111,6 +140,13 @@ func waitForBucketPolicy(parentCtx context.Context, client *s3.Client, bucket st
 	})
 }
 
+func (b *BucketPolicyResource) convergenceClient(ctx context.Context) (bucketPolicyAPI, error) {
+	if b.s3ClientForConvergence != nil {
+		return b.s3ClientForConvergence(ctx)
+	}
+	return b.client.S3Client(ctx, "")
+}
+
 func (b *BucketPolicyResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var data BucketPolicyResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
@@ -118,17 +154,20 @@ func (b *BucketPolicyResource) Create(ctx context.Context, req resource.CreateRe
 		return
 	}
 
-	s3c, err := b.client.S3Client(ctx, "")
+	s3c, err := b.convergenceClient(ctx)
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to create S3 client", err.Error())
 		return
 	}
 
-	_, err = s3c.PutBucketPolicy(ctx, &s3.PutBucketPolicyInput{
+	propagationCtx, cancel := bucketPropagationContext(ctx)
+	defer cancel()
+
+	putInput := &s3.PutBucketPolicyInput{
 		Bucket: data.Bucket.ValueStringPointer(),
 		Policy: data.Policy.ValueStringPointer(),
-	})
-	if err != nil {
+	}
+	if err := putBucketPolicy(propagationCtx, s3c, data.Bucket.ValueString(), putInput, b.bucketPropagationOptions); err != nil {
 		handleS3Error(err, &resp.Diagnostics, data.Bucket.ValueString())
 		return
 	}
@@ -140,7 +179,7 @@ func (b *BucketPolicyResource) Create(ctx context.Context, req resource.CreateRe
 	}
 
 	// wait for bucket policy to be read back from s3 API since it is not guaranteed to propagate immediately
-	if err := waitForBucketPolicy(ctx, s3c, data.Bucket.ValueString(), data.Policy.ValueString()); err != nil {
+	if err := waitForBucketPolicy(propagationCtx, s3c, data.Bucket.ValueString(), data.Policy.ValueString(), b.bucketPropagationOptions); err != nil {
 		handleS3Error(err, &resp.Diagnostics, data.Bucket.ValueString())
 		return
 	}
@@ -207,17 +246,20 @@ func (b *BucketPolicyResource) Update(ctx context.Context, req resource.UpdateRe
 		return
 	}
 
-	s3c, err := b.client.S3Client(ctx, "")
+	s3c, err := b.convergenceClient(ctx)
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to create S3 client", err.Error())
 		return
 	}
 
-	_, err = s3c.PutBucketPolicy(ctx, &s3.PutBucketPolicyInput{
+	propagationCtx, cancel := bucketPropagationContext(ctx)
+	defer cancel()
+
+	putInput := &s3.PutBucketPolicyInput{
 		Bucket: data.Bucket.ValueStringPointer(),
 		Policy: data.Policy.ValueStringPointer(),
-	})
-	if err != nil {
+	}
+	if err := putBucketPolicy(propagationCtx, s3c, data.Bucket.ValueString(), putInput, b.bucketPropagationOptions); err != nil {
 		handleS3Error(err, &resp.Diagnostics, data.Bucket.ValueString())
 		return
 	}
@@ -229,7 +271,7 @@ func (b *BucketPolicyResource) Update(ctx context.Context, req resource.UpdateRe
 	}
 
 	// wait for bucket policy to be read back from s3 API since it is not guaranteed to propagate immediately
-	if err := waitForBucketPolicy(ctx, s3c, data.Bucket.ValueString(), data.Policy.ValueString()); err != nil {
+	if err := waitForBucketPolicy(propagationCtx, s3c, data.Bucket.ValueString(), data.Policy.ValueString(), b.bucketPropagationOptions); err != nil {
 		handleS3Error(err, &resp.Diagnostics, data.Bucket.ValueString())
 		return
 	}

--- a/coreweave/object_storage/resource_bucket_policy.go
+++ b/coreweave/object_storage/resource_bucket_policy.go
@@ -124,11 +124,7 @@ func waitForBucketPolicy(
 		}
 
 		if out == nil || out.Policy == nil {
-			if expected == "" {
-				return true, nil
-			}
-
-			return false, fmt.Errorf("bucket policy for %q was nil", bucket)
+			return expected == "", nil
 		}
 
 		var actualPolicy PolicyDocument

--- a/coreweave/object_storage/resource_bucket_post_create_unit_test.go
+++ b/coreweave/object_storage/resource_bucket_post_create_unit_test.go
@@ -1,0 +1,285 @@
+package objectstorage_test
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"buf.build/gen/go/coreweave/cwobject/connectrpc/go/cwobject/v1/cwobjectv1connect"
+	cwobjectv1 "buf.build/gen/go/coreweave/cwobject/protocolbuffers/go/cwobject/v1"
+	"connectrpc.com/connect"
+	"github.com/coreweave/terraform-provider-coreweave/internal/provider"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+const (
+	postCreateTestBucket = "tf-acc-objs-post-create-invalid-region"
+	postCreateTestZone   = "US-EAST-04A"
+	postCreateTestPolicy = `{"Version":"2012-10-17","Statement":[{"Sid":"allow-all","Effect":"Allow","Principal":{"CW":"*"},"Action":["s3:*"],"Resource":["arn:aws:s3:::tf-acc-objs-post-create-invalid-region"]}]}`
+)
+
+type postCreateInvalidRegionFake struct {
+	cwobjectv1connect.UnimplementedCWObjectHandler
+
+	mu sync.Mutex
+
+	bucketExists bool
+	policy       string
+	versioning   string
+
+	headCalls          int
+	getPolicyCalls     int
+	getVersioningCalls int
+}
+
+type postCreateRequestCounts struct {
+	head          int
+	getPolicy     int
+	getVersioning int
+}
+
+func newPostCreateInvalidRegionFake(t *testing.T) (string, *postCreateInvalidRegionFake) {
+	t.Helper()
+
+	fake := &postCreateInvalidRegionFake{}
+	mux := http.NewServeMux()
+	path, handler := cwobjectv1connect.NewCWObjectHandler(fake)
+	mux.Handle(path, handler)
+	mux.HandleFunc("/", fake.handleS3)
+
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+	t.Cleanup(func() {
+		counts := fake.requestCounts()
+		t.Logf(
+			"post-create fake requests: HeadBucket=%d GetBucketPolicy=%d GetBucketVersioning=%d",
+			counts.head,
+			counts.getPolicy,
+			counts.getVersioning,
+		)
+	})
+
+	return server.URL, fake
+}
+
+func (f *postCreateInvalidRegionFake) CreateAccessKeyFromJWT(
+	_ context.Context,
+	_ *connect.Request[cwobjectv1.CreateAccessKeyFromJWTRequest],
+) (*connect.Response[cwobjectv1.CreateAccessKeyFromJWTResponse], error) {
+	return connect.NewResponse(&cwobjectv1.CreateAccessKeyFromJWTResponse{
+		AccessKeyId: "test-access-key",
+		SecretKey:   "test-secret-key",
+		Expiry:      timestamppb.New(time.Now().Add(time.Hour)),
+	}), nil
+}
+
+func (f *postCreateInvalidRegionFake) handleS3(w http.ResponseWriter, r *http.Request) {
+	bucket := strings.Trim(r.URL.Path, "/")
+	query := r.URL.Query()
+
+	switch {
+	case r.Method == http.MethodGet && bucket == "":
+		f.writeListBuckets(w)
+
+	case r.Method == http.MethodPut && bucket != "" && query.Has("versioning"):
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("read PutBucketVersioning body: %v", err), http.StatusInternalServerError)
+			return
+		}
+		f.mu.Lock()
+		if strings.Contains(string(body), "<Status>Suspended</Status>") {
+			f.versioning = "Suspended"
+		} else {
+			f.versioning = "Enabled"
+		}
+		f.mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+
+	case r.Method == http.MethodGet && bucket != "" && query.Has("versioning"):
+		f.mu.Lock()
+		f.getVersioningCalls++
+		attempt := f.getVersioningCalls
+		versioning := f.versioning
+		f.mu.Unlock()
+		if attempt == 1 {
+			writePostCreateS3Error(w, http.StatusBadRequest, "InvalidRegion", "Region does not match")
+			return
+		}
+		w.Header().Set("Content-Type", "application/xml")
+		_, _ = fmt.Fprintf(
+			w,
+			`<VersioningConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Status>%s</Status></VersioningConfiguration>`,
+			versioning,
+		)
+
+	case r.Method == http.MethodPut && bucket != "" && query.Has("policy"):
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("read PutBucketPolicy body: %v", err), http.StatusInternalServerError)
+			return
+		}
+		f.mu.Lock()
+		f.policy = string(body)
+		f.mu.Unlock()
+		w.WriteHeader(http.StatusNoContent)
+
+	case r.Method == http.MethodGet && bucket != "" && query.Has("policy"):
+		f.mu.Lock()
+		f.getPolicyCalls++
+		attempt := f.getPolicyCalls
+		policy := f.policy
+		f.mu.Unlock()
+		if attempt == 1 {
+			writePostCreateS3Error(w, http.StatusBadRequest, "InvalidRegion", "Region does not match")
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, policy)
+
+	case r.Method == http.MethodDelete && bucket != "" && query.Has("policy"):
+		f.mu.Lock()
+		f.policy = ""
+		f.mu.Unlock()
+		w.WriteHeader(http.StatusNoContent)
+
+	case r.Method == http.MethodGet && bucket != "" && query.Has("location"):
+		w.Header().Set("Content-Type", "application/xml")
+		_, _ = fmt.Fprintf(
+			w,
+			`<LocationConstraint xmlns="http://s3.amazonaws.com/doc/2006-03-01/">%s</LocationConstraint>`,
+			postCreateTestZone,
+		)
+
+	case r.Method == http.MethodGet && bucket != "" && query.Has("tagging"):
+		writePostCreateS3Error(w, http.StatusNotFound, "NoSuchTagSet", "The TagSet does not exist")
+
+	case r.Method == http.MethodPut && bucket != "":
+		f.mu.Lock()
+		f.bucketExists = true
+		f.mu.Unlock()
+		w.Header().Set("Location", "/"+bucket)
+		w.WriteHeader(http.StatusOK)
+
+	case r.Method == http.MethodHead && bucket != "":
+		f.mu.Lock()
+		f.headCalls++
+		exists := f.bucketExists
+		f.mu.Unlock()
+		if !exists {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("x-amz-bucket-region", postCreateTestZone)
+		w.WriteHeader(http.StatusOK)
+
+	case r.Method == http.MethodDelete && bucket != "":
+		f.mu.Lock()
+		f.bucketExists = false
+		f.mu.Unlock()
+		w.WriteHeader(http.StatusNoContent)
+
+	default:
+		http.Error(w, fmt.Sprintf("unhandled S3 request: %s %s", r.Method, r.URL.RequestURI()), http.StatusNotImplemented)
+	}
+}
+
+func (f *postCreateInvalidRegionFake) writeListBuckets(w http.ResponseWriter) {
+	f.mu.Lock()
+	exists := f.bucketExists
+	f.mu.Unlock()
+
+	w.Header().Set("Content-Type", "application/xml")
+	if exists {
+		_, _ = fmt.Fprintf(
+			w,
+			`<ListAllMyBucketsResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Buckets><Bucket><Name>%s</Name></Bucket></Buckets></ListAllMyBucketsResult>`,
+			postCreateTestBucket,
+		)
+		return
+	}
+	_, _ = io.WriteString(w, `<ListAllMyBucketsResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Buckets></Buckets></ListAllMyBucketsResult>`)
+}
+
+func (f *postCreateInvalidRegionFake) requestCounts() postCreateRequestCounts {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	return postCreateRequestCounts{
+		head:          f.headCalls,
+		getPolicy:     f.getPolicyCalls,
+		getVersioning: f.getVersioningCalls,
+	}
+}
+
+func writePostCreateS3Error(w http.ResponseWriter, status int, code, message string) {
+	w.Header().Set("Content-Type", "application/xml")
+	w.Header().Set("x-amz-request-id", "post-create-test-request")
+	w.WriteHeader(status)
+	_, _ = fmt.Fprintf(
+		w,
+		`<Error><Code>%s</Code><Message>%s</Message><RequestId>post-create-test-request</RequestId></Error>`,
+		code,
+		message,
+	)
+}
+
+func TestObjectStoragePostCreateInvalidRegion(t *testing.T) {
+	endpoint, fake := newPostCreateInvalidRegionFake(t)
+	t.Setenv("COREWEAVE_API_ENDPOINT", endpoint)
+	t.Setenv("COREWEAVE_S3_ENDPOINT", endpoint)
+	t.Setenv("COREWEAVE_API_TOKEN", "fake-token")
+
+	config := fmt.Sprintf(`
+resource "coreweave_object_storage_bucket" "test" {
+  name = %q
+  zone = %q
+}
+
+resource "coreweave_object_storage_bucket_versioning" "test" {
+  bucket = coreweave_object_storage_bucket.test.name
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "coreweave_object_storage_bucket_policy" "test" {
+  bucket = coreweave_object_storage_bucket.test.name
+  policy = %q
+}
+`, postCreateTestBucket, postCreateTestZone, postCreateTestPolicy)
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: provider.TestProtoV6ProviderFactories,
+		Steps: []resource.TestStep{{
+			Config: config,
+			Check: resource.ComposeAggregateTestCheckFunc(
+				resource.TestCheckResourceAttr("coreweave_object_storage_bucket.test", "name", postCreateTestBucket),
+				resource.TestCheckResourceAttr("coreweave_object_storage_bucket_versioning.test", "versioning_configuration.0.status", "Enabled"),
+				resource.TestCheckResourceAttr("coreweave_object_storage_bucket_policy.test", "bucket", postCreateTestBucket),
+				func(_ *terraform.State) error {
+					counts := fake.requestCounts()
+					if counts.head == 0 {
+						return fmt.Errorf("HeadBucket requests = 0, want readiness barrier before child resources")
+					}
+					if counts.getPolicy != 2 {
+						return fmt.Errorf("GetBucketPolicy requests = %d, want 2", counts.getPolicy)
+					}
+					if counts.getVersioning != 2 {
+						return fmt.Errorf("GetBucketVersioning requests = %d, want 2", counts.getVersioning)
+					}
+					return nil
+				},
+			),
+		}},
+	})
+}

--- a/coreweave/object_storage/resource_bucket_post_create_unit_test.go
+++ b/coreweave/object_storage/resource_bucket_post_create_unit_test.go
@@ -135,9 +135,6 @@ func (f *postCreateInvalidRegionFake) handleS3(w http.ResponseWriter, r *http.Re
 			writePostCreateS3Error(w, http.StatusBadRequest, "InvalidRegion", "Region does not match")
 			return
 		}
-		if attempt == 3 {
-			versioning = "Suspended"
-		}
 		w.Header().Set("Content-Type", "application/xml")
 		_, _ = fmt.Fprintf(
 			w,
@@ -177,9 +174,6 @@ func (f *postCreateInvalidRegionFake) handleS3(w http.ResponseWriter, r *http.Re
 		if attempt == 1 {
 			writePostCreateS3Error(w, http.StatusBadRequest, "InvalidRegion", "Region does not match")
 			return
-		}
-		if attempt == 3 {
-			policy = `{"Version":"2012-10-17","Statement":[]}`
 		}
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = io.WriteString(w, policy)
@@ -325,11 +319,11 @@ resource "coreweave_object_storage_bucket_policy" "test" {
 					if counts.putVersioning != 2 {
 						return fmt.Errorf("PutBucketVersioning requests = %d, want 2", counts.putVersioning)
 					}
-					if counts.getPolicy != 5 {
-						return fmt.Errorf("GetBucketPolicy requests = %d, want 5", counts.getPolicy)
+					if counts.getPolicy < 2 {
+						return fmt.Errorf("GetBucketPolicy requests = %d, want at least 2 after InvalidRegion", counts.getPolicy)
 					}
-					if counts.getVersioning != 5 {
-						return fmt.Errorf("GetBucketVersioning requests = %d, want 5", counts.getVersioning)
+					if counts.getVersioning < 2 {
+						return fmt.Errorf("GetBucketVersioning requests = %d, want at least 2 after InvalidRegion", counts.getVersioning)
 					}
 					return nil
 				},

--- a/coreweave/object_storage/resource_bucket_post_create_unit_test.go
+++ b/coreweave/object_storage/resource_bucket_post_create_unit_test.go
@@ -264,7 +264,7 @@ resource "coreweave_object_storage_bucket_policy" "test" {
 			Config: config,
 			Check: resource.ComposeAggregateTestCheckFunc(
 				resource.TestCheckResourceAttr("coreweave_object_storage_bucket.test", "name", postCreateTestBucket),
-				resource.TestCheckResourceAttr("coreweave_object_storage_bucket_versioning.test", "versioning_configuration.0.status", "Enabled"),
+				resource.TestCheckResourceAttr("coreweave_object_storage_bucket_versioning.test", "versioning_configuration.status", "Enabled"),
 				resource.TestCheckResourceAttr("coreweave_object_storage_bucket_policy.test", "bucket", postCreateTestBucket),
 				func(_ *terraform.State) error {
 					counts := fake.requestCounts()

--- a/coreweave/object_storage/resource_bucket_post_create_unit_test.go
+++ b/coreweave/object_storage/resource_bucket_post_create_unit_test.go
@@ -31,19 +31,26 @@ type postCreateInvalidRegionFake struct {
 
 	mu sync.Mutex
 
-	bucketExists bool
-	policy       string
-	versioning   string
+	bucketExists    bool
+	headSucceeded   bool
+	childBeforeHead bool
+	policy          string
+	versioning      string
 
 	headCalls          int
+	putPolicyCalls     int
+	putVersioningCalls int
 	getPolicyCalls     int
 	getVersioningCalls int
 }
 
 type postCreateRequestCounts struct {
-	head          int
-	getPolicy     int
-	getVersioning int
+	head            int
+	putPolicy       int
+	putVersioning   int
+	getPolicy       int
+	getVersioning   int
+	childBeforeHead bool
 }
 
 func newPostCreateInvalidRegionFake(t *testing.T) (string, *postCreateInvalidRegionFake) {
@@ -60,8 +67,10 @@ func newPostCreateInvalidRegionFake(t *testing.T) (string, *postCreateInvalidReg
 	t.Cleanup(func() {
 		counts := fake.requestCounts()
 		t.Logf(
-			"post-create fake requests: HeadBucket=%d GetBucketPolicy=%d GetBucketVersioning=%d",
+			"post-create fake requests: HeadBucket=%d PutBucketPolicy=%d PutBucketVersioning=%d GetBucketPolicy=%d GetBucketVersioning=%d",
 			counts.head,
+			counts.putPolicy,
+			counts.putVersioning,
 			counts.getPolicy,
 			counts.getVersioning,
 		)
@@ -90,12 +99,24 @@ func (f *postCreateInvalidRegionFake) handleS3(w http.ResponseWriter, r *http.Re
 		f.writeListBuckets(w)
 
 	case r.Method == http.MethodPut && bucket != "" && query.Has("versioning"):
+		f.mu.Lock()
+		if !f.headSucceeded {
+			f.childBeforeHead = true
+		}
+		f.mu.Unlock()
 		body, err := io.ReadAll(r.Body)
 		if err != nil {
 			http.Error(w, fmt.Sprintf("read PutBucketVersioning body: %v", err), http.StatusInternalServerError)
 			return
 		}
 		f.mu.Lock()
+		f.putVersioningCalls++
+		attempt := f.putVersioningCalls
+		if attempt == 1 {
+			f.mu.Unlock()
+			writePostCreateS3Error(w, http.StatusBadRequest, "InvalidRegion", "Region does not match")
+			return
+		}
 		if strings.Contains(string(body), "<Status>Suspended</Status>") {
 			f.versioning = "Suspended"
 		} else {
@@ -114,6 +135,9 @@ func (f *postCreateInvalidRegionFake) handleS3(w http.ResponseWriter, r *http.Re
 			writePostCreateS3Error(w, http.StatusBadRequest, "InvalidRegion", "Region does not match")
 			return
 		}
+		if attempt == 3 {
+			versioning = "Suspended"
+		}
 		w.Header().Set("Content-Type", "application/xml")
 		_, _ = fmt.Fprintf(
 			w,
@@ -122,12 +146,24 @@ func (f *postCreateInvalidRegionFake) handleS3(w http.ResponseWriter, r *http.Re
 		)
 
 	case r.Method == http.MethodPut && bucket != "" && query.Has("policy"):
+		f.mu.Lock()
+		if !f.headSucceeded {
+			f.childBeforeHead = true
+		}
+		f.mu.Unlock()
 		body, err := io.ReadAll(r.Body)
 		if err != nil {
 			http.Error(w, fmt.Sprintf("read PutBucketPolicy body: %v", err), http.StatusInternalServerError)
 			return
 		}
 		f.mu.Lock()
+		f.putPolicyCalls++
+		attempt := f.putPolicyCalls
+		if attempt == 1 {
+			f.mu.Unlock()
+			writePostCreateS3Error(w, http.StatusBadRequest, "InvalidRegion", "Region does not match")
+			return
+		}
 		f.policy = string(body)
 		f.mu.Unlock()
 		w.WriteHeader(http.StatusNoContent)
@@ -141,6 +177,9 @@ func (f *postCreateInvalidRegionFake) handleS3(w http.ResponseWriter, r *http.Re
 		if attempt == 1 {
 			writePostCreateS3Error(w, http.StatusBadRequest, "InvalidRegion", "Region does not match")
 			return
+		}
+		if attempt == 3 {
+			policy = `{"Version":"2012-10-17","Statement":[]}`
 		}
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = io.WriteString(w, policy)
@@ -179,6 +218,9 @@ func (f *postCreateInvalidRegionFake) handleS3(w http.ResponseWriter, r *http.Re
 			return
 		}
 		w.Header().Set("x-amz-bucket-region", postCreateTestZone)
+		f.mu.Lock()
+		f.headSucceeded = true
+		f.mu.Unlock()
 		w.WriteHeader(http.StatusOK)
 
 	case r.Method == http.MethodDelete && bucket != "":
@@ -214,9 +256,12 @@ func (f *postCreateInvalidRegionFake) requestCounts() postCreateRequestCounts {
 	defer f.mu.Unlock()
 
 	return postCreateRequestCounts{
-		head:          f.headCalls,
-		getPolicy:     f.getPolicyCalls,
-		getVersioning: f.getVersioningCalls,
+		head:            f.headCalls,
+		putPolicy:       f.putPolicyCalls,
+		putVersioning:   f.putVersioningCalls,
+		getPolicy:       f.getPolicyCalls,
+		getVersioning:   f.getVersioningCalls,
+		childBeforeHead: f.childBeforeHead,
 	}
 }
 
@@ -271,11 +316,20 @@ resource "coreweave_object_storage_bucket_policy" "test" {
 					if counts.head == 0 {
 						return fmt.Errorf("HeadBucket requests = 0, want readiness barrier before child resources")
 					}
-					if counts.getPolicy != 2 {
-						return fmt.Errorf("GetBucketPolicy requests = %d, want 2", counts.getPolicy)
+					if counts.childBeforeHead {
+						return fmt.Errorf("child resource mutation occurred before a successful HeadBucket")
 					}
-					if counts.getVersioning != 2 {
-						return fmt.Errorf("GetBucketVersioning requests = %d, want 2", counts.getVersioning)
+					if counts.putPolicy != 2 {
+						return fmt.Errorf("PutBucketPolicy requests = %d, want 2", counts.putPolicy)
+					}
+					if counts.putVersioning != 2 {
+						return fmt.Errorf("PutBucketVersioning requests = %d, want 2", counts.putVersioning)
+					}
+					if counts.getPolicy != 5 {
+						return fmt.Errorf("GetBucketPolicy requests = %d, want 5", counts.getPolicy)
+					}
+					if counts.getVersioning != 5 {
+						return fmt.Errorf("GetBucketVersioning requests = %d, want 5", counts.getVersioning)
 					}
 					return nil
 				},

--- a/coreweave/object_storage/resource_bucket_subresource_convergence_unit_test.go
+++ b/coreweave/object_storage/resource_bucket_subresource_convergence_unit_test.go
@@ -3,23 +3,16 @@ package objectstorage
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/aws/smithy-go"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 type scriptedBucketPolicyClient struct {
-	putErrors   []error
-	getErrors   []error
-	getOutputs  []*s3.GetBucketPolicyOutput
-	putInputs   []*s3.PutBucketPolicyInput
-	getInputs   []*s3.GetBucketPolicyInput
-	putContexts []context.Context
-	getContexts []context.Context
+	put scriptedS3Call[s3.PutBucketPolicyInput, s3.PutBucketPolicyOutput]
+	get scriptedS3Call[s3.GetBucketPolicyInput, s3.GetBucketPolicyOutput]
 }
 
 func (c *scriptedBucketPolicyClient) PutBucketPolicy(
@@ -27,13 +20,7 @@ func (c *scriptedBucketPolicyClient) PutBucketPolicy(
 	input *s3.PutBucketPolicyInput,
 	_ ...func(*s3.Options),
 ) (*s3.PutBucketPolicyOutput, error) {
-	index := len(c.putInputs)
-	c.putInputs = append(c.putInputs, input)
-	c.putContexts = append(c.putContexts, ctx)
-	if index < len(c.putErrors) && c.putErrors[index] != nil {
-		return nil, c.putErrors[index]
-	}
-	return &s3.PutBucketPolicyOutput{}, nil
+	return c.put.call(ctx, input)
 }
 
 func (c *scriptedBucketPolicyClient) GetBucketPolicy(
@@ -41,26 +28,12 @@ func (c *scriptedBucketPolicyClient) GetBucketPolicy(
 	input *s3.GetBucketPolicyInput,
 	_ ...func(*s3.Options),
 ) (*s3.GetBucketPolicyOutput, error) {
-	index := len(c.getInputs)
-	c.getInputs = append(c.getInputs, input)
-	c.getContexts = append(c.getContexts, ctx)
-	if index < len(c.getErrors) && c.getErrors[index] != nil {
-		return nil, c.getErrors[index]
-	}
-	if index < len(c.getOutputs) && c.getOutputs[index] != nil {
-		return c.getOutputs[index], nil
-	}
-	return &s3.GetBucketPolicyOutput{}, nil
+	return c.get.call(ctx, input)
 }
 
 type scriptedBucketVersioningClient struct {
-	putErrors   []error
-	getErrors   []error
-	getOutputs  []*s3.GetBucketVersioningOutput
-	putInputs   []*s3.PutBucketVersioningInput
-	getInputs   []*s3.GetBucketVersioningInput
-	putContexts []context.Context
-	getContexts []context.Context
+	put scriptedS3Call[s3.PutBucketVersioningInput, s3.PutBucketVersioningOutput]
+	get scriptedS3Call[s3.GetBucketVersioningInput, s3.GetBucketVersioningOutput]
 }
 
 func (c *scriptedBucketVersioningClient) PutBucketVersioning(
@@ -68,13 +41,7 @@ func (c *scriptedBucketVersioningClient) PutBucketVersioning(
 	input *s3.PutBucketVersioningInput,
 	_ ...func(*s3.Options),
 ) (*s3.PutBucketVersioningOutput, error) {
-	index := len(c.putInputs)
-	c.putInputs = append(c.putInputs, input)
-	c.putContexts = append(c.putContexts, ctx)
-	if index < len(c.putErrors) && c.putErrors[index] != nil {
-		return nil, c.putErrors[index]
-	}
-	return &s3.PutBucketVersioningOutput{}, nil
+	return c.put.call(ctx, input)
 }
 
 func (c *scriptedBucketVersioningClient) GetBucketVersioning(
@@ -82,16 +49,7 @@ func (c *scriptedBucketVersioningClient) GetBucketVersioning(
 	input *s3.GetBucketVersioningInput,
 	_ ...func(*s3.Options),
 ) (*s3.GetBucketVersioningOutput, error) {
-	index := len(c.getInputs)
-	c.getInputs = append(c.getInputs, input)
-	c.getContexts = append(c.getContexts, ctx)
-	if index < len(c.getErrors) && c.getErrors[index] != nil {
-		return nil, c.getErrors[index]
-	}
-	if index < len(c.getOutputs) && c.getOutputs[index] != nil {
-		return c.getOutputs[index], nil
-	}
-	return &s3.GetBucketVersioningOutput{}, nil
+	return c.get.call(ctx, input)
 }
 
 func TestBucketPolicyConvergenceRetriesInvalidRegion(t *testing.T) {
@@ -101,20 +59,19 @@ func TestBucketPolicyConvergenceRetriesInvalidRegion(t *testing.T) {
 		bucket = "policy-test"
 		policy = `{"Version":"2012-10-17","Statement":[]}`
 	)
-	client := &scriptedBucketPolicyClient{
-		putErrors: []error{
-			&smithy.GenericAPIError{Code: errInvalidRegion},
-			nil,
-		},
-		getErrors: []error{
-			&smithy.GenericAPIError{Code: errInvalidRegion},
-			nil,
-		},
-		getOutputs: []*s3.GetBucketPolicyOutput{
-			nil,
-			{Policy: aws.String(policy)},
-			{Policy: aws.String(policy)},
-		},
+	client := &scriptedBucketPolicyClient{}
+	client.put.errors = []error{
+		&smithy.GenericAPIError{Code: errInvalidRegion},
+		nil,
+	}
+	client.get.errors = []error{
+		&smithy.GenericAPIError{Code: errInvalidRegion},
+		nil,
+	}
+	client.get.outputs = []*s3.GetBucketPolicyOutput{
+		nil,
+		{Policy: aws.String(policy)},
+		{Policy: aws.String(policy)},
 	}
 	waits := 0
 	options := immediateS3PhaseOptions(&waits)
@@ -132,41 +89,19 @@ func TestBucketPolicyConvergenceRetriesInvalidRegion(t *testing.T) {
 		t.Fatalf("waitForBucketPolicy() error = %v", err)
 	}
 
-	if got := len(client.putInputs); got != 2 {
+	if got := len(client.put.inputs); got != 2 {
 		t.Fatalf("PutBucketPolicy calls = %d, want 2", got)
 	}
-	for attempt, got := range client.putInputs {
+	for attempt, got := range client.put.inputs {
 		if got != input {
 			t.Fatalf("PutBucketPolicy input on attempt %d was rebuilt, want immutable input %p", attempt+1, input)
 		}
 	}
-	if len(client.getInputs) != 3 || client.getInputs[0] != client.getInputs[1] || client.getInputs[1] != client.getInputs[2] {
-		t.Fatalf("GetBucketPolicy inputs = %#v, want the same input pointer on all attempts", client.getInputs)
+	if len(client.get.inputs) != 3 || client.get.inputs[0] != client.get.inputs[1] || client.get.inputs[1] != client.get.inputs[2] {
+		t.Fatalf("GetBucketPolicy inputs = %#v, want the same input pointer on all attempts", client.get.inputs)
 	}
 	if waits != 3 {
 		t.Fatalf("backoff waits = %d, want 3", waits)
-	}
-}
-
-func TestBucketPolicyConvergenceDoesNotRetryUnrelated400(t *testing.T) {
-	t.Parallel()
-
-	client := &scriptedBucketPolicyClient{putErrors: []error{
-		&smithy.GenericAPIError{Code: "InvalidBucketName"},
-		nil,
-	}}
-	waits := 0
-	input := &s3.PutBucketPolicyInput{
-		Bucket: aws.String("invalid-policy-test"),
-		Policy: aws.String(`{"Version":"2012-10-17","Statement":[]}`),
-	}
-
-	err := putBucketPolicy(t.Context(), client, aws.ToString(input.Bucket), input, immediateS3PhaseOptions(&waits))
-	if err == nil {
-		t.Fatal("putBucketPolicy() error = nil, want permanent failure")
-	}
-	if got := len(client.putInputs); got != 1 || waits != 0 {
-		t.Fatalf("PutBucketPolicy calls = %d, waits = %d, want 1 and 0", got, waits)
 	}
 }
 
@@ -174,71 +109,19 @@ func TestWaitForBucketPolicyRetriesNilResponse(t *testing.T) {
 	t.Parallel()
 
 	const policy = `{"Version":"2012-10-17","Statement":[]}`
-	client := &scriptedBucketPolicyClient{getOutputs: []*s3.GetBucketPolicyOutput{
+	client := &scriptedBucketPolicyClient{}
+	client.get.outputs = []*s3.GetBucketPolicyOutput{
 		{},
 		{Policy: aws.String(policy)},
 		{Policy: aws.String(policy)},
-	}}
+	}
 	waits := 0
 
 	if err := waitForBucketPolicy(t.Context(), client, "policy-test", policy, immediateS3PhaseOptions(&waits)); err != nil {
 		t.Fatalf("waitForBucketPolicy() error = %v", err)
 	}
-	if len(client.getInputs) != 3 || waits != 2 {
-		t.Fatalf("GetBucketPolicy calls = %d, waits = %d; want 3, 2", len(client.getInputs), waits)
-	}
-}
-
-func TestBucketPolicyCreateRetainsStateWhenReadbackTimesOut(t *testing.T) {
-	t.Parallel()
-
-	const (
-		bucket = "policy-state-retention-test"
-		policy = `{"Version":"2012-10-17","Statement":[]}`
-	)
-	client := &scriptedBucketPolicyClient{getErrors: []error{
-		&smithy.GenericAPIError{Code: errInvalidRegion},
-	}, putErrors: []error{
-		&smithy.GenericAPIError{Code: errInvalidRegion},
-		nil,
-	}}
-	resourceUnderTest := &BucketPolicyResource{
-		s3ClientForConvergence: func(context.Context) (bucketPolicyAPI, error) {
-			return client, nil
-		},
-		bucketPropagationOptions: s3PhaseOptionsTimingOutOnSecondWait(),
-	}
-
-	model := BucketPolicyResourceModel{
-		Bucket: types.StringValue(bucket),
-		Policy: types.StringValue(policy),
-	}
-	response := runCreateWithModel(t, resourceUnderTest, model)
-	assertWriteRetriedAndRetainedState(t, response.Diagnostics.HasError(), len(client.putInputs), len(client.getInputs), client.putContexts, client.getContexts)
-	if client.putInputs[0] != client.putInputs[1] {
-		t.Fatal("PutBucketPolicy rebuilt its retry input")
-	}
-	var retained BucketPolicyResourceModel
-	if diagnostics := response.State.Get(t.Context(), &retained); diagnostics.HasError() {
-		t.Fatalf("read retained state: %v", diagnostics)
-	}
-	if retained.Bucket.ValueString() != bucket || retained.Policy.ValueString() != policy {
-		t.Fatalf("retained state = (%q, %q), want (%q, %q)", retained.Bucket.ValueString(), retained.Policy.ValueString(), bucket, policy)
-	}
-}
-
-func s3PhaseOptionsTimingOutOnSecondWait() s3PhaseOptions {
-	waits := 0
-	return s3PhaseOptions{
-		now:   time.Now,
-		delay: func(int) time.Duration { return 0 },
-		wait: func(context.Context, time.Duration) error {
-			waits++
-			if waits >= 2 {
-				return context.DeadlineExceeded
-			}
-			return nil
-		},
+	if len(client.get.inputs) != 3 || waits != 2 {
+		t.Fatalf("GetBucketPolicy calls = %d, waits = %d; want 3, 2", len(client.get.inputs), waits)
 	}
 }
 
@@ -247,20 +130,19 @@ func TestBucketVersioningConvergenceRetriesInvalidRegion(t *testing.T) {
 
 	const bucket = "versioning-test"
 	const status = s3types.BucketVersioningStatusEnabled
-	client := &scriptedBucketVersioningClient{
-		putErrors: []error{
-			&smithy.GenericAPIError{Code: errInvalidRegion},
-			nil,
-		},
-		getErrors: []error{
-			&smithy.GenericAPIError{Code: errInvalidRegion},
-			nil,
-		},
-		getOutputs: []*s3.GetBucketVersioningOutput{
-			nil,
-			{Status: status},
-			{Status: status},
-		},
+	client := &scriptedBucketVersioningClient{}
+	client.put.errors = []error{
+		&smithy.GenericAPIError{Code: errInvalidRegion},
+		nil,
+	}
+	client.get.errors = []error{
+		&smithy.GenericAPIError{Code: errInvalidRegion},
+		nil,
+	}
+	client.get.outputs = []*s3.GetBucketVersioningOutput{
+		nil,
+		{Status: status},
+		{Status: status},
 	}
 	waits := 0
 	options := immediateS3PhaseOptions(&waits)
@@ -280,42 +162,18 @@ func TestBucketVersioningConvergenceRetriesInvalidRegion(t *testing.T) {
 		t.Fatalf("waitForBucketVersioning() error = %v", err)
 	}
 
-	if got := len(client.putInputs); got != 2 {
+	if got := len(client.put.inputs); got != 2 {
 		t.Fatalf("PutBucketVersioning calls = %d, want 2", got)
 	}
-	for attempt, got := range client.putInputs {
+	for attempt, got := range client.put.inputs {
 		if got != input {
 			t.Fatalf("PutBucketVersioning input on attempt %d was rebuilt, want immutable input %p", attempt+1, input)
 		}
 	}
-	if len(client.getInputs) != 3 || client.getInputs[0] != client.getInputs[1] || client.getInputs[1] != client.getInputs[2] {
-		t.Fatalf("GetBucketVersioning inputs = %#v, want the same input pointer on all attempts", client.getInputs)
+	if len(client.get.inputs) != 3 || client.get.inputs[0] != client.get.inputs[1] || client.get.inputs[1] != client.get.inputs[2] {
+		t.Fatalf("GetBucketVersioning inputs = %#v, want the same input pointer on all attempts", client.get.inputs)
 	}
 	if waits != 3 {
 		t.Fatalf("backoff waits = %d, want 3", waits)
-	}
-}
-
-func TestBucketVersioningConvergenceDoesNotRetryUnrelated400(t *testing.T) {
-	t.Parallel()
-
-	client := &scriptedBucketVersioningClient{getErrors: []error{
-		&smithy.GenericAPIError{Code: "InvalidRequest"},
-		nil,
-	}}
-	waits := 0
-
-	err := waitForBucketVersioning(
-		t.Context(),
-		client,
-		"invalid-versioning-test",
-		s3types.BucketVersioningStatusEnabled,
-		immediateS3PhaseOptions(&waits),
-	)
-	if err == nil {
-		t.Fatal("waitForBucketVersioning() error = nil, want permanent failure")
-	}
-	if len(client.getInputs) != 1 || waits != 0 {
-		t.Fatalf("GetBucketVersioning calls = %d, waits = %d, want 1 and 0", len(client.getInputs), waits)
 	}
 }

--- a/coreweave/object_storage/resource_bucket_subresource_convergence_unit_test.go
+++ b/coreweave/object_storage/resource_bucket_subresource_convergence_unit_test.go
@@ -206,7 +206,7 @@ func TestBucketPolicyCreateRetainsStateWhenReadbackTimesOut(t *testing.T) {
 		s3ClientForConvergence: func(context.Context) (bucketPolicyAPI, error) {
 			return client, nil
 		},
-		bucketPropagationOptions: s3PhaseOptionsTimingOutOnWait(2),
+		bucketPropagationOptions: s3PhaseOptionsTimingOutOnSecondWait(),
 	}
 
 	model := BucketPolicyResourceModel{
@@ -227,14 +227,14 @@ func TestBucketPolicyCreateRetainsStateWhenReadbackTimesOut(t *testing.T) {
 	}
 }
 
-func s3PhaseOptionsTimingOutOnWait(timeoutOn int) s3PhaseOptions {
+func s3PhaseOptionsTimingOutOnSecondWait() s3PhaseOptions {
 	waits := 0
 	return s3PhaseOptions{
 		now:   time.Now,
 		delay: func(int) time.Duration { return 0 },
 		wait: func(context.Context, time.Duration) error {
 			waits++
-			if waits >= timeoutOn {
+			if waits >= 2 {
 				return context.DeadlineExceeded
 			}
 			return nil

--- a/coreweave/object_storage/resource_bucket_subresource_convergence_unit_test.go
+++ b/coreweave/object_storage/resource_bucket_subresource_convergence_unit_test.go
@@ -1,0 +1,314 @@
+package objectstorage
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/aws/smithy-go"
+	fwresource "github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+type scriptedBucketPolicyClient struct {
+	putErrors   []error
+	getErrors   []error
+	getOutputs  []*s3.GetBucketPolicyOutput
+	putInputs   []*s3.PutBucketPolicyInput
+	getInputs   []*s3.GetBucketPolicyInput
+	putContexts []context.Context
+	getContexts []context.Context
+}
+
+func (c *scriptedBucketPolicyClient) PutBucketPolicy(
+	ctx context.Context,
+	input *s3.PutBucketPolicyInput,
+	_ ...func(*s3.Options),
+) (*s3.PutBucketPolicyOutput, error) {
+	index := len(c.putInputs)
+	c.putInputs = append(c.putInputs, input)
+	c.putContexts = append(c.putContexts, ctx)
+	if index < len(c.putErrors) && c.putErrors[index] != nil {
+		return nil, c.putErrors[index]
+	}
+	return &s3.PutBucketPolicyOutput{}, nil
+}
+
+func (c *scriptedBucketPolicyClient) GetBucketPolicy(
+	ctx context.Context,
+	input *s3.GetBucketPolicyInput,
+	_ ...func(*s3.Options),
+) (*s3.GetBucketPolicyOutput, error) {
+	index := len(c.getInputs)
+	c.getInputs = append(c.getInputs, input)
+	c.getContexts = append(c.getContexts, ctx)
+	if index < len(c.getErrors) && c.getErrors[index] != nil {
+		return nil, c.getErrors[index]
+	}
+	if index < len(c.getOutputs) && c.getOutputs[index] != nil {
+		return c.getOutputs[index], nil
+	}
+	return &s3.GetBucketPolicyOutput{}, nil
+}
+
+type scriptedBucketVersioningClient struct {
+	putErrors  []error
+	getErrors  []error
+	getOutputs []*s3.GetBucketVersioningOutput
+	putInputs  []*s3.PutBucketVersioningInput
+	getInputs  []*s3.GetBucketVersioningInput
+}
+
+func (c *scriptedBucketVersioningClient) PutBucketVersioning(
+	_ context.Context,
+	input *s3.PutBucketVersioningInput,
+	_ ...func(*s3.Options),
+) (*s3.PutBucketVersioningOutput, error) {
+	index := len(c.putInputs)
+	c.putInputs = append(c.putInputs, input)
+	if index < len(c.putErrors) && c.putErrors[index] != nil {
+		return nil, c.putErrors[index]
+	}
+	return &s3.PutBucketVersioningOutput{}, nil
+}
+
+func (c *scriptedBucketVersioningClient) GetBucketVersioning(
+	_ context.Context,
+	input *s3.GetBucketVersioningInput,
+	_ ...func(*s3.Options),
+) (*s3.GetBucketVersioningOutput, error) {
+	index := len(c.getInputs)
+	c.getInputs = append(c.getInputs, input)
+	if index < len(c.getErrors) && c.getErrors[index] != nil {
+		return nil, c.getErrors[index]
+	}
+	if index < len(c.getOutputs) && c.getOutputs[index] != nil {
+		return c.getOutputs[index], nil
+	}
+	return &s3.GetBucketVersioningOutput{}, nil
+}
+
+func immediateSubresourcePhaseOptions(waits *int) s3PhaseOptions {
+	return s3PhaseOptions{
+		now:   time.Now,
+		delay: func(int) time.Duration { return 0 },
+		wait: func(ctx context.Context, _ time.Duration) error {
+			*waits = *waits + 1
+			return ctx.Err()
+		},
+	}
+}
+
+func TestBucketPolicyConvergenceRetriesInvalidRegion(t *testing.T) {
+	t.Parallel()
+
+	const (
+		bucket = "policy-test"
+		policy = `{"Version":"2012-10-17","Statement":[]}`
+	)
+	client := &scriptedBucketPolicyClient{
+		putErrors: []error{
+			&smithy.GenericAPIError{Code: errInvalidRegion},
+			nil,
+		},
+		getErrors: []error{
+			&smithy.GenericAPIError{Code: errInvalidRegion},
+			nil,
+		},
+		getOutputs: []*s3.GetBucketPolicyOutput{
+			nil,
+			{Policy: aws.String(policy)},
+		},
+	}
+	waits := 0
+	options := immediateSubresourcePhaseOptions(&waits)
+	ctx, cancel := bucketPropagationContext(t.Context())
+	defer cancel()
+	input := &s3.PutBucketPolicyInput{
+		Bucket: aws.String(bucket),
+		Policy: aws.String(policy),
+	}
+
+	if err := putBucketPolicy(ctx, client, bucket, input, options); err != nil {
+		t.Fatalf("putBucketPolicy() error = %v", err)
+	}
+	if err := waitForBucketPolicy(ctx, client, bucket, policy, options); err != nil {
+		t.Fatalf("waitForBucketPolicy() error = %v", err)
+	}
+
+	if got := len(client.putInputs); got != 2 {
+		t.Fatalf("PutBucketPolicy calls = %d, want 2", got)
+	}
+	for attempt, got := range client.putInputs {
+		if got != input {
+			t.Fatalf("PutBucketPolicy input on attempt %d was rebuilt, want immutable input %p", attempt+1, input)
+		}
+	}
+	if len(client.getInputs) != 2 || client.getInputs[0] != client.getInputs[1] {
+		t.Fatalf("GetBucketPolicy inputs = %#v, want the same input pointer on both attempts", client.getInputs)
+	}
+	if waits != 2 {
+		t.Fatalf("backoff waits = %d, want 2", waits)
+	}
+}
+
+func TestBucketPolicyConvergenceDoesNotRetryUnrelated400(t *testing.T) {
+	t.Parallel()
+
+	client := &scriptedBucketPolicyClient{putErrors: []error{
+		&smithy.GenericAPIError{Code: "InvalidBucketName"},
+		nil,
+	}}
+	waits := 0
+	input := &s3.PutBucketPolicyInput{
+		Bucket: aws.String("invalid-policy-test"),
+		Policy: aws.String(`{"Version":"2012-10-17","Statement":[]}`),
+	}
+
+	err := putBucketPolicy(t.Context(), client, aws.ToString(input.Bucket), input, immediateSubresourcePhaseOptions(&waits))
+	if err == nil {
+		t.Fatal("putBucketPolicy() error = nil, want permanent failure")
+	}
+	if got := len(client.putInputs); got != 1 || waits != 0 {
+		t.Fatalf("PutBucketPolicy calls = %d, waits = %d, want 1 and 0", got, waits)
+	}
+}
+
+func TestBucketPolicyCreateRetainsStateWhenReadbackTimesOut(t *testing.T) {
+	t.Parallel()
+
+	const (
+		bucket = "policy-state-retention-test"
+		policy = `{"Version":"2012-10-17","Statement":[]}`
+	)
+	client := &scriptedBucketPolicyClient{getErrors: []error{
+		&smithy.GenericAPIError{Code: errInvalidRegion},
+	}}
+	resourceUnderTest := &BucketPolicyResource{
+		s3ClientForConvergence: func(context.Context) (bucketPolicyAPI, error) {
+			return client, nil
+		},
+		bucketPropagationOptions: s3PhaseOptions{
+			now:   time.Now,
+			delay: func(int) time.Duration { return 0 },
+			wait: func(context.Context, time.Duration) error {
+				return context.DeadlineExceeded
+			},
+		},
+	}
+
+	var schemaResponse fwresource.SchemaResponse
+	resourceUnderTest.Schema(t.Context(), fwresource.SchemaRequest{}, &schemaResponse)
+	if schemaResponse.Diagnostics.HasError() {
+		t.Fatalf("bucket policy schema diagnostics: %v", schemaResponse.Diagnostics)
+	}
+	model := BucketPolicyResourceModel{
+		Bucket: types.StringValue(bucket),
+		Policy: types.StringValue(policy),
+	}
+	plan := tfsdk.Plan{Schema: schemaResponse.Schema}
+	if diagnostics := plan.Set(t.Context(), &model); diagnostics.HasError() {
+		t.Fatalf("set test plan: %v", diagnostics)
+	}
+	response := &fwresource.CreateResponse{State: tfsdk.State{Schema: schemaResponse.Schema}}
+
+	resourceUnderTest.Create(t.Context(), fwresource.CreateRequest{Plan: plan}, response)
+
+	if !response.Diagnostics.HasError() {
+		t.Fatal("Create() diagnostics contain no error, want readback timeout")
+	}
+	if len(client.putInputs) != 1 || len(client.getInputs) != 1 {
+		t.Fatalf("S3 calls: Put=%d Get=%d, want 1 and 1", len(client.putInputs), len(client.getInputs))
+	}
+	if client.putContexts[0] != client.getContexts[0] {
+		t.Fatal("PutBucketPolicy and GetBucketPolicy used different propagation contexts")
+	}
+	var retained BucketPolicyResourceModel
+	if diagnostics := response.State.Get(t.Context(), &retained); diagnostics.HasError() {
+		t.Fatalf("read retained state: %v", diagnostics)
+	}
+	if retained.Bucket.ValueString() != bucket || retained.Policy.ValueString() != policy {
+		t.Fatalf("retained state = (%q, %q), want (%q, %q)", retained.Bucket.ValueString(), retained.Policy.ValueString(), bucket, policy)
+	}
+}
+
+func TestBucketVersioningConvergenceRetriesInvalidRegion(t *testing.T) {
+	t.Parallel()
+
+	const bucket = "versioning-test"
+	const status = s3types.BucketVersioningStatusEnabled
+	client := &scriptedBucketVersioningClient{
+		putErrors: []error{
+			&smithy.GenericAPIError{Code: errInvalidRegion},
+			nil,
+		},
+		getErrors: []error{
+			&smithy.GenericAPIError{Code: errInvalidRegion},
+			nil,
+		},
+		getOutputs: []*s3.GetBucketVersioningOutput{
+			nil,
+			{Status: status},
+		},
+	}
+	waits := 0
+	options := immediateSubresourcePhaseOptions(&waits)
+	ctx, cancel := bucketPropagationContext(t.Context())
+	defer cancel()
+	input := &s3.PutBucketVersioningInput{
+		Bucket: aws.String(bucket),
+		VersioningConfiguration: &s3types.VersioningConfiguration{
+			Status: status,
+		},
+	}
+
+	if err := putBucketVersioning(ctx, client, bucket, input, options); err != nil {
+		t.Fatalf("putBucketVersioning() error = %v", err)
+	}
+	if err := waitForBucketVersioning(ctx, client, bucket, status, options); err != nil {
+		t.Fatalf("waitForBucketVersioning() error = %v", err)
+	}
+
+	if got := len(client.putInputs); got != 2 {
+		t.Fatalf("PutBucketVersioning calls = %d, want 2", got)
+	}
+	for attempt, got := range client.putInputs {
+		if got != input {
+			t.Fatalf("PutBucketVersioning input on attempt %d was rebuilt, want immutable input %p", attempt+1, input)
+		}
+	}
+	if len(client.getInputs) != 2 || client.getInputs[0] != client.getInputs[1] {
+		t.Fatalf("GetBucketVersioning inputs = %#v, want the same input pointer on both attempts", client.getInputs)
+	}
+	if waits != 2 {
+		t.Fatalf("backoff waits = %d, want 2", waits)
+	}
+}
+
+func TestBucketVersioningConvergenceDoesNotRetryUnrelated400(t *testing.T) {
+	t.Parallel()
+
+	client := &scriptedBucketVersioningClient{getErrors: []error{
+		&smithy.GenericAPIError{Code: "InvalidRequest"},
+		nil,
+	}}
+	waits := 0
+
+	err := waitForBucketVersioning(
+		t.Context(),
+		client,
+		"invalid-versioning-test",
+		s3types.BucketVersioningStatusEnabled,
+		immediateSubresourcePhaseOptions(&waits),
+	)
+	if err == nil {
+		t.Fatal("waitForBucketVersioning() error = nil, want permanent failure")
+	}
+	if len(client.getInputs) != 1 || waits != 0 {
+		t.Fatalf("GetBucketVersioning calls = %d, waits = %d, want 1 and 0", len(client.getInputs), waits)
+	}
+}

--- a/coreweave/object_storage/resource_bucket_subresource_convergence_unit_test.go
+++ b/coreweave/object_storage/resource_bucket_subresource_convergence_unit_test.go
@@ -9,8 +9,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/aws/smithy-go"
-	fwresource "github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -56,20 +54,23 @@ func (c *scriptedBucketPolicyClient) GetBucketPolicy(
 }
 
 type scriptedBucketVersioningClient struct {
-	putErrors  []error
-	getErrors  []error
-	getOutputs []*s3.GetBucketVersioningOutput
-	putInputs  []*s3.PutBucketVersioningInput
-	getInputs  []*s3.GetBucketVersioningInput
+	putErrors   []error
+	getErrors   []error
+	getOutputs  []*s3.GetBucketVersioningOutput
+	putInputs   []*s3.PutBucketVersioningInput
+	getInputs   []*s3.GetBucketVersioningInput
+	putContexts []context.Context
+	getContexts []context.Context
 }
 
 func (c *scriptedBucketVersioningClient) PutBucketVersioning(
-	_ context.Context,
+	ctx context.Context,
 	input *s3.PutBucketVersioningInput,
 	_ ...func(*s3.Options),
 ) (*s3.PutBucketVersioningOutput, error) {
 	index := len(c.putInputs)
 	c.putInputs = append(c.putInputs, input)
+	c.putContexts = append(c.putContexts, ctx)
 	if index < len(c.putErrors) && c.putErrors[index] != nil {
 		return nil, c.putErrors[index]
 	}
@@ -77,12 +78,13 @@ func (c *scriptedBucketVersioningClient) PutBucketVersioning(
 }
 
 func (c *scriptedBucketVersioningClient) GetBucketVersioning(
-	_ context.Context,
+	ctx context.Context,
 	input *s3.GetBucketVersioningInput,
 	_ ...func(*s3.Options),
 ) (*s3.GetBucketVersioningOutput, error) {
 	index := len(c.getInputs)
 	c.getInputs = append(c.getInputs, input)
+	c.getContexts = append(c.getContexts, ctx)
 	if index < len(c.getErrors) && c.getErrors[index] != nil {
 		return nil, c.getErrors[index]
 	}
@@ -90,17 +92,6 @@ func (c *scriptedBucketVersioningClient) GetBucketVersioning(
 		return c.getOutputs[index], nil
 	}
 	return &s3.GetBucketVersioningOutput{}, nil
-}
-
-func immediateSubresourcePhaseOptions(waits *int) s3PhaseOptions {
-	return s3PhaseOptions{
-		now:   time.Now,
-		delay: func(int) time.Duration { return 0 },
-		wait: func(ctx context.Context, _ time.Duration) error {
-			*waits = *waits + 1
-			return ctx.Err()
-		},
-	}
 }
 
 func TestBucketPolicyConvergenceRetriesInvalidRegion(t *testing.T) {
@@ -122,10 +113,11 @@ func TestBucketPolicyConvergenceRetriesInvalidRegion(t *testing.T) {
 		getOutputs: []*s3.GetBucketPolicyOutput{
 			nil,
 			{Policy: aws.String(policy)},
+			{Policy: aws.String(policy)},
 		},
 	}
 	waits := 0
-	options := immediateSubresourcePhaseOptions(&waits)
+	options := immediateS3PhaseOptions(&waits)
 	ctx, cancel := bucketPropagationContext(t.Context())
 	defer cancel()
 	input := &s3.PutBucketPolicyInput{
@@ -148,11 +140,11 @@ func TestBucketPolicyConvergenceRetriesInvalidRegion(t *testing.T) {
 			t.Fatalf("PutBucketPolicy input on attempt %d was rebuilt, want immutable input %p", attempt+1, input)
 		}
 	}
-	if len(client.getInputs) != 2 || client.getInputs[0] != client.getInputs[1] {
-		t.Fatalf("GetBucketPolicy inputs = %#v, want the same input pointer on both attempts", client.getInputs)
+	if len(client.getInputs) != 3 || client.getInputs[0] != client.getInputs[1] || client.getInputs[1] != client.getInputs[2] {
+		t.Fatalf("GetBucketPolicy inputs = %#v, want the same input pointer on all attempts", client.getInputs)
 	}
-	if waits != 2 {
-		t.Fatalf("backoff waits = %d, want 2", waits)
+	if waits != 3 {
+		t.Fatalf("backoff waits = %d, want 3", waits)
 	}
 }
 
@@ -169,12 +161,31 @@ func TestBucketPolicyConvergenceDoesNotRetryUnrelated400(t *testing.T) {
 		Policy: aws.String(`{"Version":"2012-10-17","Statement":[]}`),
 	}
 
-	err := putBucketPolicy(t.Context(), client, aws.ToString(input.Bucket), input, immediateSubresourcePhaseOptions(&waits))
+	err := putBucketPolicy(t.Context(), client, aws.ToString(input.Bucket), input, immediateS3PhaseOptions(&waits))
 	if err == nil {
 		t.Fatal("putBucketPolicy() error = nil, want permanent failure")
 	}
 	if got := len(client.putInputs); got != 1 || waits != 0 {
 		t.Fatalf("PutBucketPolicy calls = %d, waits = %d, want 1 and 0", got, waits)
+	}
+}
+
+func TestWaitForBucketPolicyRetriesNilResponse(t *testing.T) {
+	t.Parallel()
+
+	const policy = `{"Version":"2012-10-17","Statement":[]}`
+	client := &scriptedBucketPolicyClient{getOutputs: []*s3.GetBucketPolicyOutput{
+		{},
+		{Policy: aws.String(policy)},
+		{Policy: aws.String(policy)},
+	}}
+	waits := 0
+
+	if err := waitForBucketPolicy(t.Context(), client, "policy-test", policy, immediateS3PhaseOptions(&waits)); err != nil {
+		t.Fatalf("waitForBucketPolicy() error = %v", err)
+	}
+	if len(client.getInputs) != 3 || waits != 2 {
+		t.Fatalf("GetBucketPolicy calls = %d, waits = %d; want 3, 2", len(client.getInputs), waits)
 	}
 }
 
@@ -187,45 +198,25 @@ func TestBucketPolicyCreateRetainsStateWhenReadbackTimesOut(t *testing.T) {
 	)
 	client := &scriptedBucketPolicyClient{getErrors: []error{
 		&smithy.GenericAPIError{Code: errInvalidRegion},
+	}, putErrors: []error{
+		&smithy.GenericAPIError{Code: errInvalidRegion},
+		nil,
 	}}
 	resourceUnderTest := &BucketPolicyResource{
 		s3ClientForConvergence: func(context.Context) (bucketPolicyAPI, error) {
 			return client, nil
 		},
-		bucketPropagationOptions: s3PhaseOptions{
-			now:   time.Now,
-			delay: func(int) time.Duration { return 0 },
-			wait: func(context.Context, time.Duration) error {
-				return context.DeadlineExceeded
-			},
-		},
+		bucketPropagationOptions: s3PhaseOptionsTimingOutOnWait(2),
 	}
 
-	var schemaResponse fwresource.SchemaResponse
-	resourceUnderTest.Schema(t.Context(), fwresource.SchemaRequest{}, &schemaResponse)
-	if schemaResponse.Diagnostics.HasError() {
-		t.Fatalf("bucket policy schema diagnostics: %v", schemaResponse.Diagnostics)
-	}
 	model := BucketPolicyResourceModel{
 		Bucket: types.StringValue(bucket),
 		Policy: types.StringValue(policy),
 	}
-	plan := tfsdk.Plan{Schema: schemaResponse.Schema}
-	if diagnostics := plan.Set(t.Context(), &model); diagnostics.HasError() {
-		t.Fatalf("set test plan: %v", diagnostics)
-	}
-	response := &fwresource.CreateResponse{State: tfsdk.State{Schema: schemaResponse.Schema}}
-
-	resourceUnderTest.Create(t.Context(), fwresource.CreateRequest{Plan: plan}, response)
-
-	if !response.Diagnostics.HasError() {
-		t.Fatal("Create() diagnostics contain no error, want readback timeout")
-	}
-	if len(client.putInputs) != 1 || len(client.getInputs) != 1 {
-		t.Fatalf("S3 calls: Put=%d Get=%d, want 1 and 1", len(client.putInputs), len(client.getInputs))
-	}
-	if client.putContexts[0] != client.getContexts[0] {
-		t.Fatal("PutBucketPolicy and GetBucketPolicy used different propagation contexts")
+	response := runCreateWithModel(t, resourceUnderTest, model)
+	assertWriteRetriedAndRetainedState(t, response.Diagnostics.HasError(), len(client.putInputs), len(client.getInputs), client.putContexts, client.getContexts)
+	if client.putInputs[0] != client.putInputs[1] {
+		t.Fatal("PutBucketPolicy rebuilt its retry input")
 	}
 	var retained BucketPolicyResourceModel
 	if diagnostics := response.State.Get(t.Context(), &retained); diagnostics.HasError() {
@@ -233,6 +224,21 @@ func TestBucketPolicyCreateRetainsStateWhenReadbackTimesOut(t *testing.T) {
 	}
 	if retained.Bucket.ValueString() != bucket || retained.Policy.ValueString() != policy {
 		t.Fatalf("retained state = (%q, %q), want (%q, %q)", retained.Bucket.ValueString(), retained.Policy.ValueString(), bucket, policy)
+	}
+}
+
+func s3PhaseOptionsTimingOutOnWait(timeoutOn int) s3PhaseOptions {
+	waits := 0
+	return s3PhaseOptions{
+		now:   time.Now,
+		delay: func(int) time.Duration { return 0 },
+		wait: func(context.Context, time.Duration) error {
+			waits++
+			if waits >= timeoutOn {
+				return context.DeadlineExceeded
+			}
+			return nil
+		},
 	}
 }
 
@@ -253,10 +259,11 @@ func TestBucketVersioningConvergenceRetriesInvalidRegion(t *testing.T) {
 		getOutputs: []*s3.GetBucketVersioningOutput{
 			nil,
 			{Status: status},
+			{Status: status},
 		},
 	}
 	waits := 0
-	options := immediateSubresourcePhaseOptions(&waits)
+	options := immediateS3PhaseOptions(&waits)
 	ctx, cancel := bucketPropagationContext(t.Context())
 	defer cancel()
 	input := &s3.PutBucketVersioningInput{
@@ -281,11 +288,11 @@ func TestBucketVersioningConvergenceRetriesInvalidRegion(t *testing.T) {
 			t.Fatalf("PutBucketVersioning input on attempt %d was rebuilt, want immutable input %p", attempt+1, input)
 		}
 	}
-	if len(client.getInputs) != 2 || client.getInputs[0] != client.getInputs[1] {
-		t.Fatalf("GetBucketVersioning inputs = %#v, want the same input pointer on both attempts", client.getInputs)
+	if len(client.getInputs) != 3 || client.getInputs[0] != client.getInputs[1] || client.getInputs[1] != client.getInputs[2] {
+		t.Fatalf("GetBucketVersioning inputs = %#v, want the same input pointer on all attempts", client.getInputs)
 	}
-	if waits != 2 {
-		t.Fatalf("backoff waits = %d, want 2", waits)
+	if waits != 3 {
+		t.Fatalf("backoff waits = %d, want 3", waits)
 	}
 }
 
@@ -303,7 +310,7 @@ func TestBucketVersioningConvergenceDoesNotRetryUnrelated400(t *testing.T) {
 		client,
 		"invalid-versioning-test",
 		s3types.BucketVersioningStatusEnabled,
-		immediateSubresourcePhaseOptions(&waits),
+		immediateS3PhaseOptions(&waits),
 	)
 	if err == nil {
 		t.Fatal("waitForBucketVersioning() error = nil, want permanent failure")

--- a/coreweave/object_storage/resource_bucket_versioning.go
+++ b/coreweave/object_storage/resource_bucket_versioning.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
@@ -42,6 +41,11 @@ type BucketVersioningResourceModel struct {
 
 type VersioningConfigurationModel struct {
 	Status types.String `tfsdk:"status"`
+}
+
+type bucketVersioningAPI interface {
+	PutBucketVersioning(context.Context, *s3.PutBucketVersioningInput, ...func(*s3.Options)) (*s3.PutBucketVersioningOutput, error)
+	GetBucketVersioning(context.Context, *s3.GetBucketVersioningInput, ...func(*s3.Options)) (*s3.GetBucketVersioningOutput, error)
 }
 
 func (b *BucketVersioningResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -88,14 +92,40 @@ func (b *BucketVersioningResource) Configure(_ context.Context, req resource.Con
 	b.client = client
 }
 
-func waitForBucketVersioning(parentCtx context.Context, client *s3.Client, bucket string, expected s3types.BucketVersioningStatus) error {
-	return coreweave.PollUntil("bucket versioning configuration", parentCtx, 5*time.Second, 5*time.Minute, func(ctx context.Context) (bool, error) {
-		out, err := client.GetBucketVersioning(ctx, &s3.GetBucketVersioningInput{Bucket: aws.String(bucket)})
+func putBucketVersioning(
+	ctx context.Context,
+	client bucketVersioningAPI,
+	bucket string,
+	input *s3.PutBucketVersioningInput,
+	options s3PhaseOptions,
+) error {
+	return runBucketMutationPhase(ctx, s3PhaseMetadata{
+		phase:  "bucket versioning application",
+		bucket: bucket,
+	}, options, func(ctx context.Context) error {
+		_, err := client.PutBucketVersioning(ctx, input)
+		return err
+	})
+}
+
+func waitForBucketVersioning(
+	ctx context.Context,
+	client bucketVersioningAPI,
+	bucket string,
+	expected s3types.BucketVersioningStatus,
+	options s3PhaseOptions,
+) error {
+	input := &s3.GetBucketVersioningInput{Bucket: aws.String(bucket)}
+	return runBucketReadbackPhase(ctx, s3PhaseMetadata{
+		phase:  "bucket versioning readback",
+		bucket: bucket,
+	}, options, func(ctx context.Context) (bool, error) {
+		out, err := client.GetBucketVersioning(ctx, input)
 		if err != nil {
-			if isTransientS3Error(err) {
-				return false, nil
-			}
 			return false, err
+		}
+		if out == nil {
+			return false, nil
 		}
 
 		return out.Status == expected, nil
@@ -117,20 +147,17 @@ func (b *BucketVersioningResource) Create(ctx context.Context, req resource.Crea
 	}
 
 	status := s3types.BucketVersioningStatus(data.VersioningConfiguration.Status.ValueString())
-	putReq := s3.PutBucketVersioningInput{
+	putReq := &s3.PutBucketVersioningInput{
 		Bucket: aws.String(data.Bucket.ValueString()),
 		VersioningConfiguration: &s3types.VersioningConfiguration{
 			Status: status,
 		},
 	}
-	_, err = s3Client.PutBucketVersioning(ctx, &putReq)
-	if err != nil {
-		handleS3Error(err, &resp.Diagnostics, data.Bucket.ValueString())
-		return
-	}
+	propagationCtx, cancel := bucketPropagationContext(ctx)
+	defer cancel()
 
-	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
-	if resp.Diagnostics.HasError() {
+	if err := putBucketVersioning(propagationCtx, s3Client, data.Bucket.ValueString(), putReq, s3PhaseOptions{}); err != nil {
+		handleS3Error(err, &resp.Diagnostics, data.Bucket.ValueString())
 		return
 	}
 
@@ -141,7 +168,7 @@ func (b *BucketVersioningResource) Create(ctx context.Context, req resource.Crea
 	}
 
 	// wait for bucket versioning to be read back from s3 API since it is not guaranteed to propagate immediately
-	if err := waitForBucketVersioning(ctx, s3Client, data.Bucket.ValueString(), status); err != nil {
+	if err := waitForBucketVersioning(propagationCtx, s3Client, data.Bucket.ValueString(), status, s3PhaseOptions{}); err != nil {
 		handleS3Error(err, &resp.Diagnostics, data.Bucket.ValueString())
 		return
 	}
@@ -193,20 +220,17 @@ func (b *BucketVersioningResource) Update(ctx context.Context, req resource.Upda
 	}
 
 	status := s3types.BucketVersioningStatus(data.VersioningConfiguration.Status.ValueString())
-	putReq := s3.PutBucketVersioningInput{
+	putReq := &s3.PutBucketVersioningInput{
 		Bucket: aws.String(data.Bucket.ValueString()),
 		VersioningConfiguration: &s3types.VersioningConfiguration{
 			Status: status,
 		},
 	}
-	_, err = s3Client.PutBucketVersioning(ctx, &putReq)
-	if err != nil {
-		handleS3Error(err, &resp.Diagnostics, data.Bucket.ValueString())
-		return
-	}
+	propagationCtx, cancel := bucketPropagationContext(ctx)
+	defer cancel()
 
-	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
-	if resp.Diagnostics.HasError() {
+	if err := putBucketVersioning(propagationCtx, s3Client, data.Bucket.ValueString(), putReq, s3PhaseOptions{}); err != nil {
+		handleS3Error(err, &resp.Diagnostics, data.Bucket.ValueString())
 		return
 	}
 
@@ -217,7 +241,7 @@ func (b *BucketVersioningResource) Update(ctx context.Context, req resource.Upda
 	}
 
 	// wait for bucket versioning to be read back from s3 API since it is not guaranteed to propagate immediately
-	if err := waitForBucketVersioning(ctx, s3Client, data.Bucket.ValueString(), status); err != nil {
+	if err := waitForBucketVersioning(propagationCtx, s3Client, data.Bucket.ValueString(), status, s3PhaseOptions{}); err != nil {
 		handleS3Error(err, &resp.Diagnostics, data.Bucket.ValueString())
 		return
 	}

--- a/coreweave/object_storage/resource_bucket_versioning.go
+++ b/coreweave/object_storage/resource_bucket_versioning.go
@@ -31,7 +31,9 @@ func NewBucketVersioningResource() resource.Resource {
 }
 
 type BucketVersioningResource struct {
-	client *coreweave.Client
+	client                   *coreweave.Client
+	s3ClientForConvergence   func(context.Context) (bucketVersioningAPI, error)
+	bucketPropagationOptions s3PhaseOptions
 }
 
 type BucketVersioningResourceModel struct {
@@ -132,6 +134,13 @@ func waitForBucketVersioning(
 	})
 }
 
+func (b *BucketVersioningResource) convergenceClient(ctx context.Context) (bucketVersioningAPI, error) {
+	if b.s3ClientForConvergence != nil {
+		return b.s3ClientForConvergence(ctx)
+	}
+	return b.client.S3Client(ctx, "")
+}
+
 func (b *BucketVersioningResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var data BucketVersioningResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
@@ -140,7 +149,7 @@ func (b *BucketVersioningResource) Create(ctx context.Context, req resource.Crea
 		return
 	}
 
-	s3Client, err := b.client.S3Client(ctx, "")
+	s3Client, err := b.convergenceClient(ctx)
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to create S3 client", err.Error())
 		return
@@ -156,7 +165,7 @@ func (b *BucketVersioningResource) Create(ctx context.Context, req resource.Crea
 	propagationCtx, cancel := bucketPropagationContext(ctx)
 	defer cancel()
 
-	if err := putBucketVersioning(propagationCtx, s3Client, data.Bucket.ValueString(), putReq, s3PhaseOptions{}); err != nil {
+	if err := putBucketVersioning(propagationCtx, s3Client, data.Bucket.ValueString(), putReq, b.bucketPropagationOptions); err != nil {
 		handleS3Error(err, &resp.Diagnostics, data.Bucket.ValueString())
 		return
 	}
@@ -168,7 +177,7 @@ func (b *BucketVersioningResource) Create(ctx context.Context, req resource.Crea
 	}
 
 	// wait for bucket versioning to be read back from s3 API since it is not guaranteed to propagate immediately
-	if err := waitForBucketVersioning(propagationCtx, s3Client, data.Bucket.ValueString(), status, s3PhaseOptions{}); err != nil {
+	if err := waitForBucketVersioning(propagationCtx, s3Client, data.Bucket.ValueString(), status, b.bucketPropagationOptions); err != nil {
 		handleS3Error(err, &resp.Diagnostics, data.Bucket.ValueString())
 		return
 	}
@@ -213,7 +222,7 @@ func (b *BucketVersioningResource) Update(ctx context.Context, req resource.Upda
 		return
 	}
 
-	s3Client, err := b.client.S3Client(ctx, "")
+	s3Client, err := b.convergenceClient(ctx)
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to create S3 client", err.Error())
 		return
@@ -229,7 +238,7 @@ func (b *BucketVersioningResource) Update(ctx context.Context, req resource.Upda
 	propagationCtx, cancel := bucketPropagationContext(ctx)
 	defer cancel()
 
-	if err := putBucketVersioning(propagationCtx, s3Client, data.Bucket.ValueString(), putReq, s3PhaseOptions{}); err != nil {
+	if err := putBucketVersioning(propagationCtx, s3Client, data.Bucket.ValueString(), putReq, b.bucketPropagationOptions); err != nil {
 		handleS3Error(err, &resp.Diagnostics, data.Bucket.ValueString())
 		return
 	}
@@ -241,7 +250,7 @@ func (b *BucketVersioningResource) Update(ctx context.Context, req resource.Upda
 	}
 
 	// wait for bucket versioning to be read back from s3 API since it is not guaranteed to propagate immediately
-	if err := waitForBucketVersioning(propagationCtx, s3Client, data.Bucket.ValueString(), status, s3PhaseOptions{}); err != nil {
+	if err := waitForBucketVersioning(propagationCtx, s3Client, data.Bucket.ValueString(), status, b.bucketPropagationOptions); err != nil {
 		handleS3Error(err, &resp.Diagnostics, data.Bucket.ValueString())
 		return
 	}

--- a/coreweave/object_storage/s3_convergence.go
+++ b/coreweave/object_storage/s3_convergence.go
@@ -1,0 +1,263 @@
+package objectstorage
+
+import (
+	"context"
+	cryptorand "crypto/rand"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"math/big"
+	"net"
+	standardhttp "net/http"
+	"net/url"
+	"time"
+
+	"github.com/aws/smithy-go"
+	smithyhttp "github.com/aws/smithy-go/transport/http"
+	"github.com/coreweave/terraform-provider-coreweave/coreweave"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+const (
+	bucketPropagationTimeout        = 5 * time.Minute
+	bucketPropagationInitialBackoff = 500 * time.Millisecond
+	bucketPropagationMaxBackoff     = 5 * time.Second
+)
+
+type s3PhaseOptions struct {
+	now   func() time.Time
+	delay func(attempt int) time.Duration
+	wait  func(context.Context, time.Duration) error
+}
+
+func (options s3PhaseOptions) withDefaults() s3PhaseOptions {
+	if options.now == nil {
+		options.now = time.Now
+	}
+	if options.delay == nil {
+		options.delay = bucketPropagationBackoff
+	}
+	if options.wait == nil {
+		options.wait = waitForS3Backoff
+	}
+	return options
+}
+
+type s3PhaseMetadata struct {
+	phase  string
+	bucket string
+	zone   string
+}
+
+type s3PhaseError struct {
+	phase    string
+	attempts int
+	elapsed  time.Duration
+	err      error
+}
+
+func (e *s3PhaseError) Error() string {
+	return fmt.Sprintf("%s failed after %d attempt(s) in %s: %v", e.phase, e.attempts, e.elapsed.Round(time.Millisecond), e.err)
+}
+
+func (e *s3PhaseError) Unwrap() error {
+	return e.err
+}
+
+func bucketPropagationContext(parent context.Context) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(parent, bucketPropagationTimeout)
+}
+
+func runS3Phase(
+	ctx context.Context,
+	metadata s3PhaseMetadata,
+	options s3PhaseOptions,
+	attempt func(context.Context) (bool, error),
+	retryable func(error) bool,
+) error {
+	options = options.withDefaults()
+	started := options.now()
+
+	for attemptNumber := 1; ; attemptNumber++ {
+		if err := ctx.Err(); err != nil {
+			return &s3PhaseError{phase: metadata.phase, attempts: attemptNumber - 1, elapsed: options.now().Sub(started), err: err}
+		}
+
+		done, err := attempt(ctx)
+		if err == nil && done {
+			return nil
+		}
+		if err != nil && !retryable(err) {
+			return &s3PhaseError{phase: metadata.phase, attempts: attemptNumber, elapsed: options.now().Sub(started), err: err}
+		}
+
+		delay := options.delay(attemptNumber)
+		errorClass, errorCode := s3ErrorMetadata(err)
+		logFields := map[string]interface{}{
+			"attempt":     attemptNumber,
+			"bucket":      metadata.bucket,
+			"elapsed":     options.now().Sub(started).String(),
+			"error_class": errorClass,
+			"error_code":  errorCode,
+			"next_delay":  delay.String(),
+			"phase":       metadata.phase,
+		}
+		if metadata.zone != "" {
+			logFields["zone"] = metadata.zone
+		}
+		tflog.Debug(ctx, "waiting for S3 operation convergence", logFields)
+		if waitErr := options.wait(ctx, delay); waitErr != nil {
+			return &s3PhaseError{phase: metadata.phase, attempts: attemptNumber, elapsed: options.now().Sub(started), err: waitErr}
+		}
+	}
+}
+
+func runBucketMutationPhase(
+	ctx context.Context,
+	metadata s3PhaseMetadata,
+	options s3PhaseOptions,
+	mutate func(context.Context) error,
+) error {
+	return runS3Phase(ctx, metadata, options, func(ctx context.Context) (bool, error) {
+		err := mutate(ctx)
+		return err == nil, err
+	}, isBucketPropagationRetryableS3Error)
+}
+
+func runBucketReadbackPhase(
+	ctx context.Context,
+	metadata s3PhaseMetadata,
+	options s3PhaseOptions,
+	converged func(context.Context) (bool, error),
+) error {
+	return runS3Phase(ctx, metadata, options, converged, isBucketPropagationRetryableS3Error)
+}
+
+func bucketPropagationBackoff(attempt int) time.Duration {
+	shift := min(max(attempt-1, 0), 4)
+	delay := bucketPropagationInitialBackoff << shift
+	if delay > bucketPropagationMaxBackoff {
+		delay = bucketPropagationMaxBackoff
+	}
+	half := delay / 2
+	jitter, err := cryptorand.Int(cryptorand.Reader, big.NewInt(int64(half)+1))
+	if err != nil {
+		return delay
+	}
+	return half + time.Duration(jitter.Int64())
+}
+
+func waitForS3Backoff(ctx context.Context, delay time.Duration) error {
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+func isBucketPropagationRetryableS3Error(err error) bool {
+	if err == nil || errors.Is(err, context.Canceled) || isPermanentTransportError(err) {
+		return false
+	}
+
+	var apiErr smithy.APIError
+	hasAPIError := errors.As(err, &apiErr)
+	if hasAPIError && isPermanentBucketAPIError(apiErr.ErrorCode()) {
+		return false
+	}
+
+	if status, ok := s3HTTPStatus(err); ok && isTransientS3HTTPStatus(status, true) {
+		return true
+	}
+	if hasAPIError {
+		return isTransientBucketAPIError(apiErr.ErrorCode(), true)
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+
+	var urlErr *url.Error
+	if errors.As(err, &urlErr) {
+		return true
+	}
+	var netErr net.Error
+	return errors.As(err, &netErr)
+}
+
+func isPermanentBucketAPIError(code string) bool {
+	switch code {
+	case "AccessDenied", "AuthorizationHeaderMalformed", "InvalidAccessKeyId",
+		"InvalidArgument", "InvalidBucketName", "InvalidRequest", "InvalidToken",
+		"SignatureDoesNotMatch":
+		return true
+	default:
+		return false
+	}
+}
+
+func isTransientBucketAPIError(code string, includePropagation bool) bool {
+	if includePropagation {
+		switch code {
+		case errInvalidRegion, ErrNoSuchBucket, errNotFound, errNoSuchTagSet:
+			return true
+		}
+	}
+
+	switch code {
+	case "BadGateway", "GatewayTimeout", "InternalError", "InternalServerError",
+		"RequestTimeout", "RequestTimeoutException", "ServiceUnavailable", "SlowDown",
+		"TooManyRequests":
+		return true
+	default:
+		return false
+	}
+}
+
+func isTransientS3HTTPStatus(status int, includeNotFound bool) bool {
+	if includeNotFound && status == standardhttp.StatusNotFound {
+		return true
+	}
+	return status == standardhttp.StatusRequestTimeout ||
+		status == standardhttp.StatusTooManyRequests ||
+		status == standardhttp.StatusInternalServerError ||
+		status == standardhttp.StatusBadGateway ||
+		status == standardhttp.StatusServiceUnavailable ||
+		status == standardhttp.StatusGatewayTimeout
+}
+
+func isPermanentTransportError(err error) bool {
+	return coreweave.IsPermanentRequestError(err)
+}
+
+func s3HTTPStatus(err error) (int, bool) {
+	var responseErr *smithyhttp.ResponseError
+	if !errors.As(err, &responseErr) || responseErr.Response == nil {
+		return 0, false
+	}
+	return responseErr.Response.StatusCode, true
+}
+
+func s3ErrorMetadata(err error) (class, code string) {
+	if err == nil {
+		return "not_converged", ""
+	}
+	var apiErr smithy.APIError
+	if errors.As(err, &apiErr) {
+		return "api", apiErr.ErrorCode()
+	}
+	if status, ok := s3HTTPStatus(err); ok {
+		return "http", fmt.Sprintf("%d", status)
+	}
+	var certificateErr *tls.CertificateVerificationError
+	if errors.As(err, &certificateErr) {
+		return "tls_certificate", ""
+	}
+	var urlErr *url.Error
+	if errors.As(err, &urlErr) {
+		return "network", ""
+	}
+	return "unknown", ""
+}

--- a/coreweave/object_storage/s3_convergence.go
+++ b/coreweave/object_storage/s3_convergence.go
@@ -22,6 +22,7 @@ const (
 	bucketPropagationTimeout        = 5 * time.Minute
 	bucketPropagationInitialBackoff = 500 * time.Millisecond
 	bucketPropagationMaxBackoff     = 5 * time.Second
+	bucketReadbackConfirmations     = 2
 )
 
 type s3PhaseOptions struct {
@@ -145,7 +146,21 @@ func runBucketReadbackPhase(
 	options s3PhaseOptions,
 	converged func(context.Context) (bool, error),
 ) error {
-	return runS3Phase(ctx, metadata, options, converged, isBucketPropagationRetryableS3Error)
+	// A matching response is request-local evidence, not a service readiness
+	// guarantee. Require a second sample through the normal backoff path so a
+	// match from one gateway does not immediately end reconciliation.
+	metadata.sharedPropagationBudget = true
+	consecutiveMatches := 0
+	return runS3Phase(ctx, metadata, options, func(ctx context.Context) (bool, error) {
+		matched, err := converged(ctx)
+		if err != nil || !matched {
+			consecutiveMatches = 0
+			return false, err
+		}
+
+		consecutiveMatches++
+		return consecutiveMatches >= bucketReadbackConfirmations, nil
+	}, isBucketPropagationRetryableS3Error)
 }
 
 func bucketPropagationBackoff(attempt int) time.Duration {

--- a/coreweave/object_storage/s3_convergence.go
+++ b/coreweave/object_storage/s3_convergence.go
@@ -121,7 +121,7 @@ func runBucketMutationPhase(
 	return runS3Phase(ctx, metadata, options, func(ctx context.Context) (bool, error) {
 		err := mutate(ctx)
 		return err == nil, err
-	}, isBucketPropagationRetryableS3Error)
+	}, isBucketSubresourceMutationRetryableS3Error)
 }
 
 func runBucketReadbackPhase(
@@ -156,6 +156,22 @@ func waitForS3Backoff(ctx context.Context, delay time.Duration) error {
 	case <-timer.C:
 		return nil
 	}
+}
+
+func isBucketSubresourceMutationRetryableS3Error(err error) bool {
+	if status, ok := s3HTTPStatus(err); ok && status == standardhttp.StatusNotFound {
+		return false
+	}
+
+	var apiErr smithy.APIError
+	if errors.As(err, &apiErr) {
+		switch apiErr.ErrorCode() {
+		case ErrNoSuchBucket, errNotFound, errNoSuchTagSet:
+			return false
+		}
+	}
+
+	return isBucketPropagationRetryableS3Error(err)
 }
 
 func isBucketPropagationRetryableS3Error(err error) bool {

--- a/coreweave/object_storage/s3_convergence.go
+++ b/coreweave/object_storage/s3_convergence.go
@@ -46,10 +46,9 @@ func (options s3PhaseOptions) withDefaults() s3PhaseOptions {
 }
 
 type s3PhaseMetadata struct {
-	phase                   string
-	bucket                  string
-	zone                    string
-	sharedPropagationBudget bool
+	phase  string
+	bucket string
+	zone   string
 }
 
 type s3PhaseError struct {
@@ -87,9 +86,6 @@ func runS3Phase(
 
 	for attemptNumber := 1; ; attemptNumber++ {
 		if err := ctx.Err(); err != nil {
-			if attemptNumber == 1 && metadata.sharedPropagationBudget && errors.Is(err, context.DeadlineExceeded) {
-				err = fmt.Errorf("shared propagation deadline exhausted before phase start: %w", err)
-			}
 			if lastAttemptErr != nil {
 				err = errors.Join(err, lastAttemptErr)
 			}
@@ -158,11 +154,20 @@ func runBucketReadbackPhase(
 		return delay
 	}
 
+	// Readback always follows a mutation on the same propagation context. If
+	// that shared budget is already spent, name it rather than reporting a
+	// bare deadline the caller cannot attribute to either phase.
+	if err := ctx.Err(); errors.Is(err, context.DeadlineExceeded) {
+		return &s3PhaseError{
+			phase: metadata.phase,
+			err:   fmt.Errorf("shared propagation deadline exhausted before phase start: %w", err),
+		}
+	}
+
 	// A matching response is request-local evidence, not a service readiness
 	// guarantee. Try immediately, then require a second matching sample after
 	// a minimum confirmation delay so a match from one gateway or cache
 	// generation does not immediately end reconciliation.
-	metadata.sharedPropagationBudget = true
 	consecutiveMatches := 0
 	return runS3Phase(ctx, metadata, options, func(ctx context.Context) (bool, error) {
 		matched, err := converged(ctx)

--- a/coreweave/object_storage/s3_convergence.go
+++ b/coreweave/object_storage/s3_convergence.go
@@ -23,6 +23,7 @@ const (
 	bucketPropagationInitialBackoff = 500 * time.Millisecond
 	bucketPropagationMaxBackoff     = 5 * time.Second
 	bucketReadbackConfirmations     = 2
+	bucketReadbackConfirmationDelay = 5 * time.Second
 )
 
 type s3PhaseOptions struct {
@@ -146,19 +147,33 @@ func runBucketReadbackPhase(
 	options s3PhaseOptions,
 	converged func(context.Context) (bool, error),
 ) error {
+	options = options.withDefaults()
+	baseDelay := options.delay
+	waitingForConfirmation := false
+	options.delay = func(attempt int) time.Duration {
+		delay := baseDelay(attempt)
+		if waitingForConfirmation && delay < bucketReadbackConfirmationDelay {
+			return bucketReadbackConfirmationDelay
+		}
+		return delay
+	}
+
 	// A matching response is request-local evidence, not a service readiness
-	// guarantee. Require a second sample through the normal backoff path so a
-	// match from one gateway does not immediately end reconciliation.
+	// guarantee. Try immediately, then require a second matching sample after
+	// a minimum confirmation delay so a match from one gateway or cache
+	// generation does not immediately end reconciliation.
 	metadata.sharedPropagationBudget = true
 	consecutiveMatches := 0
 	return runS3Phase(ctx, metadata, options, func(ctx context.Context) (bool, error) {
 		matched, err := converged(ctx)
 		if err != nil || !matched {
 			consecutiveMatches = 0
+			waitingForConfirmation = false
 			return false, err
 		}
 
 		consecutiveMatches++
+		waitingForConfirmation = consecutiveMatches < bucketReadbackConfirmations
 		return consecutiveMatches >= bucketReadbackConfirmations, nil
 	}, isBucketPropagationRetryableS3Error)
 }

--- a/coreweave/object_storage/s3_convergence.go
+++ b/coreweave/object_storage/s3_convergence.go
@@ -44,9 +44,10 @@ func (options s3PhaseOptions) withDefaults() s3PhaseOptions {
 }
 
 type s3PhaseMetadata struct {
-	phase  string
-	bucket string
-	zone   string
+	phase                   string
+	bucket                  string
+	zone                    string
+	sharedPropagationBudget bool
 }
 
 type s3PhaseError struct {
@@ -57,6 +58,9 @@ type s3PhaseError struct {
 }
 
 func (e *s3PhaseError) Error() string {
+	if e.attempts == 0 {
+		return fmt.Sprintf("%s could not start after %s: %v", e.phase, e.elapsed.Round(time.Millisecond), e.err)
+	}
 	return fmt.Sprintf("%s failed after %d attempt(s) in %s: %v", e.phase, e.attempts, e.elapsed.Round(time.Millisecond), e.err)
 }
 
@@ -77,13 +81,21 @@ func runS3Phase(
 ) error {
 	options = options.withDefaults()
 	started := options.now()
+	var lastAttemptErr error
 
 	for attemptNumber := 1; ; attemptNumber++ {
 		if err := ctx.Err(); err != nil {
+			if attemptNumber == 1 && metadata.sharedPropagationBudget && errors.Is(err, context.DeadlineExceeded) {
+				err = fmt.Errorf("shared propagation deadline exhausted before phase start: %w", err)
+			}
+			if lastAttemptErr != nil {
+				err = errors.Join(err, lastAttemptErr)
+			}
 			return &s3PhaseError{phase: metadata.phase, attempts: attemptNumber - 1, elapsed: options.now().Sub(started), err: err}
 		}
 
 		done, err := attempt(ctx)
+		lastAttemptErr = err
 		if err == nil && done {
 			return nil
 		}
@@ -107,6 +119,9 @@ func runS3Phase(
 		}
 		tflog.Debug(ctx, "waiting for S3 operation convergence", logFields)
 		if waitErr := options.wait(ctx, delay); waitErr != nil {
+			if lastAttemptErr != nil {
+				waitErr = errors.Join(waitErr, lastAttemptErr)
+			}
 			return &s3PhaseError{phase: metadata.phase, attempts: attemptNumber, elapsed: options.now().Sub(started), err: waitErr}
 		}
 	}

--- a/coreweave/object_storage/s3_convergence_test.go
+++ b/coreweave/object_storage/s3_convergence_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/aws/smithy-go"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 )
 
 func TestRunBucketMutationPhaseRetriesInvalidRegion(t *testing.T) {
@@ -68,6 +69,46 @@ func TestRunBucketMutationPhaseDoesNotRetryPermanentErrors(t *testing.T) {
 	}
 }
 
+func TestRunBucketMutationPhaseDoesNotRetryMissingResources(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]error{
+		"NoSuchBucket": &smithy.GenericAPIError{Code: ErrNoSuchBucket},
+		"NotFound":     &smithy.GenericAPIError{Code: errNotFound},
+		"NoSuchTagSet": &smithy.GenericAPIError{Code: errNoSuchTagSet},
+		"HTTP 404":     responseErrorWithCause(t, 404, errors.New("not found")),
+	}
+	for name, mutationErr := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			calls := 0
+			waits := 0
+			err := runBucketMutationPhase(
+				t.Context(),
+				s3PhaseMetadata{phase: "test mutation", bucket: "missing"},
+				s3PhaseOptions{
+					delay: func(int) time.Duration { return 0 },
+					wait: func(context.Context, time.Duration) error {
+						waits++
+						return context.DeadlineExceeded
+					},
+				},
+				func(context.Context) error {
+					calls++
+					return mutationErr
+				},
+			)
+			if err == nil {
+				t.Fatal("runBucketMutationPhase() error = nil, want permanent failure")
+			}
+			if calls != 1 || waits != 0 {
+				t.Fatalf("calls = %d, waits = %d; want 1, 0", calls, waits)
+			}
+		})
+	}
+}
+
 func TestRunBucketReadbackPhaseRetriesNonConvergedResult(t *testing.T) {
 	t.Parallel()
 
@@ -79,14 +120,101 @@ func TestRunBucketReadbackPhaseRetriesNonConvergedResult(t *testing.T) {
 		immediateS3PhaseOptions(&waits),
 		func(context.Context) (bool, error) {
 			calls++
-			return calls == 3, nil
+			return calls >= 3, nil
 		},
 	)
 	if err != nil {
 		t.Fatalf("runBucketReadbackPhase() error = %v", err)
 	}
-	if calls != 3 || waits != 2 {
-		t.Fatalf("calls = %d, waits = %d; want 3, 2", calls, waits)
+	if calls != 4 || waits != 3 {
+		t.Fatalf("calls = %d, waits = %d; want 4, 3", calls, waits)
+	}
+}
+
+func TestRunBucketReadbackPhaseRequiresStableConvergence(t *testing.T) {
+	t.Parallel()
+
+	results := []bool{true, false, true, true}
+	calls := 0
+	waits := 0
+	err := runBucketReadbackPhase(
+		t.Context(),
+		s3PhaseMetadata{phase: "test readback", bucket: "target"},
+		immediateS3PhaseOptions(&waits),
+		func(context.Context) (bool, error) {
+			if calls >= len(results) {
+				t.Fatalf("readback called more than %d times", len(results))
+			}
+			result := results[calls]
+			calls++
+			return result, nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("runBucketReadbackPhase() error = %v", err)
+	}
+	if calls != len(results) || waits != len(results)-1 {
+		t.Fatalf("calls = %d, waits = %d; want %d, %d", calls, waits, len(results), len(results)-1)
+	}
+}
+
+func TestRunBucketReadbackPhaseResetsConfirmationAfterRetryableError(t *testing.T) {
+	t.Parallel()
+
+	results := []struct {
+		matched bool
+		err     error
+	}{
+		{matched: true},
+		{err: &smithy.GenericAPIError{Code: errInvalidRegion}},
+		{matched: true},
+		{matched: true},
+	}
+	calls := 0
+	waits := 0
+	err := runBucketReadbackPhase(
+		t.Context(),
+		s3PhaseMetadata{phase: "test readback", bucket: "target"},
+		immediateS3PhaseOptions(&waits),
+		func(context.Context) (bool, error) {
+			if calls >= len(results) {
+				t.Fatalf("readback called more than %d times", len(results))
+			}
+			result := results[calls]
+			calls++
+			return result.matched, result.err
+		},
+	)
+	if err != nil {
+		t.Fatalf("runBucketReadbackPhase() error = %v", err)
+	}
+	if calls != len(results) || waits != len(results)-1 {
+		t.Fatalf("calls = %d, waits = %d; want %d, %d", calls, waits, len(results), len(results)-1)
+	}
+}
+
+func TestRunBucketReadbackPhaseStopsOnPermanentErrorAfterMatch(t *testing.T) {
+	t.Parallel()
+
+	calls := 0
+	waits := 0
+	err := runBucketReadbackPhase(
+		t.Context(),
+		s3PhaseMetadata{phase: "test readback", bucket: "target"},
+		immediateS3PhaseOptions(&waits),
+		func(context.Context) (bool, error) {
+			calls++
+			if calls == 1 {
+				return true, nil
+			}
+			return false, &smithy.GenericAPIError{Code: "AccessDenied"}
+		},
+	)
+	if err == nil {
+		t.Fatal("runBucketReadbackPhase() error = nil, want permanent failure")
+	}
+	if calls != 2 || waits != 1 {
+		t.Fatalf("calls = %d, waits = %d; want 2, 1", calls, waits)
 	}
 }
 
@@ -129,11 +257,19 @@ func TestRunBucketMutationPhaseReportsBoundedFailure(t *testing.T) {
 		},
 		func(context.Context) error {
 			calls++
-			return &smithy.GenericAPIError{Code: errInvalidRegion}
+			return &smithy.OperationError{
+				ServiceID:     "S3",
+				OperationName: "PutBucketPolicy",
+				Err:           &smithy.GenericAPIError{Code: errInvalidRegion, Message: "region does not match"},
+			}
 		},
 	)
 	if !errors.Is(err, context.DeadlineExceeded) {
 		t.Fatalf("runBucketMutationPhase() error = %v, want context.DeadlineExceeded", err)
+	}
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) || apiErr.ErrorCode() != errInvalidRegion {
+		t.Fatalf("runBucketMutationPhase() error = %v, want preserved InvalidRegion", err)
 	}
 	var phaseErr *s3PhaseError
 	if !errors.As(err, &phaseErr) {
@@ -144,6 +280,72 @@ func TestRunBucketMutationPhaseReportsBoundedFailure(t *testing.T) {
 	}
 	if message := err.Error(); !strings.Contains(message, "bucket policy application failed after 1 attempt") {
 		t.Fatalf("error = %q, want phase and attempt diagnostics", message)
+	}
+	if message := err.Error(); !strings.Contains(message, errInvalidRegion) || !strings.Contains(message, context.DeadlineExceeded.Error()) {
+		t.Fatalf("error = %q, want InvalidRegion and deadline diagnostics", message)
+	}
+
+	var diagnostics diag.Diagnostics
+	handleS3Error(err, &diagnostics, "target")
+	if len(diagnostics.Errors()) != 1 {
+		t.Fatalf("handleS3Error() diagnostics = %v, want one error", diagnostics)
+	}
+	detail := diagnostics.Errors()[0].Detail()
+	for _, expected := range []string{"bucket policy application", "1 attempt", "PutBucketPolicy", errInvalidRegion, context.DeadlineExceeded.Error()} {
+		if !strings.Contains(detail, expected) {
+			t.Fatalf("handleS3Error() detail = %q, want %q", detail, expected)
+		}
+	}
+}
+
+func TestRunBucketReadbackPhaseReportsExhaustedSharedBudget(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithDeadline(t.Context(), time.Now().Add(-time.Second))
+	defer cancel()
+
+	calls := 0
+	err := runBucketReadbackPhase(
+		ctx,
+		s3PhaseMetadata{phase: "bucket policy readback", bucket: "target"},
+		s3PhaseOptions{},
+		func(context.Context) (bool, error) {
+			calls++
+			return false, nil
+		},
+	)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("runBucketReadbackPhase() error = %v, want context.DeadlineExceeded", err)
+	}
+	if calls != 0 {
+		t.Fatalf("readback calls = %d, want 0", calls)
+	}
+	if message := err.Error(); !strings.Contains(message, "could not start") || !strings.Contains(message, "shared propagation deadline exhausted") {
+		t.Fatalf("error = %q, want shared-budget-exhausted-before-start diagnostic", message)
+	}
+}
+
+func TestRunS3PhaseDoesNotMislabelIndependentDeadline(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithDeadline(t.Context(), time.Now().Add(-time.Second))
+	defer cancel()
+
+	err := runS3Phase(
+		ctx,
+		s3PhaseMetadata{phase: "ambiguous bucket create reconciliation", bucket: "target"},
+		s3PhaseOptions{},
+		func(context.Context) (bool, error) {
+			t.Fatal("attempt called with an expired context")
+			return false, nil
+		},
+		isBucketPropagationRetryableS3Error,
+	)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("runS3Phase() error = %v, want context.DeadlineExceeded", err)
+	}
+	if message := err.Error(); strings.Contains(message, "shared propagation deadline") {
+		t.Fatalf("error = %q, should not label an independent deadline as shared", message)
 	}
 }
 

--- a/coreweave/object_storage/s3_convergence_test.go
+++ b/coreweave/object_storage/s3_convergence_test.go
@@ -11,40 +11,53 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 )
 
-func TestRunBucketMutationPhaseRetriesInvalidRegion(t *testing.T) {
+func TestIsBucketSubresourceMutationRetryableS3Error(t *testing.T) {
 	t.Parallel()
 
-	calls := 0
-	waits := 0
-	err := runBucketMutationPhase(
-		t.Context(),
-		s3PhaseMetadata{phase: "test mutation", bucket: "target"},
-		immediateS3PhaseOptions(&waits),
-		func(context.Context) error {
-			calls++
-			if calls == 1 {
-				return &smithy.GenericAPIError{Code: errInvalidRegion}
-			}
-			return nil
-		},
-	)
-	if err != nil {
-		t.Fatalf("runBucketMutationPhase() error = %v", err)
+	tests := map[string]struct {
+		err  error
+		want bool
+	}{
+		"InvalidRegion": {err: &smithy.GenericAPIError{Code: errInvalidRegion}, want: true},
+		"HTTP 503":      {err: responseErrorWithCause(t, 503, errors.New("unavailable")), want: true},
+		"NoSuchBucket":  {err: &smithy.GenericAPIError{Code: ErrNoSuchBucket}},
+		"NotFound":      {err: &smithy.GenericAPIError{Code: errNotFound}},
+		"NoSuchTagSet":  {err: &smithy.GenericAPIError{Code: errNoSuchTagSet}},
+		"HTTP 404":      {err: responseErrorWithCause(t, 404, errors.New("not found"))},
+		"AccessDenied":  {err: &smithy.GenericAPIError{Code: "AccessDenied"}},
+		"HTTP 400":      {err: responseErrorWithCause(t, 400, &smithy.GenericAPIError{Code: "BadRequest"})},
 	}
-	if calls != 2 || waits != 1 {
-		t.Fatalf("calls = %d, waits = %d; want 2, 1", calls, waits)
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			if got := isBucketSubresourceMutationRetryableS3Error(test.err); got != test.want {
+				t.Fatalf("isBucketSubresourceMutationRetryableS3Error() = %t, want %t", got, test.want)
+			}
+		})
 	}
 }
 
-func TestRunBucketMutationPhaseDoesNotRetryPermanentErrors(t *testing.T) {
+func TestRunBucketMutationPhaseUsesMutationClassifier(t *testing.T) {
 	t.Parallel()
 
-	tests := map[string]error{
-		"generic non-head 400": responseErrorWithCause(t, 400, &smithy.GenericAPIError{Code: "BadRequest"}),
-		"access denied":        &smithy.GenericAPIError{Code: "AccessDenied"},
-		"invalid signature":    &smithy.GenericAPIError{Code: "SignatureDoesNotMatch"},
+	tests := map[string]struct {
+		errors    []error
+		wantError bool
+		wantCalls int
+		wantWaits int
+	}{
+		"retries InvalidRegion": {
+			errors:    []error{&smithy.GenericAPIError{Code: errInvalidRegion}, nil},
+			wantCalls: 2,
+			wantWaits: 1,
+		},
+		"does not retry NoSuchBucket": {
+			errors:    []error{&smithy.GenericAPIError{Code: ErrNoSuchBucket}},
+			wantError: true,
+			wantCalls: 1,
+		},
 	}
-	for name, mutationErr := range tests {
+	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -55,106 +68,80 @@ func TestRunBucketMutationPhaseDoesNotRetryPermanentErrors(t *testing.T) {
 				s3PhaseMetadata{phase: "test mutation", bucket: "target"},
 				immediateS3PhaseOptions(&waits),
 				func(context.Context) error {
+					if calls >= len(test.errors) {
+						t.Fatalf("mutation called more than %d times", len(test.errors))
+					}
+					err := test.errors[calls]
 					calls++
-					return mutationErr
+					return err
 				},
 			)
-			if err == nil {
-				t.Fatal("runBucketMutationPhase() error = nil, want permanent failure")
+			if (err != nil) != test.wantError {
+				t.Fatalf("runBucketMutationPhase() error = %v, wantError %t", err, test.wantError)
 			}
-			if calls != 1 || waits != 0 {
-				t.Fatalf("calls = %d, waits = %d; want 1, 0", calls, waits)
+			if calls != test.wantCalls || waits != test.wantWaits {
+				t.Fatalf("calls = %d, waits = %d; want %d, %d", calls, waits, test.wantCalls, test.wantWaits)
 			}
 		})
 	}
 }
 
-func TestRunBucketMutationPhaseDoesNotRetryMissingResources(t *testing.T) {
+func TestRunBucketReadbackPhaseUsesStableConvergence(t *testing.T) {
 	t.Parallel()
 
-	tests := map[string]error{
-		"NoSuchBucket": &smithy.GenericAPIError{Code: ErrNoSuchBucket},
-		"NotFound":     &smithy.GenericAPIError{Code: errNotFound},
-		"NoSuchTagSet": &smithy.GenericAPIError{Code: errNoSuchTagSet},
-		"HTTP 404":     responseErrorWithCause(t, 404, errors.New("not found")),
+	type sample struct {
+		matched bool
+		err     error
 	}
-	for name, mutationErr := range tests {
+	tests := map[string]struct {
+		samples   []sample
+		wantError bool
+	}{
+		"misses before convergence": {
+			samples: []sample{{}, {}, {matched: true}, {matched: true}},
+		},
+		"mismatch resets confirmation": {
+			samples: []sample{{matched: true}, {}, {matched: true}, {matched: true}},
+		},
+		"retryable error resets confirmation": {
+			samples: []sample{
+				{matched: true},
+				{err: &smithy.GenericAPIError{Code: errInvalidRegion}},
+				{matched: true},
+				{matched: true},
+			},
+		},
+		"permanent error stops after match": {
+			samples:   []sample{{matched: true}, {err: &smithy.GenericAPIError{Code: "AccessDenied"}}},
+			wantError: true,
+		},
+	}
+	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
 			calls := 0
 			waits := 0
-			err := runBucketMutationPhase(
+			err := runBucketReadbackPhase(
 				t.Context(),
-				s3PhaseMetadata{phase: "test mutation", bucket: "missing"},
-				s3PhaseOptions{
-					delay: func(int) time.Duration { return 0 },
-					wait: func(context.Context, time.Duration) error {
-						waits++
-						return context.DeadlineExceeded
-					},
-				},
-				func(context.Context) error {
+				s3PhaseMetadata{phase: "test readback", bucket: "target"},
+				immediateS3PhaseOptions(&waits),
+				func(context.Context) (bool, error) {
+					if calls >= len(test.samples) {
+						t.Fatalf("readback called more than %d times", len(test.samples))
+					}
+					sample := test.samples[calls]
 					calls++
-					return mutationErr
+					return sample.matched, sample.err
 				},
 			)
-			if err == nil {
-				t.Fatal("runBucketMutationPhase() error = nil, want permanent failure")
+			if (err != nil) != test.wantError {
+				t.Fatalf("runBucketReadbackPhase() error = %v, wantError %t", err, test.wantError)
 			}
-			if calls != 1 || waits != 0 {
-				t.Fatalf("calls = %d, waits = %d; want 1, 0", calls, waits)
+			if calls != len(test.samples) || waits != len(test.samples)-1 {
+				t.Fatalf("calls = %d, waits = %d; want %d, %d", calls, waits, len(test.samples), len(test.samples)-1)
 			}
 		})
-	}
-}
-
-func TestRunBucketReadbackPhaseRetriesNonConvergedResult(t *testing.T) {
-	t.Parallel()
-
-	calls := 0
-	waits := 0
-	err := runBucketReadbackPhase(
-		t.Context(),
-		s3PhaseMetadata{phase: "test readback", bucket: "target"},
-		immediateS3PhaseOptions(&waits),
-		func(context.Context) (bool, error) {
-			calls++
-			return calls >= 3, nil
-		},
-	)
-	if err != nil {
-		t.Fatalf("runBucketReadbackPhase() error = %v", err)
-	}
-	if calls != 4 || waits != 3 {
-		t.Fatalf("calls = %d, waits = %d; want 4, 3", calls, waits)
-	}
-}
-
-func TestRunBucketReadbackPhaseRequiresStableConvergence(t *testing.T) {
-	t.Parallel()
-
-	results := []bool{true, false, true, true}
-	calls := 0
-	waits := 0
-	err := runBucketReadbackPhase(
-		t.Context(),
-		s3PhaseMetadata{phase: "test readback", bucket: "target"},
-		immediateS3PhaseOptions(&waits),
-		func(context.Context) (bool, error) {
-			if calls >= len(results) {
-				t.Fatalf("readback called more than %d times", len(results))
-			}
-			result := results[calls]
-			calls++
-			return result, nil
-		},
-	)
-	if err != nil {
-		t.Fatalf("runBucketReadbackPhase() error = %v", err)
-	}
-	if calls != len(results) || waits != len(results)-1 {
-		t.Fatalf("calls = %d, waits = %d; want %d, %d", calls, waits, len(results), len(results)-1)
 	}
 }
 
@@ -188,66 +175,6 @@ func TestRunBucketReadbackPhaseTriesImmediatelyAndSpansConfirmationWindow(t *tes
 	}
 	if len(waits) != 1 || waits[0] != 5*time.Second {
 		t.Fatalf("waits = %v, want [5s] between matching readbacks", waits)
-	}
-}
-
-func TestRunBucketReadbackPhaseResetsConfirmationAfterRetryableError(t *testing.T) {
-	t.Parallel()
-
-	results := []struct {
-		matched bool
-		err     error
-	}{
-		{matched: true},
-		{err: &smithy.GenericAPIError{Code: errInvalidRegion}},
-		{matched: true},
-		{matched: true},
-	}
-	calls := 0
-	waits := 0
-	err := runBucketReadbackPhase(
-		t.Context(),
-		s3PhaseMetadata{phase: "test readback", bucket: "target"},
-		immediateS3PhaseOptions(&waits),
-		func(context.Context) (bool, error) {
-			if calls >= len(results) {
-				t.Fatalf("readback called more than %d times", len(results))
-			}
-			result := results[calls]
-			calls++
-			return result.matched, result.err
-		},
-	)
-	if err != nil {
-		t.Fatalf("runBucketReadbackPhase() error = %v", err)
-	}
-	if calls != len(results) || waits != len(results)-1 {
-		t.Fatalf("calls = %d, waits = %d; want %d, %d", calls, waits, len(results), len(results)-1)
-	}
-}
-
-func TestRunBucketReadbackPhaseStopsOnPermanentErrorAfterMatch(t *testing.T) {
-	t.Parallel()
-
-	calls := 0
-	waits := 0
-	err := runBucketReadbackPhase(
-		t.Context(),
-		s3PhaseMetadata{phase: "test readback", bucket: "target"},
-		immediateS3PhaseOptions(&waits),
-		func(context.Context) (bool, error) {
-			calls++
-			if calls == 1 {
-				return true, nil
-			}
-			return false, &smithy.GenericAPIError{Code: "AccessDenied"}
-		},
-	)
-	if err == nil {
-		t.Fatal("runBucketReadbackPhase() error = nil, want permanent failure")
-	}
-	if calls != 2 || waits != 1 {
-		t.Fatalf("calls = %d, waits = %d; want 2, 1", calls, waits)
 	}
 }
 
@@ -387,7 +314,7 @@ func immediateS3PhaseOptions(waits *int) s3PhaseOptions {
 		now:   time.Now,
 		delay: func(int) time.Duration { return 0 },
 		wait: func(ctx context.Context, _ time.Duration) error {
-			*waits++
+			(*waits)++
 			return ctx.Err()
 		},
 	}

--- a/coreweave/object_storage/s3_convergence_test.go
+++ b/coreweave/object_storage/s3_convergence_test.go
@@ -158,6 +158,39 @@ func TestRunBucketReadbackPhaseRequiresStableConvergence(t *testing.T) {
 	}
 }
 
+func TestRunBucketReadbackPhaseTriesImmediatelyAndSpansConfirmationWindow(t *testing.T) {
+	t.Parallel()
+
+	events := []string{}
+	waits := []time.Duration{}
+	err := runBucketReadbackPhase(
+		t.Context(),
+		s3PhaseMetadata{phase: "test readback", bucket: "target"},
+		s3PhaseOptions{
+			now:   time.Now,
+			delay: func(int) time.Duration { return 0 },
+			wait: func(ctx context.Context, delay time.Duration) error {
+				events = append(events, "wait")
+				waits = append(waits, delay)
+				return ctx.Err()
+			},
+		},
+		func(context.Context) (bool, error) {
+			events = append(events, "attempt")
+			return true, nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("runBucketReadbackPhase() error = %v", err)
+	}
+	if got, want := strings.Join(events, ","), "attempt,wait,attempt"; got != want {
+		t.Fatalf("events = %q, want %q", got, want)
+	}
+	if len(waits) != 1 || waits[0] != 5*time.Second {
+		t.Fatalf("waits = %v, want [5s] between matching readbacks", waits)
+	}
+}
+
 func TestRunBucketReadbackPhaseResetsConfirmationAfterRetryableError(t *testing.T) {
 	t.Parallel()
 

--- a/coreweave/object_storage/s3_convergence_test.go
+++ b/coreweave/object_storage/s3_convergence_test.go
@@ -1,0 +1,159 @@
+package objectstorage
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aws/smithy-go"
+)
+
+func TestRunBucketMutationPhaseRetriesInvalidRegion(t *testing.T) {
+	t.Parallel()
+
+	calls := 0
+	waits := 0
+	err := runBucketMutationPhase(
+		t.Context(),
+		s3PhaseMetadata{phase: "test mutation", bucket: "target"},
+		immediateS3PhaseOptions(&waits),
+		func(context.Context) error {
+			calls++
+			if calls == 1 {
+				return &smithy.GenericAPIError{Code: errInvalidRegion}
+			}
+			return nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("runBucketMutationPhase() error = %v", err)
+	}
+	if calls != 2 || waits != 1 {
+		t.Fatalf("calls = %d, waits = %d; want 2, 1", calls, waits)
+	}
+}
+
+func TestRunBucketMutationPhaseDoesNotRetryPermanentErrors(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]error{
+		"generic non-head 400": responseErrorWithCause(t, 400, &smithy.GenericAPIError{Code: "BadRequest"}),
+		"access denied":        &smithy.GenericAPIError{Code: "AccessDenied"},
+		"invalid signature":    &smithy.GenericAPIError{Code: "SignatureDoesNotMatch"},
+	}
+	for name, mutationErr := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			calls := 0
+			waits := 0
+			err := runBucketMutationPhase(
+				t.Context(),
+				s3PhaseMetadata{phase: "test mutation", bucket: "target"},
+				immediateS3PhaseOptions(&waits),
+				func(context.Context) error {
+					calls++
+					return mutationErr
+				},
+			)
+			if err == nil {
+				t.Fatal("runBucketMutationPhase() error = nil, want permanent failure")
+			}
+			if calls != 1 || waits != 0 {
+				t.Fatalf("calls = %d, waits = %d; want 1, 0", calls, waits)
+			}
+		})
+	}
+}
+
+func TestRunBucketReadbackPhaseRetriesNonConvergedResult(t *testing.T) {
+	t.Parallel()
+
+	calls := 0
+	waits := 0
+	err := runBucketReadbackPhase(
+		t.Context(),
+		s3PhaseMetadata{phase: "test readback", bucket: "target"},
+		immediateS3PhaseOptions(&waits),
+		func(context.Context) (bool, error) {
+			calls++
+			return calls == 3, nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("runBucketReadbackPhase() error = %v", err)
+	}
+	if calls != 3 || waits != 2 {
+		t.Fatalf("calls = %d, waits = %d; want 3, 2", calls, waits)
+	}
+}
+
+func TestRunBucketMutationPhaseHonorsCanceledContext(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	calls := 0
+	waits := 0
+	err := runBucketMutationPhase(
+		ctx,
+		s3PhaseMetadata{phase: "test mutation", bucket: "target"},
+		immediateS3PhaseOptions(&waits),
+		func(context.Context) error {
+			calls++
+			return &smithy.GenericAPIError{Code: errInvalidRegion}
+		},
+	)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("runBucketMutationPhase() error = %v, want context.Canceled", err)
+	}
+	if calls != 0 || waits != 0 {
+		t.Fatalf("calls = %d, waits = %d; want 0, 0", calls, waits)
+	}
+}
+
+func TestRunBucketMutationPhaseReportsBoundedFailure(t *testing.T) {
+	t.Parallel()
+
+	calls := 0
+	err := runBucketMutationPhase(
+		t.Context(),
+		s3PhaseMetadata{phase: "bucket policy application", bucket: "target"},
+		s3PhaseOptions{
+			delay: func(int) time.Duration { return 0 },
+			wait: func(context.Context, time.Duration) error {
+				return context.DeadlineExceeded
+			},
+		},
+		func(context.Context) error {
+			calls++
+			return &smithy.GenericAPIError{Code: errInvalidRegion}
+		},
+	)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("runBucketMutationPhase() error = %v, want context.DeadlineExceeded", err)
+	}
+	var phaseErr *s3PhaseError
+	if !errors.As(err, &phaseErr) {
+		t.Fatalf("runBucketMutationPhase() error type = %T, want *s3PhaseError", err)
+	}
+	if calls != 1 || phaseErr.attempts != 1 || phaseErr.phase != "bucket policy application" {
+		t.Fatalf("calls = %d, phase error = %#v; want one bucket policy application attempt", calls, phaseErr)
+	}
+	if message := err.Error(); !strings.Contains(message, "bucket policy application failed after 1 attempt") {
+		t.Fatalf("error = %q, want phase and attempt diagnostics", message)
+	}
+}
+
+func immediateS3PhaseOptions(waits *int) s3PhaseOptions {
+	return s3PhaseOptions{
+		now:   time.Now,
+		delay: func(int) time.Duration { return 0 },
+		wait: func(ctx context.Context, _ time.Duration) error {
+			*waits++
+			return ctx.Err()
+		},
+	}
+}


### PR DESCRIPTION
## Summary

Adds bounded retries for transient S3 `InvalidRegion` errors during bucket policy, versioning, lifecycle, and inventory Create/Update operations. This extends the tag-specific fix from [PR #420](https://github.com/coreweave/terraform-provider-coreweave/pull/420) and generalizes the convergence handling introduced in [PR #426](https://github.com/coreweave/terraform-provider-coreweave/pull/426).

## Findings

A successful `HeadBucket` does not guarantee that bucket subresource routes have converged. Customer logs showed accepted writes followed by `InvalidRegion` during readback, including resources managed separately from the bucket.

Customer context: [Slack thread](https://coreweave.slack.com/archives/C052XLUTY10/p1787905849768849?thread_ts=1787590757.398109&cid=C052XLUTY10)

The fix retries the affected write/readback sequence within one bounded timeout. Generic `400 BadRequest` retries remain limited to `HeadBucket`; global AWS retry behavior is unchanged.

The regression was added red in `8173e82` and made green by `ff079eb`.

Two notable call outs for reviewers:

- Mutation retries currently include `NoSuchBucket`/404, which could delay reporting a genuinely deleted bucket during Update.
- Direct wiring coverage could be strengthened for lifecycle, inventory, and versioning writes.

## Validation

- Focused post-create `InvalidRegion` regression
- Full object-storage test package
- `go build ./...`
- `go vet ./coreweave/...`

Tracking: [CLDAPI-1088](https://coreweave.atlassian.net/browse/CLDAPI-1088)


[CLDAPI-1088]: https://coreweave.atlassian.net/browse/CLDAPI-1088?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ