### PR TITLE
docs(object-storage): complete native inventory example

### DIFF
--- a/coreweave/object_storage/resource_bucket_inventory.go
+++ b/coreweave/object_storage/resource_bucket_inventory.go
@@ -108,6 +108,9 @@ func (r *BucketInventoryResource) Metadata(ctx context.Context, req resource.Met
 }
 
 func (r *BucketInventoryResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	// CoreWeave supports LastAccessedDate, which is not in the AWS SDK enum.
+	optionalFields := []string{"Size", "LastModifiedDate", "LastAccessedDate", "StorageClass", "ETag", "IsMultipartUploaded", "EncryptionStatus", "ChecksumAlgorithm"}
+
 	resp.Schema = schema.Schema{
 		MarkdownDescription: "Manages a CoreWeave AI Object Storage bucket inventory configuration. The provider obtains temporary S3 credentials using its configured authentication; no separately managed access-key resource is required. The authenticated identity must have permission to manage inventory configurations on the source bucket and policies on the destination bucket. [Learn more about inventory reporting](https://docs.coreweave.com/products/storage/object-storage/buckets/inventory-reporting/configure).",
 		Attributes: map[string]schema.Attribute{
@@ -139,10 +142,10 @@ func (r *BucketInventoryResource) Schema(ctx context.Context, req resource.Schem
 			"optional_fields": schema.SetAttribute{
 				Optional:            true,
 				ElementType:         types.StringType,
-				MarkdownDescription: "Additional report fields: `Size`, `LastModifiedDate`, `LastAccessedDate`, `StorageClass`, `ETag`, `IsMultipartUploaded`, `EncryptionStatus`, or `ChecksumAlgorithm`. Omit to include no additional fields; an empty set is invalid.",
+				MarkdownDescription: fmt.Sprintf("Additional report fields: `%s`. Omit to include no additional fields; an empty set is invalid.", strings.Join(optionalFields, "`, `")),
 				Validators: []validator.Set{
 					setvalidator.SizeAtLeast(1),
-					setvalidator.ValueStringsAre(stringvalidator.OneOf("Size", "LastModifiedDate", "LastAccessedDate", "StorageClass", "ETag", "IsMultipartUploaded", "EncryptionStatus", "ChecksumAlgorithm")),
+					setvalidator.ValueStringsAre(stringvalidator.OneOf(optionalFields...)),
 				},
 			},
 		},

--- a/coreweave/object_storage/resource_bucket_inventory.go
+++ b/coreweave/object_storage/resource_bucket_inventory.go
@@ -109,7 +109,7 @@ func (r *BucketInventoryResource) Metadata(ctx context.Context, req resource.Met
 
 func (r *BucketInventoryResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		MarkdownDescription: "Manages a Coreweave AI Object Storage bucket inventory configuration. [Learn more about inventory reporting](https://docs.coreweave.com/products/storage/object-storage)",
+		MarkdownDescription: "Manages a CoreWeave AI Object Storage bucket inventory configuration. The provider obtains temporary S3 credentials using its configured authentication; no separately managed access-key resource is required. The authenticated identity must have permission to manage inventory configurations on the source bucket and policies on the destination bucket. [Learn more about inventory reporting](https://docs.coreweave.com/products/storage/object-storage/buckets/inventory-reporting/configure).",
 		Attributes: map[string]schema.Attribute{
 			"bucket": schema.StringAttribute{
 				Required:            true,
@@ -131,7 +131,7 @@ func (r *BucketInventoryResource) Schema(ctx context.Context, req resource.Schem
 			},
 			"included_object_versions": schema.StringAttribute{
 				Required:            true,
-				MarkdownDescription: "Specifies which object versions are included in the inventory results. Valid values are `All` and `Current`.",
+				MarkdownDescription: "Object versions to include: `All` includes all versions; `Current` includes only current versions.",
 				// Accepted values are sourced from the AWS SDK enum rather than
 				// hardcoded literals; see s3types.InventoryIncludedObjectVersions.
 				Validators: []validator.String{stringvalidator.OneOf(enumStrings(s3types.InventoryIncludedObjectVersions("").Values())...)},
@@ -139,7 +139,7 @@ func (r *BucketInventoryResource) Schema(ctx context.Context, req resource.Schem
 			"optional_fields": schema.SetAttribute{
 				Optional:            true,
 				ElementType:         types.StringType,
-				MarkdownDescription: "List of optional fields to include in the inventory results",
+				MarkdownDescription: "Additional report fields: `Size`, `LastModifiedDate`, `LastAccessedDate`, `StorageClass`, `ETag`, `IsMultipartUploaded`, `EncryptionStatus`, or `ChecksumAlgorithm`. Omit to include no additional fields; an empty set is invalid.",
 				Validators: []validator.Set{
 					setvalidator.SizeAtLeast(1),
 					setvalidator.ValueStringsAre(stringvalidator.OneOf("Size", "LastModifiedDate", "LastAccessedDate", "StorageClass", "ETag", "IsMultipartUploaded", "EncryptionStatus", "ChecksumAlgorithm")),
@@ -168,7 +168,7 @@ func (r *BucketInventoryResource) Schema(ctx context.Context, req resource.Schem
 				Validators: []validator.Object{objectvalidator.IsRequired()},
 			},
 			"destination": schema.SingleNestedBlock{
-				MarkdownDescription: "Where the inventory report is written. May be the same bucket as the source.",
+				MarkdownDescription: "Where the inventory report is written. May be the same bucket as the source. The destination policy must grant the inventory service `s3:PutObject` and `s3:AbortMultipartUpload` on report objects. Use `depends_on` to apply that policy before the inventory configuration.",
 				Blocks: map[string]schema.Block{
 					"bucket": schema.SingleNestedBlock{
 						MarkdownDescription: "Destination bucket for the report (may equal the source bucket).",

--- a/coreweave/object_storage/resource_bucket_inventory.go
+++ b/coreweave/object_storage/resource_bucket_inventory.go
@@ -160,7 +160,7 @@ func (r *BucketInventoryResource) Schema(ctx context.Context, req resource.Schem
 				},
 			},
 			"schedule": schema.SingleNestedBlock{
-				MarkdownDescription: "Schedule for generating the inventory report.",
+				MarkdownDescription: "Required. Schedule for generating the inventory report.",
 				Attributes: map[string]schema.Attribute{
 					"frequency": schema.StringAttribute{
 						Required:            true,
@@ -171,10 +171,10 @@ func (r *BucketInventoryResource) Schema(ctx context.Context, req resource.Schem
 				Validators: []validator.Object{objectvalidator.IsRequired()},
 			},
 			"destination": schema.SingleNestedBlock{
-				MarkdownDescription: "Where the inventory report is written. May be the same bucket as the source. The destination policy must grant the inventory service `s3:PutObject` and `s3:AbortMultipartUpload` on report objects. Use `depends_on` to apply that policy before the inventory configuration.",
+				MarkdownDescription: "Required. Where the inventory report is written. May be the same bucket as the source. The destination policy must grant the inventory service `s3:PutObject` and `s3:AbortMultipartUpload` on report objects. Use `depends_on` to apply that policy before the inventory configuration.",
 				Blocks: map[string]schema.Block{
 					"bucket": schema.SingleNestedBlock{
-						MarkdownDescription: "Destination bucket for the report (may equal the source bucket).",
+						MarkdownDescription: "Required. Destination bucket for the report (may equal the source bucket).",
 						Attributes: map[string]schema.Attribute{
 							"bucket_arn": schema.StringAttribute{
 								Required:            true,

--- a/coreweave/object_storage/resource_bucket_inventory.go
+++ b/coreweave/object_storage/resource_bucket_inventory.go
@@ -171,7 +171,7 @@ func (r *BucketInventoryResource) Schema(ctx context.Context, req resource.Schem
 				Validators: []validator.Object{objectvalidator.IsRequired()},
 			},
 			"destination": schema.SingleNestedBlock{
-				MarkdownDescription: "Required. Where the inventory report is written. May be the same bucket as the source. The destination policy must grant the inventory service `s3:PutObject` and `s3:AbortMultipartUpload` on report objects. Use `depends_on` to apply that policy before the inventory configuration.",
+				MarkdownDescription: "Required. Where the inventory report is written. May be the same bucket as the source. The destination policy must grant the inventory service `s3:PutObject` and `s3:AbortMultipartUpload` on report objects. Use `depends_on` to apply that policy before the inventory configuration. Bucket policies are evaluated after organization policies; requests without a matching bucket grant are implicitly denied even if an organization policy allows them. Include caller permissions for Terraform bucket reads and cleanup, and explicit grants for report readers. The policy resource replaces the entire existing bucket policy, so retain all required statements. `s3:PutBucketPolicy` itself evaluates organization permissions only. See [policy evaluation](https://docs.coreweave.com/products/storage/object-storage/auth-access/policies#policy-evaluation).",
 				Blocks: map[string]schema.Block{
 					"bucket": schema.SingleNestedBlock{
 						MarkdownDescription: "Required. Destination bucket for the report (may equal the source bucket).",

--- a/docs/resources/object_storage_bucket_inventory.md
+++ b/docs/resources/object_storage_bucket_inventory.md
@@ -13,6 +13,13 @@ Manages a CoreWeave AI Object Storage bucket inventory configuration. The provid
 ## Example Usage
 
 ```terraform
+# Requires CoreWeave provider v0.22.0 or later for caller_identity.
+data "coreweave_caller_identity" "current" {}
+
+locals {
+  caller_principal = "arn:aws:iam::${data.coreweave_caller_identity.current.organization_id}:coreweave/${data.coreweave_caller_identity.current.principal_id}"
+}
+
 # Replace the example bucket names with globally unique names and configure CoreWeave provider authentication.
 resource "coreweave_object_storage_bucket" "source" {
   name = "inventory-source-example"
@@ -24,19 +31,49 @@ resource "coreweave_object_storage_bucket" "destination" {
   zone = "US-EAST-04A"
 }
 
+# This resource replaces the entire bucket policy; retain any other required grants.
+# Unmatched requests are implicitly denied even if an organization policy allows them.
+# Add explicit bucket grants for other report readers. PutBucketPolicy itself uses only organization permissions.
 resource "coreweave_object_storage_bucket_policy" "inventory_destination" {
   bucket = coreweave_object_storage_bucket.destination.name
   policy = jsonencode({
     Version = "2012-10-17"
-    Statement = [{
-      Sid    = "AllowInventoryReports"
-      Effect = "Allow"
-      Principal = {
-        CW = "arn:aws:iam::static:role/static/inventory"
-      }
-      Action   = ["s3:PutObject", "s3:AbortMultipartUpload"]
-      Resource = ["arn:aws:s3:::${coreweave_object_storage_bucket.destination.name}/inventory-reports/*"]
-    }]
+    Statement = [
+      {
+        Sid    = "AllowInventoryReports"
+        Effect = "Allow"
+        Principal = {
+          CW = "arn:aws:iam::static:role/static/inventory"
+        }
+        Action   = ["s3:PutObject", "s3:AbortMultipartUpload"]
+        Resource = ["arn:aws:s3:::${coreweave_object_storage_bucket.destination.name}/inventory-reports/*"]
+      },
+      {
+        Sid    = "AllowCallerManageDestination"
+        Effect = "Allow"
+        Principal = {
+          CW = local.caller_principal
+        }
+        Action = [
+          "s3:ListBucket",
+          "s3:GetBucketPolicy",
+          "s3:DeleteBucketPolicy",
+          "s3:GetBucketLocation",
+          "s3:GetBucketTagging",
+          "s3:DeleteBucket",
+        ]
+        Resource = ["arn:aws:s3:::${coreweave_object_storage_bucket.destination.name}"]
+      },
+      {
+        Sid    = "AllowCallerManageReports"
+        Effect = "Allow"
+        Principal = {
+          CW = local.caller_principal
+        }
+        Action   = ["s3:GetObject", "s3:PutObject", "s3:DeleteObject"]
+        Resource = ["arn:aws:s3:::${coreweave_object_storage_bucket.destination.name}/inventory-reports/*"]
+      },
+    ]
   })
 }
 
@@ -82,7 +119,7 @@ resource "coreweave_object_storage_bucket_inventory" "default" {
 
 ### Optional
 
-- `destination` (Block, Optional) Required. Where the inventory report is written. May be the same bucket as the source. The destination policy must grant the inventory service `s3:PutObject` and `s3:AbortMultipartUpload` on report objects. Use `depends_on` to apply that policy before the inventory configuration. (see [below for nested schema](#nestedblock--destination))
+- `destination` (Block, Optional) Required. Where the inventory report is written. May be the same bucket as the source. The destination policy must grant the inventory service `s3:PutObject` and `s3:AbortMultipartUpload` on report objects. Use `depends_on` to apply that policy before the inventory configuration. Bucket policies are evaluated after organization policies; requests without a matching bucket grant are implicitly denied even if an organization policy allows them. Include caller permissions for Terraform bucket reads and cleanup, and explicit grants for report readers. The policy resource replaces the entire existing bucket policy, so retain all required statements. `s3:PutBucketPolicy` itself evaluates organization permissions only. See [policy evaluation](https://docs.coreweave.com/products/storage/object-storage/auth-access/policies#policy-evaluation). (see [below for nested schema](#nestedblock--destination))
 - `enabled` (Boolean) Whether the inventory configuration is enabled. Defaults to `true`.
 - `filter` (Block, Optional) Limits the inventory report to objects matching a prefix. (see [below for nested schema](#nestedblock--filter))
 - `optional_fields` (Set of String) Additional report fields: `Size`, `LastModifiedDate`, `LastAccessedDate`, `StorageClass`, `ETag`, `IsMultipartUploaded`, `EncryptionStatus`, `ChecksumAlgorithm`. Omit to include no additional fields; an empty set is invalid.

--- a/docs/resources/object_storage_bucket_inventory.md
+++ b/docs/resources/object_storage_bucket_inventory.md
@@ -13,7 +13,7 @@ Manages a CoreWeave AI Object Storage bucket inventory configuration. The provid
 ## Example Usage
 
 ```terraform
-# Choose globally unique bucket names and configure CoreWeave provider authentication.
+# Replace the example bucket names with globally unique names and configure CoreWeave provider authentication.
 resource "coreweave_object_storage_bucket" "source" {
   name = "inventory-source-example"
   zone = "US-EAST-04A"
@@ -82,18 +82,18 @@ resource "coreweave_object_storage_bucket_inventory" "default" {
 
 ### Optional
 
-- `destination` (Block, Optional) Where the inventory report is written. May be the same bucket as the source. The destination policy must grant the inventory service `s3:PutObject` and `s3:AbortMultipartUpload` on report objects. Use `depends_on` to apply that policy before the inventory configuration. (see [below for nested schema](#nestedblock--destination))
+- `destination` (Block, Optional) Required. Where the inventory report is written. May be the same bucket as the source. The destination policy must grant the inventory service `s3:PutObject` and `s3:AbortMultipartUpload` on report objects. Use `depends_on` to apply that policy before the inventory configuration. (see [below for nested schema](#nestedblock--destination))
 - `enabled` (Boolean) Whether the inventory configuration is enabled. Defaults to `true`.
 - `filter` (Block, Optional) Limits the inventory report to objects matching a prefix. (see [below for nested schema](#nestedblock--filter))
 - `optional_fields` (Set of String) Additional report fields: `Size`, `LastModifiedDate`, `LastAccessedDate`, `StorageClass`, `ETag`, `IsMultipartUploaded`, `EncryptionStatus`, `ChecksumAlgorithm`. Omit to include no additional fields; an empty set is invalid.
-- `schedule` (Block, Optional) Schedule for generating the inventory report. (see [below for nested schema](#nestedblock--schedule))
+- `schedule` (Block, Optional) Required. Schedule for generating the inventory report. (see [below for nested schema](#nestedblock--schedule))
 
 <a id="nestedblock--destination"></a>
 ### Nested Schema for `destination`
 
 Optional:
 
-- `bucket` (Block, Optional) Destination bucket for the report (may equal the source bucket). (see [below for nested schema](#nestedblock--destination--bucket))
+- `bucket` (Block, Optional) Required. Destination bucket for the report (may equal the source bucket). (see [below for nested schema](#nestedblock--destination--bucket))
 
 <a id="nestedblock--destination--bucket"></a>
 ### Nested Schema for `destination.bucket`

--- a/docs/resources/object_storage_bucket_inventory.md
+++ b/docs/resources/object_storage_bucket_inventory.md
@@ -85,7 +85,7 @@ resource "coreweave_object_storage_bucket_inventory" "default" {
 - `destination` (Block, Optional) Where the inventory report is written. May be the same bucket as the source. The destination policy must grant the inventory service `s3:PutObject` and `s3:AbortMultipartUpload` on report objects. Use `depends_on` to apply that policy before the inventory configuration. (see [below for nested schema](#nestedblock--destination))
 - `enabled` (Boolean) Whether the inventory configuration is enabled. Defaults to `true`.
 - `filter` (Block, Optional) Limits the inventory report to objects matching a prefix. (see [below for nested schema](#nestedblock--filter))
-- `optional_fields` (Set of String) Additional report fields: `Size`, `LastModifiedDate`, `LastAccessedDate`, `StorageClass`, `ETag`, `IsMultipartUploaded`, `EncryptionStatus`, or `ChecksumAlgorithm`. Omit to include no additional fields; an empty set is invalid.
+- `optional_fields` (Set of String) Additional report fields: `Size`, `LastModifiedDate`, `LastAccessedDate`, `StorageClass`, `ETag`, `IsMultipartUploaded`, `EncryptionStatus`, `ChecksumAlgorithm`. Omit to include no additional fields; an empty set is invalid.
 - `schedule` (Block, Optional) Schedule for generating the inventory report. (see [below for nested schema](#nestedblock--schedule))
 
 <a id="nestedblock--destination"></a>

--- a/docs/resources/object_storage_bucket_inventory.md
+++ b/docs/resources/object_storage_bucket_inventory.md
@@ -3,16 +3,17 @@
 page_title: "coreweave_object_storage_bucket_inventory Resource - coreweave"
 subcategory: ""
 description: |-
-  Manages a Coreweave AI Object Storage bucket inventory configuration. Learn more about inventory reporting https://docs.coreweave.com/products/storage/object-storage
+  Manages a CoreWeave AI Object Storage bucket inventory configuration. The provider obtains temporary S3 credentials using its configured authentication; no separately managed access-key resource is required. The authenticated identity must have permission to manage inventory configurations on the source bucket and policies on the destination bucket. Learn more about inventory reporting https://docs.coreweave.com/products/storage/object-storage/buckets/inventory-reporting/configure.
 ---
 
 # coreweave_object_storage_bucket_inventory (Resource)
 
-Manages a Coreweave AI Object Storage bucket inventory configuration. [Learn more about inventory reporting](https://docs.coreweave.com/products/storage/object-storage)
+Manages a CoreWeave AI Object Storage bucket inventory configuration. The provider obtains temporary S3 credentials using its configured authentication; no separately managed access-key resource is required. The authenticated identity must have permission to manage inventory configurations on the source bucket and policies on the destination bucket. [Learn more about inventory reporting](https://docs.coreweave.com/products/storage/object-storage/buckets/inventory-reporting/configure).
 
 ## Example Usage
 
 ```terraform
+# Choose globally unique bucket names and configure CoreWeave provider authentication.
 resource "coreweave_object_storage_bucket" "source" {
   name = "inventory-source-example"
   zone = "US-EAST-04A"
@@ -23,14 +24,33 @@ resource "coreweave_object_storage_bucket" "destination" {
   zone = "US-EAST-04A"
 }
 
+resource "coreweave_object_storage_bucket_policy" "inventory_destination" {
+  bucket = coreweave_object_storage_bucket.destination.name
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Sid    = "AllowInventoryReports"
+      Effect = "Allow"
+      Principal = {
+        CW = "arn:aws:iam::static:role/static/inventory"
+      }
+      Action   = ["s3:PutObject", "s3:AbortMultipartUpload"]
+      Resource = ["arn:aws:s3:::${coreweave_object_storage_bucket.destination.name}/inventory-reports/*"]
+    }]
+  })
+}
+
 resource "coreweave_object_storage_bucket_inventory" "default" {
+  # The service validates destination access when configuring inventory.
+  depends_on = [coreweave_object_storage_bucket_policy.inventory_destination]
+
   bucket                   = coreweave_object_storage_bucket.source.name
   name                     = "daily-inventory"
   enabled                  = true
   included_object_versions = "All"
 
   # Optional: omit entirely to include no extra fields. An empty set is invalid.
-  optional_fields = ["Size", "LastModifiedDate", "StorageClass", "ETag"]
+  optional_fields = ["Size", "LastModifiedDate", "LastAccessedDate", "StorageClass", "ETag"]
 
   # Optional: limit the report to objects under a prefix.
   filter {
@@ -57,15 +77,15 @@ resource "coreweave_object_storage_bucket_inventory" "default" {
 ### Required
 
 - `bucket` (String) Name of source bucket to which the inventory configuration applies
-- `included_object_versions` (String) Specifies which object versions are included in the inventory results. Valid values are `All` and `Current`.
+- `included_object_versions` (String) Object versions to include: `All` includes all versions; `Current` includes only current versions.
 - `name` (String) Name of the inventory configuration. Must be unique within the bucket.
 
 ### Optional
 
-- `destination` (Block, Optional) Where the inventory report is written. May be the same bucket as the source. (see [below for nested schema](#nestedblock--destination))
+- `destination` (Block, Optional) Where the inventory report is written. May be the same bucket as the source. The destination policy must grant the inventory service `s3:PutObject` and `s3:AbortMultipartUpload` on report objects. Use `depends_on` to apply that policy before the inventory configuration. (see [below for nested schema](#nestedblock--destination))
 - `enabled` (Boolean) Whether the inventory configuration is enabled. Defaults to `true`.
 - `filter` (Block, Optional) Limits the inventory report to objects matching a prefix. (see [below for nested schema](#nestedblock--filter))
-- `optional_fields` (Set of String) List of optional fields to include in the inventory results
+- `optional_fields` (Set of String) Additional report fields: `Size`, `LastModifiedDate`, `LastAccessedDate`, `StorageClass`, `ETag`, `IsMultipartUploaded`, `EncryptionStatus`, or `ChecksumAlgorithm`. Omit to include no additional fields; an empty set is invalid.
 - `schedule` (Block, Optional) Schedule for generating the inventory report. (see [below for nested schema](#nestedblock--schedule))
 
 <a id="nestedblock--destination"></a>

--- a/examples/resources/coreweave_object_storage_bucket_inventory/resource.tf
+++ b/examples/resources/coreweave_object_storage_bucket_inventory/resource.tf
@@ -1,3 +1,10 @@
+# Requires CoreWeave provider v0.22.0 or later for caller_identity.
+data "coreweave_caller_identity" "current" {}
+
+locals {
+  caller_principal = "arn:aws:iam::${data.coreweave_caller_identity.current.organization_id}:coreweave/${data.coreweave_caller_identity.current.principal_id}"
+}
+
 # Replace the example bucket names with globally unique names and configure CoreWeave provider authentication.
 resource "coreweave_object_storage_bucket" "source" {
   name = "inventory-source-example"
@@ -9,19 +16,49 @@ resource "coreweave_object_storage_bucket" "destination" {
   zone = "US-EAST-04A"
 }
 
+# This resource replaces the entire bucket policy; retain any other required grants.
+# Unmatched requests are implicitly denied even if an organization policy allows them.
+# Add explicit bucket grants for other report readers. PutBucketPolicy itself uses only organization permissions.
 resource "coreweave_object_storage_bucket_policy" "inventory_destination" {
   bucket = coreweave_object_storage_bucket.destination.name
   policy = jsonencode({
     Version = "2012-10-17"
-    Statement = [{
-      Sid    = "AllowInventoryReports"
-      Effect = "Allow"
-      Principal = {
-        CW = "arn:aws:iam::static:role/static/inventory"
-      }
-      Action   = ["s3:PutObject", "s3:AbortMultipartUpload"]
-      Resource = ["arn:aws:s3:::${coreweave_object_storage_bucket.destination.name}/inventory-reports/*"]
-    }]
+    Statement = [
+      {
+        Sid    = "AllowInventoryReports"
+        Effect = "Allow"
+        Principal = {
+          CW = "arn:aws:iam::static:role/static/inventory"
+        }
+        Action   = ["s3:PutObject", "s3:AbortMultipartUpload"]
+        Resource = ["arn:aws:s3:::${coreweave_object_storage_bucket.destination.name}/inventory-reports/*"]
+      },
+      {
+        Sid    = "AllowCallerManageDestination"
+        Effect = "Allow"
+        Principal = {
+          CW = local.caller_principal
+        }
+        Action = [
+          "s3:ListBucket",
+          "s3:GetBucketPolicy",
+          "s3:DeleteBucketPolicy",
+          "s3:GetBucketLocation",
+          "s3:GetBucketTagging",
+          "s3:DeleteBucket",
+        ]
+        Resource = ["arn:aws:s3:::${coreweave_object_storage_bucket.destination.name}"]
+      },
+      {
+        Sid    = "AllowCallerManageReports"
+        Effect = "Allow"
+        Principal = {
+          CW = local.caller_principal
+        }
+        Action   = ["s3:GetObject", "s3:PutObject", "s3:DeleteObject"]
+        Resource = ["arn:aws:s3:::${coreweave_object_storage_bucket.destination.name}/inventory-reports/*"]
+      },
+    ]
   })
 }
 

--- a/examples/resources/coreweave_object_storage_bucket_inventory/resource.tf
+++ b/examples/resources/coreweave_object_storage_bucket_inventory/resource.tf
@@ -1,3 +1,4 @@
+# Choose globally unique bucket names and configure CoreWeave provider authentication.
 resource "coreweave_object_storage_bucket" "source" {
   name = "inventory-source-example"
   zone = "US-EAST-04A"
@@ -8,14 +9,33 @@ resource "coreweave_object_storage_bucket" "destination" {
   zone = "US-EAST-04A"
 }
 
+resource "coreweave_object_storage_bucket_policy" "inventory_destination" {
+  bucket = coreweave_object_storage_bucket.destination.name
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Sid    = "AllowInventoryReports"
+      Effect = "Allow"
+      Principal = {
+        CW = "arn:aws:iam::static:role/static/inventory"
+      }
+      Action   = ["s3:PutObject", "s3:AbortMultipartUpload"]
+      Resource = ["arn:aws:s3:::${coreweave_object_storage_bucket.destination.name}/inventory-reports/*"]
+    }]
+  })
+}
+
 resource "coreweave_object_storage_bucket_inventory" "default" {
+  # The service validates destination access when configuring inventory.
+  depends_on = [coreweave_object_storage_bucket_policy.inventory_destination]
+
   bucket                   = coreweave_object_storage_bucket.source.name
   name                     = "daily-inventory"
   enabled                  = true
   included_object_versions = "All"
 
   # Optional: omit entirely to include no extra fields. An empty set is invalid.
-  optional_fields = ["Size", "LastModifiedDate", "StorageClass", "ETag"]
+  optional_fields = ["Size", "LastModifiedDate", "LastAccessedDate", "StorageClass", "ETag"]
 
   # Optional: limit the report to objects under a prefix.
   filter {

--- a/examples/resources/coreweave_object_storage_bucket_inventory/resource.tf
+++ b/examples/resources/coreweave_object_storage_bucket_inventory/resource.tf
@@ -1,4 +1,4 @@
-# Choose globally unique bucket names and configure CoreWeave provider authentication.
+# Replace the example bucket names with globally unique names and configure CoreWeave provider authentication.
 resource "coreweave_object_storage_bucket" "source" {
   name = "inventory-source-example"
   zone = "US-EAST-04A"


### PR DESCRIPTION
Complete the native bucket inventory example with `LastAccessedDate`, explicit policy ordering, and caller access alongside the inventory service. The destination policy grants the service report writes and multipart-upload cleanup under `inventory-reports/`, and uses `coreweave_caller_identity` (v0.22.0+) to grant the caller bucket reads/cleanup and report-object access.

Document CoreWeave's bucket-policy implicit deny, full-policy replacement, and the organization-only `PutBucketPolicy` exception. Expand schema descriptions for required blocks, supported fields, object versions, and provider-managed temporary S3 credentials; regenerate the provider documentation while retaining formats and import examples.

Provider portion of [CLDAPI-1116](https://coreweave.atlassian.net/browse/CLDAPI-1116). The public guide is handled separately in [coreweave/docs#3740](https://github.com/coreweave/docs/pull/3740).

Validation: `make generate`, pinned `make lint` (0 issues), Terraform formatting, and `terraform validate` against the locally built provider via `devtf` passed. Permissions checked against provider lifecycle calls and CoreWeave's documented policy evaluation. No live infrastructure apply; resource behavior is unchanged.


[CLDAPI-1116]: https://coreweave.atlassian.net/browse/CLDAPI-1116?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ