### PR TITLE
feat(object_storage): add bucket capacity caps support to Terraform

### DIFF
--- a/coreweave/object_storage/fake_cwobject_test.go
+++ b/coreweave/object_storage/fake_cwobject_test.go
@@ -20,7 +20,6 @@ var (
 	errArchiveDaysRequired     = errors.New("invalid archive settings: archive_after_last_access_days is required when archive is enabled")
 	errArchiveDaysBelowMinimum = errors.New("invalid archive settings: archive_after_last_access_days must be >= 60")
 	errNotFound                = errors.New("not found")
-	errCapNotEntitled          = errors.New("organization is not entitled to feature(s): BucketCapacityCap")
 )
 
 // fakeCWObject is an in-process stand-in for a CWObject service, covering
@@ -33,10 +32,6 @@ type fakeCWObject struct {
 
 	archiveEntitled bool
 	archiveMinDays  int32
-
-	// denyCapacityCap makes any cap-changing request (set or clear) fail with a
-	// permission error, modeling an org not entitled to the capacity-cap feature.
-	denyCapacityCap bool
 
 	// buckets holds the persisted settings, keyed by bucket name.
 	buckets map[string]*fakeBucketSettings
@@ -176,11 +171,6 @@ func (f *fakeCWObject) SetBucketSettings(
 
 	if hasArchiveFields(settings) && !f.archiveEntitled {
 		return nil, connect.NewError(connect.CodePermissionDenied, errFeatureNotEntitled)
-	}
-
-	// thoth gates the whole capacity_cap_update oneof (set or clear), so match it.
-	if settings.HasCapacityCapUpdate() && f.denyCapacityCap {
-		return nil, connect.NewError(connect.CodePermissionDenied, errCapNotEntitled)
 	}
 
 	if hasArchiveFields(settings) {

--- a/coreweave/object_storage/fake_cwobject_test.go
+++ b/coreweave/object_storage/fake_cwobject_test.go
@@ -20,6 +20,7 @@ var (
 	errArchiveDaysRequired     = errors.New("invalid archive settings: archive_after_last_access_days is required when archive is enabled")
 	errArchiveDaysBelowMinimum = errors.New("invalid archive settings: archive_after_last_access_days must be >= 60")
 	errNotFound                = errors.New("not found")
+	errCapNotEntitled          = errors.New("organization is not entitled to feature(s): BucketCapacityCap")
 )
 
 // fakeCWObject is an in-process stand-in for a CWObject service, covering
@@ -33,6 +34,10 @@ type fakeCWObject struct {
 	archiveEntitled bool
 	archiveMinDays  int32
 
+	// denyCapacityCap makes any cap-changing request (set or clear) fail with a
+	// permission error, modeling an org not entitled to the capacity-cap feature.
+	denyCapacityCap bool
+
 	// buckets holds the persisted settings, keyed by bucket name.
 	buckets map[string]*fakeBucketSettings
 
@@ -43,6 +48,7 @@ type fakeBucketSettings struct {
 	auditLoggingEnabled        *bool
 	archiveEnabled             *bool
 	archiveAfterLastAccessDays *int32
+	capacityCapBytes           *uint64
 }
 
 const fakeArchiveMinDays int32 = 60
@@ -83,11 +89,11 @@ func (f *fakeCWObject) setRequestSettings() []*cwobjectv1.CWObjectBucketSettings
 // storedSettings returns the persisted settings for a bucket, unsanitized, so
 // tests can assert on what the service actually kept rather than on what it was
 // willing to disclose.
-func (f *fakeCWObject) storedSettings(bucketName string) *fakeBucketSettings {
+func (f *fakeCWObject) storedSettings() *fakeBucketSettings {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 
-	stored, ok := f.buckets[bucketName]
+	stored, ok := f.buckets[testBucketName]
 	if !ok {
 		return nil
 	}
@@ -95,6 +101,14 @@ func (f *fakeCWObject) storedSettings(bucketName string) *fakeBucketSettings {
 	clone := *stored
 
 	return &clone
+}
+
+func (f *fakeCWObject) setStoredCapacityCap(capacityCapBytes uint64) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	value := capacityCapBytes
+	f.buckets[testBucketName].capacityCapBytes = &value
 }
 
 func hasArchiveFields(settings *cwobjectv1.CWObjectBucketSettings) bool {
@@ -114,6 +128,12 @@ func (f *fakeCWObject) sanitizeForOrg(settings *cwobjectv1.CWObjectBucketSetting
 		AuditLoggingEnabled: settings.GetAuditLoggingEnabled(),
 	}
 
+	// The cap stays visible regardless of archive entitlement, matching thoth's
+	// sanitizeCWObjectBucketSettingsForOrg.
+	if configured := settings.GetConfiguredCapacityCapBytes(); configured != nil {
+		out.SetConfiguredCapacityCapBytes(configured)
+	}
+
 	return out
 }
 
@@ -130,6 +150,11 @@ func (b *fakeBucketSettings) toProto() *cwobjectv1.CWObjectBucketSettings {
 
 	if b.archiveAfterLastAccessDays != nil {
 		out.ArchiveAfterLastAccessDays = wrapperspb.Int32(*b.archiveAfterLastAccessDays)
+	}
+
+	// Surface the cap through the read-only field.
+	if b.capacityCapBytes != nil {
+		out.SetConfiguredCapacityCapBytes(wrapperspb.UInt64(*b.capacityCapBytes))
 	}
 
 	return out
@@ -151,6 +176,11 @@ func (f *fakeCWObject) SetBucketSettings(
 
 	if hasArchiveFields(settings) && !f.archiveEntitled {
 		return nil, connect.NewError(connect.CodePermissionDenied, errFeatureNotEntitled)
+	}
+
+	// thoth gates the whole capacity_cap_update oneof (set or clear), so match it.
+	if settings.HasCapacityCapUpdate() && f.denyCapacityCap {
+		return nil, connect.NewError(connect.CodePermissionDenied, errCapNotEntitled)
 	}
 
 	if hasArchiveFields(settings) {
@@ -190,6 +220,15 @@ func (f *fakeCWObject) persist(stored *fakeBucketSettings, settings *cwobjectv1.
 	if audit := settings.GetAuditLoggingEnabled(); audit != nil {
 		value := audit.GetValue()
 		stored.auditLoggingEnabled = &value
+	}
+
+	// Persist a set cap (0 valid) or a clear, before the archive switch's early return.
+	switch {
+	case settings.HasCapacityCapBytes():
+		value := settings.GetCapacityCapBytes()
+		stored.capacityCapBytes = &value
+	case settings.HasClearCapacityCap():
+		stored.capacityCapBytes = nil
 	}
 
 	enabled := settings.GetArchiveEnabled()

--- a/coreweave/object_storage/resource_bucket_settings.go
+++ b/coreweave/object_storage/resource_bucket_settings.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int32validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -43,6 +44,7 @@ type BucketSettingsModel struct {
 	AuditLoggingEnabled        types.Bool   `tfsdk:"audit_logging_enabled"`
 	ArchiveEnabled             types.Bool   `tfsdk:"archive_enabled"`
 	ArchiveAfterLastAccessDays types.Int32  `tfsdk:"archive_after_last_access_days"`
+	CapacityCapBytes           types.Int64  `tfsdk:"capacity_cap_bytes"`
 }
 
 // BucketSettingsResourceModel is an alias for BucketSettingsModel for consistency with other resources
@@ -70,6 +72,13 @@ func (s *BucketSettingsModel) Set(settings *cwobjectv1.CWObjectBucketSettings) {
 	} else {
 		s.ArchiveAfterLastAccessDays = types.Int32Null()
 	}
+
+	// Read the cap from the read-only configured field (the write oneof isn't returned).
+	if settings.ConfiguredCapacityCapBytes != nil {
+		s.CapacityCapBytes = types.Int64Value(int64(settings.ConfiguredCapacityCapBytes.Value)) //nolint:gosec
+	} else {
+		s.CapacityCapBytes = types.Int64Null()
+	}
 }
 
 func (s *BucketSettingsModel) ToProtoObject() *cwobjectv1.CWObjectBucketSettings {
@@ -86,7 +95,20 @@ func (s *BucketSettingsModel) ToProtoObject() *cwobjectv1.CWObjectBucketSettings
 	if !s.ArchiveAfterLastAccessDays.IsNull() && !s.ArchiveAfterLastAccessDays.IsUnknown() {
 		settings.SetArchiveAfterLastAccessDays(wrapperspb.Int32(s.ArchiveAfterLastAccessDays.ValueInt32()))
 	}
+	// A known value (0 included) sets the cap; null/unknown is skipped. Update
+	// also strips a state-copied value via omitUnconfiguredCapacityCap.
+	if !s.CapacityCapBytes.IsNull() && !s.CapacityCapBytes.IsUnknown() {
+		settings.SetCapacityCapBytes(uint64(s.CapacityCapBytes.ValueInt64())) //nolint:gosec
+	}
 	return &settings
+}
+
+// omitUnconfiguredCapacityCap keeps an Optional+Computed value copied from
+// refreshed state from becoming a write; only a configured cap may set it.
+func omitUnconfiguredCapacityCap(settings *cwobjectv1.CWObjectBucketSettings, configured types.Int64) {
+	if configured.IsNull() || configured.IsUnknown() {
+		settings.ClearCapacityCapUpdate()
+	}
 }
 
 func (b *BucketSettingsResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
@@ -155,6 +177,8 @@ func (b *BucketSettingsResource) Delete(ctx context.Context, req resource.Delete
 		settings.ArchiveEnabled = wrapperspb.Bool(false)
 	}
 
+	// The cap is intentionally left untouched: bucket deletion clears it
+	// server-side without capacity-cap permission, so destroy needs none.
 	deleteReq := cwobjectv1.SetBucketSettingsRequest{
 		BucketName: data.Bucket.ValueString(),
 		Settings:   &settings,
@@ -240,6 +264,15 @@ func (b *BucketSettingsResource) Schema(ctx context.Context, req resource.Schema
 					int32validator.AtLeast(1),
 				},
 			},
+			// Optional+Computed like archive_enabled: omit leaves the cap unchanged.
+			"capacity_cap_bytes": schema.Int64Attribute{
+				MarkdownDescription: "Maximum number of STANDARD-class bytes the bucket may store. New STANDARD writes are rejected once bucket usage would exceed this cap; `0` is a valid cap that blocks all new STANDARD writes. Omit to leave the cap unchanged. Removing this resource leaves any cap in place; the cap is cleared when the bucket itself is deleted. Your organization must be entitled to configure this setting.",
+				Optional:            true,
+				Computed:            true,
+				Validators: []validator.Int64{
+					int64validator.AtLeast(0),
+				},
+			},
 		},
 	}
 }
@@ -278,13 +311,20 @@ func (b *BucketSettingsResource) ValidateConfig(ctx context.Context, req resourc
 func (b *BucketSettingsResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 	var data BucketSettingsModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	var config BucketSettingsModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
+	// Optional+Computed copies a state cap into the plan; strip it unless the
+	// practitioner configured one, so an unrelated update never re-sends it.
+	settings := data.ToProtoObject()
+	omitUnconfiguredCapacityCap(settings, config.CapacityCapBytes)
+
 	setReq := cwobjectv1.SetBucketSettingsRequest{
 		BucketName: data.Bucket.ValueString(),
-		Settings:   data.ToProtoObject(),
+		Settings:   settings,
 	}
 
 	setResp, err := b.client.SetBucketSettings(ctx, connect.NewRequest(&setReq))
@@ -345,6 +385,11 @@ func MustRenderBucketSettingsResource(_ context.Context, name string, settings *
 	// archive_after_last_access_days attribute
 	if !settings.ArchiveAfterLastAccessDays.IsNull() {
 		resourceBody.SetAttributeValue("archive_after_last_access_days", cty.NumberIntVal(int64(settings.ArchiveAfterLastAccessDays.ValueInt32())))
+	}
+
+	// capacity_cap_bytes attribute
+	if !settings.CapacityCapBytes.IsNull() {
+		resourceBody.SetAttributeValue("capacity_cap_bytes", cty.NumberIntVal(settings.CapacityCapBytes.ValueInt64()))
 	}
 
 	var buf bytes.Buffer

--- a/coreweave/object_storage/resource_bucket_settings.go
+++ b/coreweave/object_storage/resource_bucket_settings.go
@@ -102,8 +102,9 @@ func (s *BucketSettingsModel) ToProtoObject() *cwobjectv1.CWObjectBucketSettings
 	return &settings
 }
 
-// Optional+Computed may copy a remote cap into the plan. Drop it unless the
-// attribute is configured, so unrelated updates leave the cap unchanged.
+// An omitted cap can still appear in the plan from state, including an
+// out-of-band value. Exclude it so unrelated updates neither change the cap
+// nor require capacity-cap permission.
 func omitUnconfiguredCapacityCap(settings *cwobjectv1.CWObjectBucketSettings, configured types.Int64) {
 	if configured.IsNull() || configured.IsUnknown() {
 		settings.ClearCapacityCapUpdate()

--- a/coreweave/object_storage/resource_bucket_settings.go
+++ b/coreweave/object_storage/resource_bucket_settings.go
@@ -95,16 +95,15 @@ func (s *BucketSettingsModel) ToProtoObject() *cwobjectv1.CWObjectBucketSettings
 	if !s.ArchiveAfterLastAccessDays.IsNull() && !s.ArchiveAfterLastAccessDays.IsUnknown() {
 		settings.SetArchiveAfterLastAccessDays(wrapperspb.Int32(s.ArchiveAfterLastAccessDays.ValueInt32()))
 	}
-	// A known value (0 included) sets the cap; null/unknown is skipped. Update
-	// also strips a state-copied value via omitUnconfiguredCapacityCap.
+	// Null or unknown omits the cap mutation; zero remains a valid cap.
 	if !s.CapacityCapBytes.IsNull() && !s.CapacityCapBytes.IsUnknown() {
 		settings.SetCapacityCapBytes(uint64(s.CapacityCapBytes.ValueInt64())) //nolint:gosec
 	}
 	return &settings
 }
 
-// omitUnconfiguredCapacityCap keeps an Optional+Computed value copied from
-// refreshed state from becoming a write; only a configured cap may set it.
+// Optional+Computed may copy a remote cap into the plan. Drop it unless the
+// attribute is configured, so unrelated updates leave the cap unchanged.
 func omitUnconfiguredCapacityCap(settings *cwobjectv1.CWObjectBucketSettings, configured types.Int64) {
 	if configured.IsNull() || configured.IsUnknown() {
 		settings.ClearCapacityCapUpdate()
@@ -177,8 +176,8 @@ func (b *BucketSettingsResource) Delete(ctx context.Context, req resource.Delete
 		settings.ArchiveEnabled = wrapperspb.Bool(false)
 	}
 
-	// The cap is intentionally left untouched: bucket deletion clears it
-	// server-side without capacity-cap permission, so destroy needs none.
+	// Keep the cap: it may be managed elsewhere, and bucket deletion removes it
+	// without requiring cap permission.
 	deleteReq := cwobjectv1.SetBucketSettingsRequest{
 		BucketName: data.Bucket.ValueString(),
 		Settings:   &settings,
@@ -264,7 +263,7 @@ func (b *BucketSettingsResource) Schema(ctx context.Context, req resource.Schema
 					int32validator.AtLeast(1),
 				},
 			},
-			// Optional+Computed like archive_enabled: omit leaves the cap unchanged.
+			// Omission leaves the cap unchanged.
 			"capacity_cap_bytes": schema.Int64Attribute{
 				MarkdownDescription: "Maximum number of STANDARD-class bytes the bucket may store. New STANDARD writes are rejected once bucket usage would exceed this cap; `0` is a valid cap that blocks all new STANDARD writes. Omit to leave the cap unchanged. Removing this resource leaves any cap in place; the cap is cleared when the bucket itself is deleted. Your organization must be entitled to configure this setting.",
 				Optional:            true,
@@ -317,8 +316,6 @@ func (b *BucketSettingsResource) Update(ctx context.Context, req resource.Update
 		return
 	}
 
-	// Optional+Computed copies a state cap into the plan; strip it unless the
-	// practitioner configured one, so an unrelated update never re-sends it.
 	settings := data.ToProtoObject()
 	omitUnconfiguredCapacityCap(settings, config.CapacityCapBytes)
 

--- a/coreweave/object_storage/resource_bucket_settings_test.go
+++ b/coreweave/object_storage/resource_bucket_settings_test.go
@@ -56,6 +56,7 @@ func createBucketSettingsTestStep(ctx context.Context, t *testing.T, opts bucket
 		AuditLoggingEnabled:        opts.settings.AuditLoggingEnabled,
 		ArchiveEnabled:             opts.settings.ArchiveEnabled,
 		ArchiveAfterLastAccessDays: opts.settings.ArchiveAfterLastAccessDays,
+		CapacityCapBytes:           opts.settings.CapacityCapBytes,
 	})
 	config := bucketHCL + settingsHCL
 
@@ -70,6 +71,9 @@ func createBucketSettingsTestStep(ctx context.Context, t *testing.T, opts bucket
 	}
 	if !opts.settings.ArchiveAfterLastAccessDays.IsNull() {
 		checks = append(checks, statecheck.ExpectKnownValue(rs, tfjsonpath.New("archive_after_last_access_days"), knownvalue.Int32Exact(opts.settings.ArchiveAfterLastAccessDays.ValueInt32())))
+	}
+	if !opts.settings.CapacityCapBytes.IsNull() {
+		checks = append(checks, statecheck.ExpectKnownValue(rs, tfjsonpath.New("capacity_cap_bytes"), knownvalue.Int64Exact(opts.settings.CapacityCapBytes.ValueInt64())))
 	}
 
 	return resource.TestStep{

--- a/coreweave/object_storage/resource_bucket_settings_unit_test.go
+++ b/coreweave/object_storage/resource_bucket_settings_unit_test.go
@@ -107,6 +107,7 @@ type bucketSettingsConfig struct {
 	auditLoggingEnabled        *bool
 	archiveEnabled             *bool
 	archiveAfterLastAccessDays *int32
+	capacityCapBytes           *int64
 }
 
 // value builds the configuration object.
@@ -128,11 +129,17 @@ func (c bucketSettingsConfig) value(objectType tftypes.Type) tftypes.Value {
 		daysValue = tftypes.NewValue(tftypes.Number, *c.archiveAfterLastAccessDays)
 	}
 
+	capValue := tftypes.NewValue(tftypes.Number, nil)
+	if c.capacityCapBytes != nil {
+		capValue = tftypes.NewValue(tftypes.Number, *c.capacityCapBytes)
+	}
+
 	return tftypes.NewValue(objectType, map[string]tftypes.Value{
 		"bucket":                         tftypes.NewValue(tftypes.String, c.bucket),
 		"audit_logging_enabled":          boolValue(c.auditLoggingEnabled),
 		"archive_enabled":                boolValue(c.archiveEnabled),
 		"archive_after_last_access_days": daysValue,
+		"capacity_cap_bytes":             capValue,
 	})
 }
 
@@ -332,6 +339,7 @@ func requireNoDiagErrors(t *testing.T, diags []*tfprotov6.Diagnostic, step strin
 
 func boolPtr(b bool) *bool    { return &b }
 func int32Ptr(i int32) *int32 { return &i }
+func int64Ptr(i int64) *int64 { return &i }
 
 // TestBucketSettingsUnentitledOrgIsUnaffectedByArchive is the regression test
 // for the entitlement break. An organization that is not on the bucket archive
@@ -416,7 +424,7 @@ func TestBucketSettingsEntitledOrgRoundTrip(t *testing.T) {
 	})
 	requireNoDiagErrors(t, diags, "create")
 
-	stored := h.fake.storedSettings(testBucketName)
+	stored := h.fake.storedSettings()
 	require.NotNil(t, stored.archiveEnabled)
 	assert.True(t, *stored.archiveEnabled)
 	require.NotNil(t, stored.archiveAfterLastAccessDays)
@@ -447,7 +455,7 @@ func TestBucketSettingsDisablingArchiveDiscardsRetention(t *testing.T) {
 	}, state)
 	requireNoDiagErrors(t, diags, "update disabling archive")
 
-	stored := h.fake.storedSettings(testBucketName)
+	stored := h.fake.storedSettings()
 	require.NotNil(t, stored.archiveEnabled)
 	assert.False(t, *stored.archiveEnabled)
 	assert.Nil(t, stored.archiveAfterLastAccessDays,
@@ -618,4 +626,216 @@ func TestBucketSettingsArchiveWithoutRetentionRejectedAtValidate(t *testing.T) {
 
 	require.True(t, diagsHaveErrors(diags), "archive on without a retention must be rejected")
 	assert.Contains(t, diagText(diags), "Missing archive_after_last_access_days")
+}
+
+// TestBucketSettingsCapacityCapRoundTrip: a cap is written via the oneof and read
+// back from the configured field; 0 is a valid value, distinct from unset.
+func TestBucketSettingsCapacityCapRoundTrip(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		cap  int64
+	}{
+		{name: "positive cap", cap: 1024},
+		{name: "zero cap blocks all writes", cap: 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := t.Context()
+			h := newBucketSettingsHarness(ctx, t, true)
+
+			config := bucketSettingsConfig{
+				bucket:           testBucketName,
+				capacityCapBytes: int64Ptr(tc.cap),
+			}
+
+			applied, diags := h.create(ctx, config)
+			requireNoDiagErrors(t, diags, "create")
+
+			stored := h.fake.storedSettings()
+			require.NotNil(t, stored.capacityCapBytes, "cap must be persisted server-side")
+			assert.Equal(t, uint64(tc.cap), *stored.capacityCapBytes)
+
+			// Refresh then re-plan: a correct read/write split converges to empty.
+			refreshed := h.refresh(ctx, applied)
+			replanned, diags := h.plan(ctx, config, refreshed)
+			requireNoDiagErrors(t, diags, "re-plan")
+			assert.True(t, replanned.Equal(refreshed),
+				"plan after apply must be empty\n refreshed: %s\n planned:   %s", refreshed, replanned)
+		})
+	}
+}
+
+func TestBucketSettingsCapacityCapExplicitUpdate(t *testing.T) {
+	ctx := t.Context()
+	h := newBucketSettingsHarness(ctx, t, true)
+
+	state, diags := h.create(ctx, bucketSettingsConfig{
+		bucket:           testBucketName,
+		capacityCapBytes: int64Ptr(1024),
+	})
+	requireNoDiagErrors(t, diags, "create with cap")
+
+	_, diags = h.apply(ctx, bucketSettingsConfig{
+		bucket:           testBucketName,
+		capacityCapBytes: int64Ptr(2048),
+	}, state)
+	requireNoDiagErrors(t, diags, "update cap")
+
+	requests := h.fake.setRequestSettings()
+	require.NotEmpty(t, requests)
+	require.True(t, requests[len(requests)-1].HasCapacityCapBytes())
+	assert.Equal(t, uint64(2048), requests[len(requests)-1].GetCapacityCapBytes())
+
+	stored := h.fake.storedSettings()
+	require.NotNil(t, stored.capacityCapBytes)
+	assert.Equal(t, uint64(2048), *stored.capacityCapBytes)
+}
+
+// TestBucketSettingsCapacityCapConvergesAfterRemovingFromConfig: once set, dropping
+// the attribute leaves the server value in place (no diff, no clear).
+func TestBucketSettingsCapacityCapConvergesAfterRemovingFromConfig(t *testing.T) {
+	ctx := t.Context()
+	h := newBucketSettingsHarness(ctx, t, true)
+
+	withCap := bucketSettingsConfig{
+		bucket:           testBucketName,
+		capacityCapBytes: int64Ptr(1024),
+	}
+	state, diags := h.create(ctx, withCap)
+	requireNoDiagErrors(t, diags, "create with cap")
+
+	// Stop managing the cap at all.
+	unmanaged := bucketSettingsConfig{bucket: testBucketName}
+	state, diags = h.apply(ctx, unmanaged, state)
+	requireNoDiagErrors(t, diags, "remove cap from config")
+
+	stored := h.fake.storedSettings()
+	require.NotNil(t, stored.capacityCapBytes, "dropping the attribute must not clear the cap")
+	assert.Equal(t, uint64(1024), *stored.capacityCapBytes)
+
+	refreshed := h.refresh(ctx, state)
+	replanned, diags := h.plan(ctx, unmanaged, refreshed)
+	requireNoDiagErrors(t, diags, "re-plan")
+	assert.True(t, replanned.Equal(refreshed),
+		"plan must be empty after cap dropped from config\n refreshed: %s\n planned: %s", refreshed, replanned)
+}
+
+// TestBucketSettingsCapacityCapNegativeRejectedAtValidate pins the AtLeast(0)
+// validator: a negative cap is rejected during config validation, before any
+// request (0 stays valid, covered by the round-trip test).
+func TestBucketSettingsCapacityCapNegativeRejectedAtValidate(t *testing.T) {
+	ctx := t.Context()
+	h := newBucketSettingsHarness(ctx, t, true)
+
+	diags := h.validate(ctx, bucketSettingsConfig{
+		bucket:           testBucketName,
+		capacityCapBytes: int64Ptr(-1),
+	})
+
+	require.True(t, diagsHaveErrors(diags), "a negative cap must be rejected")
+	assert.Contains(t, diagText(diags), "at least 0")
+}
+
+// TestBucketSettingsCapacityCapWithoutEntitlementIsRejected records that the
+// provider adds no client-side gate: an API permission error surfaces as a
+// diagnostic, exactly as the archive path does.
+func TestBucketSettingsCapacityCapWithoutEntitlementIsRejected(t *testing.T) {
+	ctx := t.Context()
+	h := newBucketSettingsHarness(ctx, t, true)
+	h.fake.denyCapacityCap = true
+
+	_, diags := h.create(ctx, bucketSettingsConfig{
+		bucket:           testBucketName,
+		capacityCapBytes: int64Ptr(1024),
+	})
+
+	require.True(t, diagsHaveErrors(diags), "setting a cap without entitlement must fail")
+	assert.Contains(t, diagText(diags), "BucketCapacityCap")
+}
+
+// TestBucketSettingsOmittedCapacityCapIsNotResent verifies the wire-level no-op:
+// Optional+Computed preserves a remotely observed cap in the plan, so an
+// unrelated update must consult configuration before writing.
+func TestBucketSettingsOmittedCapacityCapIsNotResent(t *testing.T) {
+	ctx := t.Context()
+	h := newBucketSettingsHarness(ctx, t, true)
+
+	state, diags := h.create(ctx, bucketSettingsConfig{
+		bucket:              testBucketName,
+		auditLoggingEnabled: boolPtr(false),
+	})
+	requireNoDiagErrors(t, diags, "create without cap")
+
+	// Simulate a cap created outside Terraform, then let refresh observe it.
+	h.fake.setStoredCapacityCap(2048)
+	state = h.refresh(ctx, state)
+
+	_, diags = h.apply(ctx, bucketSettingsConfig{
+		bucket:              testBucketName,
+		auditLoggingEnabled: boolPtr(true),
+	}, state)
+	requireNoDiagErrors(t, diags, "update audit logging with cap omitted")
+
+	requests := h.fake.setRequestSettings()
+	require.NotEmpty(t, requests)
+	assert.False(t, requests[len(requests)-1].HasCapacityCapUpdate(),
+		"an omitted cap must not produce a cap mutation during an unrelated update")
+
+	stored := h.fake.storedSettings()
+	require.NotNil(t, stored.capacityCapBytes)
+	assert.Equal(t, uint64(2048), *stored.capacityCapBytes)
+}
+
+// TestBucketSettingsCapacityCapSurvivesDestroy verifies that destroy never sends
+// a cap instruction and leaves the cap in place. Bucket deletion clears the cap
+// server-side, so destroy needs no capacity-cap permission.
+func TestBucketSettingsCapacityCapSurvivesDestroy(t *testing.T) {
+	// Destroy is the last SetBucketSettings call; only it must carry no cap update
+	// (create may legitimately have set one).
+	assertNoCapInstruction := func(t *testing.T, h *bucketSettingsHarness) {
+		t.Helper()
+		requests := h.fake.setRequestSettings()
+		require.NotEmpty(t, requests)
+		assert.False(t, requests[len(requests)-1].HasCapacityCapUpdate(),
+			"destroy must not send a cap instruction")
+	}
+
+	t.Run("managed cap survives destroy", func(t *testing.T) {
+		ctx := t.Context()
+		h := newBucketSettingsHarness(ctx, t, true)
+
+		state, diags := h.create(ctx, bucketSettingsConfig{
+			bucket:           testBucketName,
+			capacityCapBytes: int64Ptr(1024),
+		})
+		requireNoDiagErrors(t, diags, "create with cap")
+
+		diags = h.destroy(ctx, state)
+		requireNoDiagErrors(t, diags, "destroy")
+
+		assertNoCapInstruction(t, h)
+		stored := h.fake.storedSettings()
+		require.NotNil(t, stored)
+		require.NotNil(t, stored.capacityCapBytes, "destroy must leave the cap in place")
+		assert.Equal(t, uint64(1024), *stored.capacityCapBytes)
+	})
+
+	t.Run("externally configured cap survives destroy", func(t *testing.T) {
+		ctx := t.Context()
+		h := newBucketSettingsHarness(ctx, t, true)
+
+		state, diags := h.create(ctx, bucketSettingsConfig{bucket: testBucketName})
+		requireNoDiagErrors(t, diags, "create without cap")
+
+		h.fake.setStoredCapacityCap(2048)
+		state = h.refresh(ctx, state)
+
+		diags = h.destroy(ctx, state)
+		requireNoDiagErrors(t, diags, "destroy")
+
+		assertNoCapInstruction(t, h)
+		stored := h.fake.storedSettings()
+		require.NotNil(t, stored)
+		require.NotNil(t, stored.capacityCapBytes, "destroy must leave an out-of-band cap in place")
+		assert.Equal(t, uint64(2048), *stored.capacityCapBytes)
+	})
 }

--- a/coreweave/object_storage/resource_bucket_settings_unit_test.go
+++ b/coreweave/object_storage/resource_bucket_settings_unit_test.go
@@ -735,23 +735,6 @@ func TestBucketSettingsCapacityCapNegativeRejectedAtValidate(t *testing.T) {
 	assert.Contains(t, diagText(diags), "at least 0")
 }
 
-// TestBucketSettingsCapacityCapWithoutEntitlementIsRejected records that the
-// provider adds no client-side gate: an API permission error surfaces as a
-// diagnostic, exactly as the archive path does.
-func TestBucketSettingsCapacityCapWithoutEntitlementIsRejected(t *testing.T) {
-	ctx := t.Context()
-	h := newBucketSettingsHarness(ctx, t, true)
-	h.fake.denyCapacityCap = true
-
-	_, diags := h.create(ctx, bucketSettingsConfig{
-		bucket:           testBucketName,
-		capacityCapBytes: int64Ptr(1024),
-	})
-
-	require.True(t, diagsHaveErrors(diags), "setting a cap without entitlement must fail")
-	assert.Contains(t, diagText(diags), "BucketCapacityCap")
-}
-
 // TestBucketSettingsOmittedCapacityCapIsNotResent verifies the wire-level no-op:
 // Optional+Computed preserves a remotely observed cap in the plan, so an
 // unrelated update must consult configuration before writing.

--- a/docs/resources/object_storage_bucket_settings.md
+++ b/docs/resources/object_storage_bucket_settings.md
@@ -22,6 +22,10 @@ resource "coreweave_object_storage_bucket_settings" "default" {
   bucket                = coreweave_object_storage_bucket.default.name
   audit_logging_enabled = true
 
+  # Limit STANDARD storage to 1 TiB. Your organization must be entitled to
+  # configure per-bucket capacity caps before setting this attribute.
+  capacity_cap_bytes = 1099511627776
+
   # Archive idle STANDARD objects to STANDARD_IA. Your organization must be
   # entitled to configure archive settings before enabling this.
   archive_enabled                = true
@@ -41,6 +45,7 @@ resource "coreweave_object_storage_bucket_settings" "default" {
 - `archive_after_last_access_days` (Number) Days since last access (or creation if never accessed) before a STANDARD object version is archived to STANDARD_IA. The default minimum is 60; your organization's entitlement may permit a different minimum, so the effective floor is validated server-side. Required when `archive_enabled` is true, and rejected otherwise.
 - `archive_enabled` (Boolean) When true, idle STANDARD objects are archived to STANDARD_IA after `archive_after_last_access_days` without access. Your organization must be entitled to configure this setting.
 - `audit_logging_enabled` (Boolean) Whether audit logging is enabled for the bucket. Contact support to enable audit logging for your organization before enabling this setting.
+- `capacity_cap_bytes` (Number) Maximum number of STANDARD-class bytes the bucket may store. New STANDARD writes are rejected once bucket usage would exceed this cap; `0` is a valid cap that blocks all new STANDARD writes. Omit to leave the cap unchanged. Removing this resource leaves any cap in place; the cap is cleared when the bucket itself is deleted. Your organization must be entitled to configure this setting.
 
 ## Import
 

--- a/examples/resources/coreweave_object_storage_bucket_settings/resource.tf
+++ b/examples/resources/coreweave_object_storage_bucket_settings/resource.tf
@@ -7,6 +7,10 @@ resource "coreweave_object_storage_bucket_settings" "default" {
   bucket                = coreweave_object_storage_bucket.default.name
   audit_logging_enabled = true
 
+  # Limit STANDARD storage to 1 TiB. Your organization must be entitled to
+  # configure per-bucket capacity caps before setting this attribute.
+  capacity_cap_bytes = 1099511627776
+
   # Archive idle STANDARD objects to STANDARD_IA. Your organization must be
   # entitled to configure archive settings before enabling this.
   archive_enabled                = true

--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,8 @@ go 1.26.6
 require (
 	buf.build/gen/go/coreweave/cks/connectrpc/go v1.19.1-20260326215135-be22b90e1aa6.2
 	buf.build/gen/go/coreweave/cks/protocolbuffers/go v1.36.11-20260326215135-be22b90e1aa6.1
-	buf.build/gen/go/coreweave/cwobject/connectrpc/go v1.19.1-20260729060712-bb1877226449.2
-	buf.build/gen/go/coreweave/cwobject/protocolbuffers/go v1.36.11-20260729060712-bb1877226449.1
+	buf.build/gen/go/coreweave/cwobject/connectrpc/go v1.20.0-20260831154917-08064e55742b.1
+	buf.build/gen/go/coreweave/cwobject/protocolbuffers/go v1.36.12-20260831154917-08064e55742b.1
 	buf.build/gen/go/coreweave/inference/connectrpc/go v1.20.0-20260825010541-7cc01a738b29.1
 	buf.build/gen/go/coreweave/inference/protocolbuffers/go v1.36.12-20260825010541-7cc01a738b29.1
 	buf.build/gen/go/coreweave/networking/connectrpc/go v1.19.1-20260121155637-a637e7777165.2
@@ -41,7 +41,7 @@ require (
 require (
 	buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.12-20260415201107-50325440f8f2.1 // indirect
 	buf.build/gen/go/gnostic/gnostic/protocolbuffers/go v1.36.11-20230414000709-087bc8072ce4.1 // indirect
-	buf.build/gen/go/grpc-ecosystem/grpc-gateway/protocolbuffers/go v1.36.11-20241220201140-4c5ba75caaf8.1 // indirect
+	buf.build/gen/go/grpc-ecosystem/grpc-gateway/protocolbuffers/go v1.36.12-20241220201140-4c5ba75caaf8.1 // indirect
 	github.com/ProtonMail/go-crypto v1.1.6 // indirect
 	github.com/agext/levenshtein v1.2.2 // indirect
 	github.com/apparentlymart/go-textseg/v15 v15.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,10 +4,10 @@ buf.build/gen/go/coreweave/cks/connectrpc/go v1.19.1-20260326215135-be22b90e1aa6
 buf.build/gen/go/coreweave/cks/connectrpc/go v1.19.1-20260326215135-be22b90e1aa6.2/go.mod h1:aCkr4xvjAVXYnCSfQFFaZ+g6vqd2t27+svGkCgwLKzo=
 buf.build/gen/go/coreweave/cks/protocolbuffers/go v1.36.11-20260326215135-be22b90e1aa6.1 h1:6VTjkKgYaRgrVlO2aq6RuCNVsV3+0J/4GM5HKX17VNM=
 buf.build/gen/go/coreweave/cks/protocolbuffers/go v1.36.11-20260326215135-be22b90e1aa6.1/go.mod h1:ByX23QBucj1Ao4H8Wn41segTqTbgOT4Sbjnm7AvLGYY=
-buf.build/gen/go/coreweave/cwobject/connectrpc/go v1.19.1-20260729060712-bb1877226449.2 h1:KLhMvLNiOczSUr81SK8n9u3UjLhkupdohAZM9Y5NFsE=
-buf.build/gen/go/coreweave/cwobject/connectrpc/go v1.19.1-20260729060712-bb1877226449.2/go.mod h1:e88kN35aV9wjti8nBUgWA3S5KYcymennOZ5CRI4oY0c=
-buf.build/gen/go/coreweave/cwobject/protocolbuffers/go v1.36.11-20260729060712-bb1877226449.1 h1:h67dxeSusDhd1Jj5Dl/Gu7ycCIxHTK6YnUav8uQsbYc=
-buf.build/gen/go/coreweave/cwobject/protocolbuffers/go v1.36.11-20260729060712-bb1877226449.1/go.mod h1:3WufjtsvyOj3cbTSqpNCzrW0CmwZMoY0gRgKoXmvsEI=
+buf.build/gen/go/coreweave/cwobject/connectrpc/go v1.20.0-20260831154917-08064e55742b.1 h1:/E8vN6/S4jX3HwSQ/TkWiRh8CsBw0bJAdLWREC/OutM=
+buf.build/gen/go/coreweave/cwobject/connectrpc/go v1.20.0-20260831154917-08064e55742b.1/go.mod h1:isk49adM33HqNqQa8otV6ZnGC224oG3l3rBmVzPFuN0=
+buf.build/gen/go/coreweave/cwobject/protocolbuffers/go v1.36.12-20260831154917-08064e55742b.1 h1:IaWM6K1v1zpcJun459iDz0d2EZH1CZKr9tQ4B69Pjgw=
+buf.build/gen/go/coreweave/cwobject/protocolbuffers/go v1.36.12-20260831154917-08064e55742b.1/go.mod h1:LYJWc01KSOldvmulAIGE9ba7/HUr1QKQ6LRtPLLhdq4=
 buf.build/gen/go/coreweave/inference/connectrpc/go v1.20.0-20260825010541-7cc01a738b29.1 h1:Y/4tqYLfM7hq4Mp1Pj7qwUuaJjXCvlAgPpexNUrwWhA=
 buf.build/gen/go/coreweave/inference/connectrpc/go v1.20.0-20260825010541-7cc01a738b29.1/go.mod h1:8axC+BDS3Nkyp6MDwOOFFI24ONED8SjdCJeEbI/ZosY=
 buf.build/gen/go/coreweave/inference/protocolbuffers/go v1.36.12-20260825010541-7cc01a738b29.1 h1:P20RBcTtI8Rnl/yfzoCLIG+v+HjdA0qAcLhCtHm09gk=
@@ -26,8 +26,8 @@ buf.build/gen/go/coreweave/workload-federation/protocolbuffers/go v1.36.12-20260
 buf.build/gen/go/coreweave/workload-federation/protocolbuffers/go v1.36.12-20260825153113-5bfae6057a98.1/go.mod h1:0tfgmTdtC5FHBaMGAhPUMImL/nqImiyBwcq86Rjv9nk=
 buf.build/gen/go/gnostic/gnostic/protocolbuffers/go v1.36.11-20230414000709-087bc8072ce4.1 h1:t8f+WWZ5WNrZaP5zrpWD8f1tKU7eelJMbIAT9FRX558=
 buf.build/gen/go/gnostic/gnostic/protocolbuffers/go v1.36.11-20230414000709-087bc8072ce4.1/go.mod h1:/t9AeRQQp2iNkiGHDLfHLW3SzNpYpNPGRZ+Ih8+SOUs=
-buf.build/gen/go/grpc-ecosystem/grpc-gateway/protocolbuffers/go v1.36.11-20241220201140-4c5ba75caaf8.1 h1:cpnZuwF24ackV1HgofmoFNsdw9z4/066sujIFtxYg5g=
-buf.build/gen/go/grpc-ecosystem/grpc-gateway/protocolbuffers/go v1.36.11-20241220201140-4c5ba75caaf8.1/go.mod h1:KAAU6zfI4aGOR/SiWil31PiNwdpo1SlqZidcB3z+sL0=
+buf.build/gen/go/grpc-ecosystem/grpc-gateway/protocolbuffers/go v1.36.12-20241220201140-4c5ba75caaf8.1 h1:tUdD9w+8U70KRudIRO4Ass2S8mSB6P+0QmrrlmqlpDY=
+buf.build/gen/go/grpc-ecosystem/grpc-gateway/protocolbuffers/go v1.36.12-20241220201140-4c5ba75caaf8.1/go.mod h1:tGHWROdiYQqFpI6EFJWW82Kfbg58TqH2EGNbkGajR0E=
 connectrpc.com/connect v1.20.0 h1:6TNDAB+WeNd2uolWNlYczB5E0KNNaVMNUEx8JEUsPmQ=
 connectrpc.com/connect v1.20.0/go.mod h1:A2ygJrukXwWy32vkCAAHNVguZrqZ+jeZ9rGRnGR4dN4=
 dario.cat/mergo v1.0.0 h1:AGCNq9Evsj31mOgNPcLyXc+4PNABt905YmuqPYYpBWk=


### PR DESCRIPTION
## Overview

Adds `capacity_cap_bytes` to object storage bucket settings in Terraform.

Create a 1 TiB cap:

```hcl
resource "coreweave_object_storage_bucket_settings" "example" {
  bucket             = coreweave_object_storage_bucket.example.name
  capacity_cap_bytes = 1099511627776
}
```

To update it, change the number and run `terraform apply` again.

These semantics provide a safe, predictable customer experience:

- An omitted cap value is ignored, so an existing cap stays.
- An out-of-band (created out of terraform) cap is observed but not changed when omitted; it will be updated if hcl has a different value.
- Destroying bucket settings (not bucket) via terraform keeps the cap.
- Deleting the bucket removes the cap without requiring cap permission (true for both API and Terraform).
- The organization must be entitled to create or update caps.



## Test
Verified locally hitting staging and Prod CAIOS APIs, cases covered for create, update, destroy, omission behavior and out-of-band cap handling behaviors 
